### PR TITLE
avoid index error if no svc perm for user

### DIFF
--- a/magpie/management/group/group.py
+++ b/magpie/management/group/group.py
@@ -106,6 +106,8 @@ def get_group_service_permissions_view(request):
             perms_found = service_type_dict[svc.type].permission_names
         else:
             svc_perm_list = get_group_services_permissions(grp, db_session=db, resource_ids=[svc.resource_id])
+            if len(svc_perm_list) < 1:
+                return svc, list()
             svc_found, perms_found = svc_perm_list[0]
         return svc_found, perms_found
 


### PR DESCRIPTION
caused a crash if user / group didn't have any permission on a specific service / resource when requested via `{bird}/magpie/groups/anonymous/services/ncWMS2/permissions`

## before:

```
{
    "type": "application/json",
    "code": 500,
    "call": {
        "content": "{u'group': {u'users': [<User: anonymous>], u'group_id': 124, u'description': 'None', u'member_count': 0, u'group_name': 'anonymous'}, u'service': {u'service_type': 'wps', u'service_name': 'lb_malleefowl', u'service_url': 'http://colibri.crim.ca:58091/wps', u'permission_names': [], u'resource_id': 1}}",
        "exception": "IndexError('list index out of range',)"
    },
    "detail": "Failed to extract permissions names from group-service"
}
```

## now:
```
{
    "permission_names": [],
    "code": 200,
    "type": "application/json",
    "detail": "Get group service permissions successful"
}
```