### PR TITLE
different 'catalog' access with valid perms

### DIFF
--- a/magpie/services.py
+++ b/magpie/services.py
@@ -183,6 +183,8 @@ class ServiceTHREDDS(ServiceI):
             elems[-1] = elems[-1].replace('.html', '')
         elif 'catalog' in elems:
             first_idx = elems.index('catalog')
+        elif elems[-1] == 'catalog.html':
+            first_idx = elems.index(self.service.resource_name) - 1
         else:
             return self.acl
 


### PR DESCRIPTION
Manage catalog access with permissions from equivalent urls:

`https://<bird>.crim.ca/ows/proxy/thredds/birdhouse/dummy_files/catalog.html`
`https://<bird>.crim.ca/ows/proxy/thredds/catalog/birdhouse/dummy_files/catalog.html`

1st was failing if `thredds` permission was removed even if every sub-resource permission were allowed