### PR TITLE
PAV-424 - Customize edition of Services + Confirmation Delete

### DIFF
--- a/magpie/__init__.py
+++ b/magpie/__init__.py
@@ -35,17 +35,18 @@ from ziggurat_foundations.permissions import ANY_PERMISSION
 from ziggurat_foundations.models.services.resource_tree import ResourceTreeService
 from ziggurat_foundations.models.services.resource_tree_postgres import ResourceTreeServicePostgreSQL
 from pyramid.security import NO_PERMISSION_REQUIRED
-ADMIN_USER = os.getenv('ADMIN_USER')
-ADMIN_GROUP = os.getenv('ADMIN_GROUP')
-ADMIN_PASSWORD = os.getenv('ADMIN_PASSWORD')
+ADMIN_USER = os.getenv('ADMIN_USER', 'admin')
+ADMIN_GROUP = os.getenv('ADMIN_GROUP', 'admin')
+ADMIN_PASSWORD = os.getenv('ADMIN_PASSWORD', 'admin')
 
-USER_GROUP = os.getenv('USER_GROUP')
+USER_GROUP = os.getenv('USER_GROUP', 'user')
 
-ANONYMOUS_USER = os.getenv('ANONYMOUS_USER')
+ANONYMOUS_USER = os.getenv('ANONYMOUS_USER', 'anonymous')
 
 #ADMIN_PERM = 'edit'
 ADMIN_PERM = NO_PERMISSION_REQUIRED
 
+LOGGED_USER = 'current'
 
 
 def get_multiformat_post(request, key):

--- a/magpie/login/login.py
+++ b/magpie/login/login.py
@@ -44,7 +44,7 @@ def sign_in(request):
         #return HTTPTemporaryRedirect(location=request.route_url('ziggurat.routes.sign_in'))
 
         ziggu_url = request.route_url('ziggurat.routes.sign_in')
-        res = requests.post(ziggu_url, data=data_to_send)
+        res = requests.post(ziggu_url, data=data_to_send, verify=False)
         if res.status_code < 400:
             pyr_res = Response(body=res.content)
             for cookie in res.cookies:

--- a/magpie/magpie.ini
+++ b/magpie/magpie.ini
@@ -38,6 +38,12 @@ magpie.max_restart = 5
 
 pyramid.includes = pyramid_tm ziggurat_foundations.ext.pyramid.sign_in ziggurat_foundations.ext.pyramid.get_user
 
+filter-with = urlprefix
+
+[filter:urlprefix]
+use = egg:PasteDeploy#prefix
+prefix = /magpie
+
 ###
 # wsgi server configuration
 ###

--- a/magpie/management/service/service.py
+++ b/magpie/management/service/service.py
@@ -99,6 +99,23 @@ def unregister_service(request):
     return HTTPOk()
 
 
+@view_config(route_name='service', request_method='PUT')
+def update_service(request):
+    service_name = get_multiformat_post(request, 'service_name')
+    service_url = get_multiformat_post(request, 'service_url')
+    db = request.db
+    if service_name is None:
+        raise HTTPBadRequest(detail='the service_name is missing')
+    try:
+        service = models.Service.by_service_name(service_name, db_session=db)
+        service.url = service_url
+    except Exception:
+        db.rollback()
+        raise HTTPNotFound('incorrect service_name')
+
+    return HTTPOk()
+
+
 from services import service_type_dico
 @view_config(route_name='service_permissions', request_method='GET')
 def get_service_permissions(request):

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -136,18 +136,19 @@ class Service(Resource):
             self.__acl__.append((outcome, perm_user, perm_name,))
 
 
+class File(Resource):
+    __mapper_args__ = {'polymorphic_identity': 'file'}
+    permission_names = ['read',
+                        'write']
+    resource_type_name = 'file'
+
+
 class Directory(Resource):
     __mapper_args__ = {'polymorphic_identity': 'directory'}
-    permission_names = ['download',
-                        'upload']
+    permission_names = File.permission_names
     resource_type_name = 'directory'
 
 
-class File(Resource):
-    __mapper_args__ = {'polymorphic_identity': 'file'}
-    permission_names = ['download',
-                        'upload']
-    resource_type_name = 'file'
 
 
 class Workspace(Resource):

--- a/magpie/owsrequest.py
+++ b/magpie/owsrequest.py
@@ -80,5 +80,7 @@ class Post(OWSParser):
     def _get_param_value(self, param):
         if param in self.document.attrib:
             return self.document.attrib[param].lower()
+        elif param == 'request':
+            return self.document.tag.lower()
         else:
             return None

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -8,11 +8,11 @@ class ServiceI(object):
     permission_names = []
     param_values = []
     resource_types = []
-    acl = []
 
     def __init__(self, service, request):
         self.service = service
         self.request = request
+        self.acl = []
 
     @property
     def __acl__(self):
@@ -171,8 +171,7 @@ class ServiceWFS(ServiceI):
 
 
 class ServiceTHREDDS(ServiceI):
-    permission_names = ['download',
-                        'upload']
+    permission_names = models.File.permission_names
 
     resource_types = [models.Directory.resource_type_name,
                       models.File.resource_type_name]

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -88,6 +88,82 @@ tr:nth-child(even) {
     /*background-color: #dddddd;*/
 }
 
+/*---Panel Information Box---*/
+
+.panel_box {
+    background-color: #fff;
+    border: 1px solid;
+    border-radius: 4px;
+    border-color: #ddd;
+    margin-top: 10px;
+    padding: 1px;
+}
+
+.panel_heading {
+    background-color: #f5f5f5;
+    border-bottom: 1px solid transparent;
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    border-color: #ddd;
+    color: #333;
+    padding: 10px 15px;
+}
+
+.panel_heading_button {
+    float: right!important;
+    margin-top: -3px;
+}
+
+.panel_body {
+    padding: 15px;
+}
+
+.panel_line {
+    margin: 0.5em;
+}
+
+.panel_line input[type="submit"] {
+    height: auto;
+}
+
+.panel_title {
+    font-weight: bold;
+}
+
+.panel_entry {
+    font-weight: bold;
+}
+
+.panel_value {
+}
+
+/*---Labels---*/
+
+.label_danger {
+    background-color: #CD0000;
+}
+
+.label_warning {
+    background-color: #F0AD4E;
+}
+
+.label_info {
+    background-color: #5BC0DE;
+}
+
+.label {
+    display: inline;
+    padding: .2em .5em;
+    font-size: 75%;
+    font-weight: 700;
+    line-height: 1;
+    color: #fff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: .25em;
+}
+
 /*---View users page ---*/
 
 .simple_list_table tr th:first-child,
@@ -118,6 +194,8 @@ tr:nth-child(even) {
 .tree li {
     border-bottom: 1px solid #dddddd;
     list-style-type: circle;
+    line-height: 24px;
+    padding-bottom: 4px;
 }
 
 .Collapsable input {
@@ -288,6 +366,12 @@ a.tab:link, a.tab:visited {
     text-align: center;
     text-decoration: none;
     display: inline-block;
+}
+
+/*---service details---*/
+
+table.service_details {
+    table-layout: fixed;
 }
 
 /*---field_form---*/

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -14,9 +14,9 @@ html,body {
     margin: 1em 0em 1em;
 }
 
-input[type="submit"].disabled_button,
-input[type="submit"].disabled_button:hover,
-input[type="submit"].disabled_button:focus {
+input[type="submit"].button.disabled,
+input[type="submit"].button.disabled:hover,
+input[type="submit"].button.disabled:focus {
     border: 1px solid #808080;
     background-color: #DDDDDD;
     color: #808080;
@@ -24,7 +24,8 @@ input[type="submit"].disabled_button:focus {
     cursor:not-allowed;
 }
 
-input[type="submit"].delete_button {
+input[type="button"].button.delete,
+input[type="submit"].button.delete {
     border: 1px solid #8B3A3A;
     background-color: #CD0000;
     color: white;
@@ -32,8 +33,10 @@ input[type="submit"].delete_button {
     cursor:pointer;
 }
 
-input[type="submit"].delete_button:hover,
-input[type="submit"].delete_button:focus {
+input[type="button"].button.delete:hover,
+input[type="button"].button.delete:focus,
+input[type="submit"].button.delete:hover,
+input[type="submit"].button.delete:focus {
 	background-color: #EE6363;
 }
 
@@ -57,15 +60,17 @@ input[type="submit"]:hover, input[type="submit"]:focus {
 }
 
 .img_button,
-input[type="submit"]{
+input[type="button"],
+input[type="submit"] {
     border-radius: 3px;
 }
 
-input[type="submit"]{
+input[type="button"],
+input[type="submit"] {
     height: 2em;
 }
 
-.tree input[type="submit"]{
+.tree input[type="submit"] {
     height: 1.5em;
 }
 
@@ -139,18 +144,6 @@ tr:nth-child(even) {
 
 /*---Labels---*/
 
-.label_danger {
-    background-color: #CD0000;
-}
-
-.label_warning {
-    background-color: #F0AD4E;
-}
-
-.label_info {
-    background-color: #5BC0DE;
-}
-
 .label {
     display: inline;
     padding: .2em .5em;
@@ -162,6 +155,66 @@ tr:nth-child(even) {
     white-space: nowrap;
     vertical-align: baseline;
     border-radius: .25em;
+    background-color: #5BC0DE; /*info default*/ 
+}
+
+.label.danger {
+    background-color: #CD0000;
+}
+
+.label.warning {
+    background-color: #F0AD4E;
+}
+
+.label.info {
+    background-color: #5BC0DE;
+}
+
+.label.success {
+    background-color: #4CAF50;
+}
+
+/*---Alerts---*/
+
+.alert {
+    padding: 20px;    
+    color: white;
+    opacity: 1;
+    transition: opacity 0.6s;
+    margin-bottom: 15px;
+    display: none;              /*hidden default*/
+    background-color: #2196F3;  /*info default*/
+}
+
+.alert.danger {
+    background-color: #F44336;
+}
+
+.alert.warning {
+    background-color: #FF9800;
+}
+
+.alert.info {
+    background-color: #2196F3;
+}
+
+.alert.success {
+    background-color: #4CAF50;
+}
+
+.alert_button {
+    margin-left: 15px;
+    color: white;
+    font-weight: bold;
+    float: right;
+    font-size: 22px;
+    line-height: 20px;
+    cursor: pointer;
+    transition: 0.3s;
+}
+
+.alert_button:hover {
+    color: black;
 }
 
 /*---View users page ---*/

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -3,21 +3,21 @@
 
 <%def name="render_item(key, value, level)">
     % if level > 0:
-        <div class="tree_button"><input type="submit" value="Delete" name="delete_child" class="delete_button"></div>
+        <div class="tree_button"><input type="submit" value="Delete" name="delete_child" class="button delete"></div>
     % else:
-        <div class="tree_button"><input type="submit" value="Delete" name="delete_child" class="disabled_button" disabled></div>
+        <div class="tree_button"><input type="submit" value="Delete" name="delete_child" class="button disabled" disabled></div>
     % endif
     % if 'id' in value.keys():
         % if int(value['id']) in resources_id_type.keys():
             % if not resources_id_type[int(value['id'])] in resources_no_child:
                 <div class="tree_button"><input type="submit" value="Add child" name="add_child"></div>
             % else:
-                <div class="tree_button"><input type="submit" value="Add child" name="add_child" class="disabled_button" disabled></div>
+                <div class="tree_button"><input type="submit" value="Add child" name="add_child" class="button disabled" disabled></div>
             % endif
         % elif len(resources_types) > 0:
             <div class="tree_button"><input type="submit" value="Add child" name="add_child"></div>
         % else:
-            <div class="tree_button"><input type="submit" value="Add child" name="add_child" class="disabled_button" disabled></div>
+            <div class="tree_button"><input type="submit" value="Add child" name="add_child" class="button disabled" disabled></div>
         % endif
     % endif
 </%def>
@@ -28,13 +28,27 @@
 <li><a href="${request.route_url('edit_service', service_name=service_name, service_url=service_url, cur_svc_type=cur_svc_type)}">${service_name}</a></li>
 </%block>
 
+<div class="alert danger" id="EditService_DeleteAlert">
+    <form action="${request.path}" method="post">
+        <input type="submit" id="EditService_DeleteConfirm" name="delete" value="Delete" style="display:none;">
+    </form>
+    <label class="alert_button" onclick="this.parentElement.style.display='none';" for="EditService_DeleteConfirm">&check;</label>
+    <span class="alert_button" onclick="this.parentElement.style.display='none';">&times;</span>
+    <strong>Danger!</strong>
+    <p>
+        This operation will remove the service and all its sub-resources.
+        This operation is not reversable.
+    </p>
+    <p>Continue?</p>
+</div>
+
 <form action="${request.path}" method="post">
     <div class="panel_box">
         <div class="panel_heading">
             <span class="panel_title">Service: </span>
             <span class="panel_value">${service_name}</span>
             <span class="panel_heading_button">
-                <input type="submit" value="Remove Service" name="delete" class="delete_button">
+                <input type="button" value="Remove Service" onclick="$('#EditService_DeleteAlert').show();" class="button delete">
             </span>
         </div>
         <div class="panel_body">
@@ -67,7 +81,7 @@
                     </p>
                     <p class="panel_line">
                         <span class="panel_entry">Type: </span>
-                        <span class="label label_info">${cur_svc_type}</span>
+                        <span class="label info">${cur_svc_type}</span>
                     </p>
                     <p class="panel_line">
                         <span class="panel_entry">Permissions: </span>

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -3,9 +3,9 @@
 
 <%def name="render_item(key, value, level)">
     % if level > 0:
-        <div class="tree_button"><input type="submit" value="Delete" name="delete" class="delete_button"></div>
+        <div class="tree_button"><input type="submit" value="Delete" name="delete_child" class="delete_button"></div>
     % else:
-        <div class="tree_button"><input type="submit" value="Delete" name="delete" class="disabled_button" disabled></div>
+        <div class="tree_button"><input type="submit" value="Delete" name="delete_child" class="disabled_button" disabled></div>
     % endif
     % if 'id' in value.keys():
         % if int(value['id']) in resources_id_type.keys():
@@ -25,12 +25,72 @@
 <%block name="breadcrumb">
 <li><a href="${request.route_url('home')}">Home</a></li>
 <li><a href="${request.route_url('view_services', cur_svc_type=cur_svc_type)}">Services</a></li>
-<li><a href="${request.route_url('edit_service', service_name=service_name, cur_svc_type=cur_svc_type)}">Service ${service_name}</a></li>
+<li><a href="${request.route_url('edit_service', service_name=service_name, service_url=service_url, cur_svc_type=cur_svc_type)}">${service_name}</a></li>
 </%block>
 
-<h1>Service ${service_name} Resources</h1>
+<form action="${request.path}" method="post">
+    <div class="panel_box">
+        <div class="panel_heading">
+            <span class="panel_title">Service: </span>
+            <span class="panel_value">${service_name}</span>
+            <span class="panel_heading_button">
+                <input type="submit" value="Remove Service" name="delete" class="delete_button">
+            </span>
+        </div>
+        <div class="panel_body">
+            <div class="panel_box">
+                <div class="panel_heading">
+                    <div class="panel_title">Details</div>
+                </div>
+                <div>
+                    <p class="panel_line">
+                        <span class="panel_entry">Name: </span>
+                        %if edit_mode == 'edit_name':
+                            <input type="text" value="${service_name}" name="new_svc_name">
+                            <input type="submit" value="Save" name="save_name">
+                            <input type="submit" value="Cancel" name="no_edit">
+                        %else:
+                            <span class="panel_value">${service_name}</span>
+                            <input type="submit" value="Edit" name="edit_name">
+                        %endif
+                    </p>
+                    <p class="panel_line">
+                        <span class="panel_entry">URL: </span>
+                        %if edit_mode == 'edit_url':
+                            <input type="text" value="${service_url}" name="new_svc_url">
+                            <input type="submit" value="Save" name="save_url">
+                            <input type="submit" value="Cancel" name="no_edit">
+                        %else:
+                            <span class="panel_value">${service_url}</span>
+                            <input type="submit" value="Edit" name="edit_url">
+                        %endif
+                    </p>
+                    <p class="panel_line">
+                        <span class="panel_entry">Type: </span>
+                        <span class="label label_info">${cur_svc_type}</span>
+                    </p>
+                    <p class="panel_line">
+                        <span class="panel_entry">Permissions: </span>
+                        <span class="panel_value">${service_perm}</span>
+                    </p>
+                    <p class="panel_line">
+                        <span class="panel_entry">ID: </span>
+                        <span class="panel_value">${service_id}</span>
+                    </p>
+                </div>
+            </div>
 
-<div class="clear"/>
-<div class="tree">
-    ${tree.render_tree(render_item, resources)}
-</div>
+            <div class="panel_box">
+                <div class="panel_heading">
+                    <div class="panel_title">Resources</div>
+                </div>
+                <div>
+                    <div class="clear"/>
+                    <div class="tree">
+                        ${tree.render_tree(render_item, resources)}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/magpie/ui/management/templates/view_groups.mako
+++ b/magpie/ui/management/templates/view_groups.mako
@@ -26,7 +26,7 @@
     <td>${group_names[group]['members']}</td>
     <td style="white-space: nowrap">
         <input type="submit" value="Edit" name="edit">
-        <input type="submit" value="Delete" name="delete" class="delete_button">
+        <input type="submit" value="Delete" name="delete" class="button delete">
     </td>
 </tr>
 </form>

--- a/magpie/ui/management/templates/view_services.mako
+++ b/magpie/ui/management/templates/view_services.mako
@@ -5,6 +5,23 @@
 <li><a href="${request.route_url('view_services', cur_svc_type=cur_svc_type)}">Services</a></li>
 </%block>
 
+%for service in service_names:
+    <div class="alert danger" id="ViewService_DeleteAlert_${service}">
+        <form action="${request.path}" method="post">
+            <input type="hidden" value=${service} name="service_name">
+            <input type="submit" id="ViewService_DeleteConfirm_${service}" name="delete" value="Delete" style="display:none;">
+        </form>
+        <label class="alert_button" onclick="this.parentElement.style.display='none';" for="ViewService_DeleteConfirm_${service}">&check;</label>
+        <span class="alert_button" onclick="this.parentElement.style.display='none';">&times;</span>
+        <strong>Danger!</strong>
+        <p>
+            This operation will remove the service and all its sub-resources.
+            This operation is not reversable.
+        </p>
+        <p>Continue?</p>
+    </div>
+%endfor
+
 <h1>Services</h1>
 
 <button class="img_button" type="button" onclick="location.href='${request.route_url('add_service', cur_svc_type=cur_svc_type)}'">
@@ -37,7 +54,7 @@
                         </td>
                         <td style="white-space: nowrap">
                             <input type="submit" value="Edit" name="edit">
-                            <input type="submit" value="Delete" name="delete" class="delete_button">
+                            <input type="button" value="Delete" onclick="$('#ViewService_DeleteAlert_${service}').show();" class="button delete">
                         </td>
                     </tr>
                 </form>

--- a/magpie/ui/management/templates/view_services.mako
+++ b/magpie/ui/management/templates/view_services.mako
@@ -32,7 +32,9 @@
             %for service in service_names:
                 <form action="${request.path}" method="post">
                     <tr>
-                        <td><input type="hidden" value=${service} name="service_name">${service}</td>
+                        <td>
+                            <input type="hidden" value=${service} name="service_name">${service}
+                        </td>
                         <td style="white-space: nowrap">
                             <input type="submit" value="Edit" name="edit">
                             <input type="submit" value="Delete" name="delete" class="delete_button">

--- a/magpie/ui/management/templates/view_users.mako
+++ b/magpie/ui/management/templates/view_users.mako
@@ -25,7 +25,7 @@
     <td><input type="hidden" value=${user} name="user_name">${user}</td>
     <td style="white-space: nowrap">
         <input type="submit" value="Edit" name="edit">
-        <input type="submit" value="Delete" name="delete" class="delete_button">
+        <input type="submit" value="Delete" name="delete" class="button delete">
     </td>
 </tr>
 </form>

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -20,7 +20,7 @@ class ManagementViews(object):
         self.magpie_url = self.request.registry.settings['magpie.url']
 
     def create_group(self, group_name):
-        data = {'group_name': group_name}
+        data = {u'group_name': group_name}
         check_res(requests.post(self.magpie_url + '/groups', data))
 
     def get_groups(self):
@@ -90,10 +90,10 @@ class ManagementViews(object):
             if group_name not in groups:
                 self.create_group(group_name)
 
-            data = {'user_name': user_name,
-                    'email': self.request.POST.get('email'),
-                    'password': self.request.POST.get('password'),
-                    'group_name': group_name}
+            data = {u'user_name': user_name,
+                    u'email': self.request.POST.get('email'),
+                    u'password': self.request.POST.get('password'),
+                    u'group_name': group_name}
             check_res(requests.post(self.magpie_url+'/users', data))
 
         if 'delete' in self.request.POST:
@@ -116,15 +116,15 @@ class ManagementViews(object):
             if group_name not in groups:
                 self.create_group(group_name)
 
-            data = {'user_name': user_name,
-                    'email': self.request.POST.get('email'),
-                    'password': self.request.POST.get('password'),
-                    'group_name': group_name}
+            data = {u'user_name': user_name,
+                    u'email': self.request.POST.get('email'),
+                    u'password': self.request.POST.get('password'),
+                    u'group_name': group_name}
             check_res(requests.post(self.magpie_url + '/users', data))
             return HTTPFound(self.request.route_url('view_users'))
 
         return add_template_data(self.request,
-                                 {'user_groups': self.get_groups()})
+                                 {u'user_groups': self.get_groups()})
 
     @view_config(route_name='edit_user', renderer='templates/edit_user.mako')
     def edit_user(self):
@@ -146,9 +146,9 @@ class ManagementViews(object):
             own_groups = self.get_user_groups(user_name)
 
         return add_template_data(self.request,
-                                 {'user_name': user_name,
-                                  'own_groups': own_groups,
-                                  'groups': self.get_groups()})
+                                 {u'user_name': user_name,
+                                  u'own_groups': own_groups,
+                                  u'groups': self.get_groups()})
 
     @view_config(route_name='view_groups', renderer='templates/view_groups.mako')
     def view_groups(self):
@@ -163,7 +163,7 @@ class ManagementViews(object):
         groups_info = {}
         groups = self.get_groups()
         for group in groups:
-            groups_info[group] = {'members': len(self.get_group_users(group))}
+            groups_info[group] = {u'members': len(self.get_group_users(group))}
 
         return add_template_data(self.request, {'group_names': groups_info})
 
@@ -230,7 +230,7 @@ class ManagementViews(object):
                     check_res(requests.delete(url + '/' + perm))
 
                 for perm in new_perms:
-                    data = {'permission_name': perm}
+                    data = {u'permission_name': perm}
                     check_res(requests.post(url, data=data))
 
                 members = self.get_group_users(group_name)
@@ -244,7 +244,7 @@ class ManagementViews(object):
                     check_res(requests.delete(self.magpie_url + '/users/' + user + '/groups/' + group_name))
 
                 for user in new_members:
-                    check_res(requests.post(self.magpie_url+'/users/'+ user+'/groups/' + group_name))
+                    check_res(requests.post(self.magpie_url+'/users/' + user + '/groups/' + group_name))
 
                 members = self.get_group_users(group_name)
         #elif 'edit_group_offset' in self.request.session:
@@ -280,26 +280,13 @@ class ManagementViews(object):
             raise HTTPBadRequest(detail='Bad Json response')
 
         return add_template_data(self.request,
-                                 {'group_name': group_name,
-                                  'users': self.get_users(),
-                                  'members': members,
-                                  'svc_types': svc_types,
-                                  'cur_svc_type': cur_svc_type,
-                                  'resources': resources,
-                                  'permissions': list(perms)})
-
-    def get_services(self, cur_svc_type):
-        try:
-            res_svcs = requests.get(self.magpie_url + '/services')
-            check_res(res_svcs)
-            all_services = res_svcs.json()['services']
-            svc_types = all_services.keys()
-            if cur_svc_type not in svc_types:
-                cur_svc_type = svc_types[0]
-            services = all_services[cur_svc_type]
-            return svc_types, cur_svc_type, services
-        except Exception:
-            raise HTTPBadRequest(detail='Bad Json response')
+                                 {u'group_name': group_name,
+                                  u'users': self.get_users(),
+                                  u'members': members,
+                                  u'svc_types': svc_types,
+                                  u'cur_svc_type': cur_svc_type,
+                                  u'resources': resources,
+                                  u'permissions': list(perms)})
 
     @view_config(route_name='view_services', renderer='templates/view_services.mako')
     def view_services(self):
@@ -373,12 +360,16 @@ class ManagementViews(object):
             raise HTTPBadRequest(detail='Bad Json response [Exception: ' + e.message + ']')
 
         return add_template_data(self.request,
-                                 {'service_name': service_name,
-                                  'cur_svc_type': cur_svc_type,
-                                  'resources': resources,
-                                  'resources_types': raw_resources_types,
-                                  'resources_id_type': raw_resources_id_type,
-                                  'resources_no_child': {'file'}})
+                                 {u'edit_mode': edit_mode,
+                                  u'service_name': service_name,
+                                  u'service_url': service_url,
+                                  u'service_perm': service_perm,
+                                  u'service_id': service_id,
+                                  u'cur_svc_type': cur_svc_type,
+                                  u'resources': resources,
+                                  u'resources_types': raw_resources_types,
+                                  u'resources_id_type': raw_resources_id_type,
+                                  u'resources_no_child': {u'file'}})
 
     @view_config(route_name='add_resource', renderer='templates/add_resource.mako')
     def add_resource(self):
@@ -390,9 +381,9 @@ class ManagementViews(object):
             resource_name = self.request.POST.get('resource_name')
             resource_type = self.request.POST.get('resource_type')
 
-            data = {'resource_name': resource_name,
-                    'resource_type': resource_type,
-                    'parent_id': resource_id}
+            data = {u'resource_name': resource_name,
+                    u'resource_type': resource_type,
+                    u'parent_id': resource_id}
 
             check_res(requests.post(self.magpie_url + '/resources', data=data))
 
@@ -402,7 +393,7 @@ class ManagementViews(object):
         raw_svc_res = cur_svc_res.json()['resource_types']
 
         return add_template_data(self.request,
-                                 {'service_name': service_name,
-                                  'cur_svc_type': cur_svc_type,
-                                  'resource_id': resource_id,
-                                  'cur_svc_res': raw_svc_res})
+                                 {u'service_name': service_name,
+                                  u'cur_svc_type': cur_svc_type,
+                                  u'resource_id': resource_id,
+                                  u'cur_svc_res': raw_svc_res})

--- a/register_default_group.py
+++ b/register_default_group.py
@@ -8,59 +8,61 @@ LOGGER = logging.getLogger(__name__)
 
 
 
-
-def init_anonymous(db_session):
+def register_user_with_group(user_name, group_name, email, password, db_session):
     db = db_session
-    if not GroupService.by_group_name(ANONYMOUS_USER, db_session=db):
-        anonymous_group = models.Group(group_name=ANONYMOUS_USER)
-        db.add(anonymous_group)
+    if not GroupService.by_group_name(group_name, db_session=db):
+        new_group = models.Group(group_name=group_name)
+        db.add(new_group)
 
-    if not UserService.by_user_name(ANONYMOUS_USER, db_session=db):
-        anonymous_user = models.User(user_name=ANONYMOUS_USER, email=ANONYMOUS_USER + '@mail.com')
-        db.add(anonymous_user)
+    if not UserService.by_user_name(user_name, db_session=db):
+        new_user = models.User(user_name=user_name, email=email)
+        new_user.set_password(password)
+        new_user.regenerate_security_code()
+        db.add(new_user)
 
-        group_id = GroupService.by_group_name(ANONYMOUS_USER, db_session=db).id
-        user_id = UserService.by_user_name(ANONYMOUS_USER, db_session=db).id
+        group_id = GroupService.by_group_name(user_name, db_session=db).id
+        user_id = UserService.by_user_name(user_name, db_session=db).id
         group_entry = models.UserGroup(group_id=group_id, user_id=user_id)
         db.add(group_entry)
-
     else:
-        LOGGER.debug('anonymous already initialized')
+        LOGGER.debug(user_name+' already exist')
+
+
+def init_anonymous(db_session):
+    register_user_with_group(user_name=ANONYMOUS_USER,
+                             group_name=ANONYMOUS_USER,
+                             email=ANONYMOUS_USER+'@mail.com',
+                             password=ANONYMOUS_USER,
+                             db_session=db_session)
 
 
 def init_admin(db_session):
-    db = db_session
-    if not GroupService.by_group_name(ADMIN_GROUP, db_session=db):
-        admin_group = models.Group(group_name=ADMIN_GROUP)
-        db.add(admin_group)
+    if not (UserService.by_user_name(ADMIN_USER, db_session=db_session)
+            and GroupService.by_group_name(ADMIN_GROUP, db_session=db_session)):
+        register_user_with_group(user_name=ADMIN_USER,
+                                 group_name=ADMIN_GROUP,
+                                 email=ADMIN_USER + '@mail.com',
+                                 password=ADMIN_PASSWORD,
+                                 db_session=db_session)
 
-    if not UserService.by_user_name(ADMIN_USER, db_session=db):
-        admin_user = models.User(user_name=ADMIN_USER, email=ADMIN_USER + '@mail.com')
-        admin_user.set_password(ADMIN_PASSWORD)
-        admin_user.regenerate_security_code()
-        db.add(admin_user)
-
-        group = GroupService.by_group_name(ADMIN_GROUP, db_session=db)
-        admin = UserService.by_user_name(ADMIN_USER, db_session=db)
-
-        group_entry = models.UserGroup(group_id=group.id, user_id=admin.id)
-        db.add(group_entry)
-
+        group = GroupService.by_group_name(ADMIN_GROUP, db_session=db_session)
         new_group_permission = models.GroupPermission(perm_name=ADMIN_PERM, group_id=group.id)
-        db.add(new_group_permission)
+        try:
+            db_session.add(new_group_permission)
+        except Exception, e:
+            db_session.rollback()
+            raise e
 
-    else:
-        LOGGER.debug('admin already initialized')
 
-
-def init_user(db_session):
+def init_user_group(db_session):
     db = db_session
     if not GroupService.by_group_name(USER_GROUP, db_session=db):
         admin_group = models.Group(group_name=USER_GROUP)
         db.add(admin_group)
-
     else:
         LOGGER.debug('group USER already initialized')
+
+
 
 import time
 from magpie.db import get_tm_session, get_session_factory, get_engine, is_database_ready
@@ -80,7 +82,7 @@ if __name__ == '__main__':
 
     init_admin(db_session)
     init_anonymous(db_session)
-    init_user(db_session)
+    init_user_group(db_session)
     transaction.commit()
     db_session.close()
 


### PR DESCRIPTION
## Main modifications

- add service name/url edition support within `edit_service` page
- add danger confirmation message step for delete service both on `edit_service` and  `view_services` pages
- add `PUT` function to Magpie Rest API to allow modification of a service URL

## Extra

- suppress some `SAWarning` caused by raw strings passed instead of unicode
- refactor some CSS styles and display of tree items
- add utility CSS styles (banners, info/alert, button styles)