### PR TITLE
Permissions refactoring for Service-typed Resources

### DIFF
--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -3,7 +3,7 @@ General meta information on the magpie package.
 """
 
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 __author__ = "Francois-Xavier"
 __email__ = 'francois-xavier.derue@crim.ca'

--- a/magpie/alembic/versions/a395ef9d3fe6_reference_root_service.py
+++ b/magpie/alembic/versions/a395ef9d3fe6_reference_root_service.py
@@ -1,0 +1,76 @@
+"""reference root service
+
+Revision ID: a395ef9d3fe6
+Revises: ae1a3c8c7860
+Create Date: 2018-06-04 11:38:31.296950
+
+"""
+import os, sys
+cur_file = os.path.abspath(__file__)
+root_dir = os.path.dirname(cur_file)    # version
+root_dir = os.path.dirname(root_dir)    # alembic
+root_dir = os.path.dirname(root_dir)    # magpie
+root_dir = os.path.dirname(root_dir)    # root
+sys.path.insert(0, root_dir)
+
+from alembic import op
+import sqlalchemy as sa
+from alembic.context import get_context
+from sqlalchemy.dialects.postgresql.base import PGDialect
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.engine import reflection
+from magpie import models, ANONYMOUS_USER
+from ziggurat_definitions import *
+
+Session = sessionmaker()
+
+
+# revision identifiers, used by Alembic.
+revision = 'a395ef9d3fe6'
+down_revision = 'ae1a3c8c7860'
+branch_labels = None
+depends_on = None
+
+
+def get_resource_top_parent(resource, db_session):
+    if resource is not None:
+        if resource.parent_id is None:
+            return resource
+        parent_resource = ResourceService.by_resource_id(resource.parent_id, db_session=db_session)
+        return get_resource_top_parent(parent_resource, db_session=db_session)
+    return None
+
+
+def upgrade():
+    context = get_context()
+    session = Session(bind=op.get_bind())
+
+    # two following lines avoids double 'DELETE' erroneous call when deleting group due to incorrect checks
+    # https://stackoverflow.com/questions/28824401/sqlalchemy-attempting-to-twice-delete-many-to-many-secondary-relationship
+    context.connection.engine.dialect.supports_sane_rowcount = False
+    context.connection.engine.dialect.supports_sane_multi_rowcount = False
+
+    if isinstance(context.connection.engine.dialect, PGDialect):
+
+        # check if column exists, add it otherwise
+        inspector = reflection.Inspector.from_engine(context.connection.engine)
+        has_root_service_column = False
+        for column in inspector.get_columns(table_name='resources'):
+            if 'root_service_id' in column['name']:
+                has_root_service_column = True
+                break
+
+        if not has_root_service_column:
+            op.add_column('resources', sa.Column('root_service_id', sa.Integer(), nullable=True))
+
+        # add existing resource references to their root service, loop through reference tree chain
+        all_resources = session.query(models.Resource)
+        for resource in all_resources:
+            service_resource = get_resource_top_parent(resource, session)
+            if service_resource.resource_id != resource.resource_id:
+                resource.root_service_id = service_resource.resource_id
+        session.commit()
+
+
+def downgrade():
+    pass

--- a/magpie/alembic/versions/a395ef9d3fe6_reference_root_service.py
+++ b/magpie/alembic/versions/a395ef9d3fe6_reference_root_service.py
@@ -19,8 +19,8 @@ from alembic.context import get_context
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.engine import reflection
-from magpie import models, ANONYMOUS_USER
-from ziggurat_definitions import *
+from magpie import models
+from magpie.management.resource.resource_utils import get_resource_root_service
 
 Session = sessionmaker()
 
@@ -30,15 +30,6 @@ revision = 'a395ef9d3fe6'
 down_revision = 'ae1a3c8c7860'
 branch_labels = None
 depends_on = None
-
-
-def get_resource_top_parent(resource, db_session):
-    if resource is not None:
-        if resource.parent_id is None:
-            return resource
-        parent_resource = ResourceService.by_resource_id(resource.parent_id, db_session=db_session)
-        return get_resource_top_parent(parent_resource, db_session=db_session)
-    return None
 
 
 def upgrade():
@@ -66,7 +57,7 @@ def upgrade():
         # add existing resource references to their root service, loop through reference tree chain
         all_resources = session.query(models.Resource)
         for resource in all_resources:
-            service_resource = get_resource_top_parent(resource, session)
+            service_resource = get_resource_root_service(resource, session)
             if service_resource.resource_id != resource.resource_id:
                 resource.root_service_id = service_resource.resource_id
         session.commit()

--- a/magpie/api_except.py
+++ b/magpie/api_except.py
@@ -89,9 +89,9 @@ def verify_param(param, paramCompare=None, httpError=HTTPNotAcceptable, httpKWAr
     if isIn:
         status = status or (param not in paramCompare)
     if notEqual:
-        status = status or (param != paramCompare)
-    if isEqual:
         status = status or (param == paramCompare)
+    if isEqual:
+        status = status or (param != paramCompare)
     if ofType is not None:
         status = status or (not type(param) == ofType)
     if status:

--- a/magpie/api_requests.py
+++ b/magpie/api_requests.py
@@ -8,15 +8,15 @@ from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
 
 def get_service_or_resource_types(service_resource):
     if isinstance(service_resource, models.Service):
-        svc_res_type_dict = service_type_dict[service_resource.type]
-        svc_res_type_str = "service"
+        svc_res_type_obj = service_type_dict[service_resource.type]
+        svc_res_type_str = u"service"
     elif isinstance(service_resource, models.Resource):
-        svc_res_type_dict = resource_type_dict[service_resource.resource_type]
-        svc_res_type_str = "resource"
+        svc_res_type_obj = resource_type_dict[service_resource.resource_type]
+        svc_res_type_str = u"resource"
     else:
         raise_http(httpError=HTTPInternalServerError, detail="Invalid service/resource object",
                    content={u'service_resource': repr(type(service_resource))})
-    return svc_res_type_dict, svc_res_type_str
+    return svc_res_type_obj, svc_res_type_str
 
 
 def get_multiformat_post(request, key):
@@ -33,9 +33,9 @@ def get_multiformat_delete(request, key):
 
 
 def get_permission_multiformat_post_checked(request, service_resource, permission_name_key='permission_name'):
-    svc_res_type_dict, svc_res_type_str = get_service_or_resource_types(service_resource)
+    svc_res_type_obj, svc_res_type_str = get_service_or_resource_types(service_resource)
     perm_name = get_value_multiformat_post_checked(request, permission_name_key)
-    verify_param(perm_name, paramCompare=svc_res_type_dict.permission_names, isIn=True,
+    verify_param(perm_name, paramCompare=svc_res_type_obj.permission_names, isIn=True,
                  httpError=HTTPForbidden, msgOnFail="Permission not allowed for that " + str(svc_res_type_str))
     return perm_name
 
@@ -127,9 +127,9 @@ def get_service_matchdict_checked(request, service_name_key='service_name'):
 
 
 def get_permission_matchdict_checked(request, service_resource, permission_name_key='permission_name'):
-    svc_res_type_dict, svc_res_type_str = get_service_or_resource_types(service_resource)
+    svc_res_type_obj, svc_res_type_str = get_service_or_resource_types(service_resource)
     perm_name = get_value_matchdict_checked(request, permission_name_key)
-    verify_param(perm_name, paramCompare=svc_res_type_dict.permission_names, isIn=True,
+    verify_param(perm_name, paramCompare=svc_res_type_obj.permission_names, isIn=True,
                  httpError=HTTPForbidden, msgOnFail="Permission not allowed for that " + str(svc_res_type_str))
     return perm_name
 

--- a/magpie/api_requests.py
+++ b/magpie/api_requests.py
@@ -1,22 +1,8 @@
 from magpie import *
 from api_except import *
 from ziggurat_definitions import *
-from models import resource_type_dict
-from services import service_type_dict
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
-
-
-def get_service_or_resource_types(service_resource):
-    if isinstance(service_resource, models.Service):
-        svc_res_type_obj = service_type_dict[service_resource.type]
-        svc_res_type_str = u"service"
-    elif isinstance(service_resource, models.Resource):
-        svc_res_type_obj = resource_type_dict[service_resource.resource_type]
-        svc_res_type_str = u"resource"
-    else:
-        raise_http(httpError=HTTPInternalServerError, detail="Invalid service/resource object",
-                   content={u'service_resource': repr(type(service_resource))})
-    return svc_res_type_obj, svc_res_type_str
+from management.resource.resource_utils import check_valid_service_resource_permission
 
 
 def get_multiformat_post(request, key):
@@ -33,10 +19,8 @@ def get_multiformat_delete(request, key):
 
 
 def get_permission_multiformat_post_checked(request, service_resource, permission_name_key='permission_name'):
-    svc_res_type_obj, svc_res_type_str = get_service_or_resource_types(service_resource)
     perm_name = get_value_multiformat_post_checked(request, permission_name_key)
-    verify_param(perm_name, paramCompare=svc_res_type_obj.permission_names, isIn=True,
-                 httpError=HTTPForbidden, msgOnFail="Permission not allowed for that " + str(svc_res_type_str))
+    check_valid_service_resource_permission(perm_name, service_resource, request.db)
     return perm_name
 
 
@@ -110,8 +94,6 @@ def get_resource_matchdict_checked(request, resource_name_key='resource_id'):
                              fallback=lambda: request.db.rollback(),
                              httpError=HTTPForbidden, msgOnFail="Resource query by id refused by db")
     verify_param(resource, notNone=True, httpError=HTTPNotFound, msgOnFail="Resource ID not found in db")
-    verify_param(resource.resource_type, paramCompare=resource_type_dict, isIn=True,
-                 httpError=HTTPNotAcceptable, msgOnFail="Resource type does not match any valid entry")
     return resource
 
 
@@ -127,10 +109,8 @@ def get_service_matchdict_checked(request, service_name_key='service_name'):
 
 
 def get_permission_matchdict_checked(request, service_resource, permission_name_key='permission_name'):
-    svc_res_type_obj, svc_res_type_str = get_service_or_resource_types(service_resource)
     perm_name = get_value_matchdict_checked(request, permission_name_key)
-    verify_param(perm_name, paramCompare=svc_res_type_obj.permission_names, isIn=True,
-                 httpError=HTTPForbidden, msgOnFail="Permission not allowed for that " + str(svc_res_type_str))
+    check_valid_service_resource_permission(perm_name, service_resource, request.db)
     return perm_name
 
 

--- a/magpie/magpie.py
+++ b/magpie/magpie.py
@@ -20,7 +20,7 @@ from ziggurat_foundations.models import groupfinder
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.session import SignedCookieSessionFactory
-from pyramid.view import view_config, notfound_view_config, exception_view_config
+from pyramid.view import *
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.config import Configurator
 
@@ -44,15 +44,26 @@ def get_version(request):
 
 @notfound_view_config()
 def not_found(request):
-    content = get_request_info(request, default_msg="The route resource could not be found")
+    content = get_request_info(request, default_msg="The route resource could not be found.")
     return raise_http(nothrow=True, httpError=HTTPNotFound, contentType='application/json',
                       detail=content['detail'], content=content)
 
 
 @exception_view_config()
 def internal_server_error(request):
-    content = get_request_info(request, default_msg="Internal Server Error. Unhandled exception occurred")
+    content = get_request_info(request, default_msg="Internal Server Error. Unhandled exception occurred.")
     return raise_http(nothrow=True, httpError=HTTPInternalServerError, contentType='application/json',
+                      detail=content['detail'], content=content)
+
+
+@forbidden_view_config()
+def unauthorized_access(request):
+    # if not overridden, default is HTTPForbidden [403], which is for a slightly different situation
+    # this better reflects the HTTPUnauthorized [401] user access with specified AuthZ headers
+    # [http://www.restapitutorial.com/httpstatuscodes.html]
+    msg = "Unauthorized. Insufficient user privileges or missing authentication headers."
+    content = get_request_info(request, default_msg=msg)
+    return raise_http(nothrow=True, httpError=HTTPUnauthorized, contentType='application/json',
                       detail=content['detail'], content=content)
 
 

--- a/magpie/management/group/group_utils.py
+++ b/magpie/management/group/group_utils.py
@@ -35,7 +35,7 @@ def get_group_resources(group, db_session):
 
 def create_group_resource_permission(permission_name, resource, group_id, db_session):
     resource_id = resource.resource_id
-    check_valid_service_resource_permission(permission_name, resource_id, db_session)
+    check_valid_service_resource_permission(permission_name, resource, db_session)
     perm_content = {u'permission_name': str(permission_name), u'resource_id': resource_id, u'group_id': group_id}
     new_perm = evaluate_call(lambda: models.GroupResourcePermission(resource_id=resource_id, group_id=group_id),
                              fallback=lambda: db_session.rollback(), httpError=HTTPForbidden,

--- a/magpie/management/group/group_utils.py
+++ b/magpie/management/group/group_utils.py
@@ -1,6 +1,8 @@
 from api_requests import *
 from api_except import *
-from models import resource_tree_service
+from models import resource_tree_service, resource_type_dict
+from services import service_type_dict
+from management.resource.resource_utils import check_valid_service_resource_permission
 from management.service.service_formats import format_service_resources, format_service
 from group_formats import *
 from ziggurat_definitions import *
@@ -31,7 +33,9 @@ def get_group_resources(group, db_session):
     return json_response
 
 
-def create_group_resource_permission(permission_name, resource_id, group_id, db_session):
+def create_group_resource_permission(permission_name, resource, group_id, db_session):
+    resource_id = resource.resource_id
+    check_valid_service_resource_permission(permission_name, resource_id, db_session)
     perm_content = {u'permission_name': str(permission_name), u'resource_id': resource_id, u'group_id': group_id}
     new_perm = evaluate_call(lambda: models.GroupResourcePermission(resource_id=resource_id, group_id=group_id),
                              fallback=lambda: db_session.rollback(), httpError=HTTPForbidden,
@@ -77,7 +81,9 @@ def get_group_resource_permissions(group, resource, db_session):
                          content={u'group': repr(group), u'resource': repr(resource)})
 
 
-def delete_group_resource_permission(permission_name, resource_id, group_id, db_session):
+def delete_group_resource_permission(permission_name, resource, group_id, db_session):
+    resource_id = resource.resource_id
+    check_valid_service_resource_permission(permission_name, resource_id, db_session)
     perm_content = {u'permission_name': str(permission_name), u'resource_id': resource_id, u'group_id': group_id}
     del_perm = evaluate_call(
         lambda: GroupResourcePermissionService.get(group_id, resource_id, permission_name, db_session=db_session),

--- a/magpie/management/group/group_utils.py
+++ b/magpie/management/group/group_utils.py
@@ -12,16 +12,6 @@ def get_all_groups(db_session):
     return group_names
 
 
-def check_valid_service_resource_permission(permission_name, service_resource, db_session):
-    if service_resource.resource_type == u'service':
-        resource = models.Resource.by_resource_id(service_resource.resource_id, db_session)
-        verify_param(permission_name, paramCompare=service_type_dict[resource.type].permission_names,
-                     isIn=True, httpError=HTTPBadRequest, msgOnFail="Permission not allowed for that service type")
-    else:
-        verify_param(permission_name, paramCompare=resource_type_dict[service_resource.resource_type].permission_names,
-                     isIn=True, httpError=HTTPBadRequest, msgOnFail="Permission not allowed for that resource type")
-
-
 def get_group_resources(group, db_session):
     json_response = {}
     for svc in models.Service.all(db_session=db_session):

--- a/magpie/management/group/group_views.py
+++ b/magpie/management/group/group_views.py
@@ -86,7 +86,7 @@ def create_group_service_permission(request):
     group = get_group_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, service)
-    return create_group_resource_permission(perm_name, service.resource_id, group.id, db_session=request.db)
+    return create_group_resource_permission(perm_name, service, group.id, db_session=request.db)
 
 
 @view_config(route_name='group_service_permission', request_method='DELETE')
@@ -94,7 +94,7 @@ def delete_group_service_permission(request):
     group = get_group_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_matchdict_checked(request, service)
-    return delete_group_resource_permission(perm_name, service.resource_id, group.id, db_session=request.db)
+    return delete_group_resource_permission(perm_name, service, group.id, db_session=request.db)
 
 
 @view_config(route_name='group_resources', request_method='GET')
@@ -120,7 +120,7 @@ def create_group_resource_permission_view(request):
     group = get_group_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, resource)
-    return create_group_resource_permission(perm_name, resource.resource_id, group.id, db_session=request.db)
+    return create_group_resource_permission(perm_name, resource, group.id, db_session=request.db)
 
 
 @view_config(route_name='group_resource_permission', request_method='DELETE')
@@ -128,7 +128,7 @@ def delete_group_resource_permission_view(request):
     group = get_group_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_matchdict_checked(request, resource)
-    return delete_group_resource_permission(perm_name, resource.resource_id, group.id, db_session=request.db)
+    return delete_group_resource_permission(perm_name, resource, group.id, db_session=request.db)
 
 
 @view_config(route_name='group_service_resources', request_method='GET')

--- a/magpie/management/group/group_views.py
+++ b/magpie/management/group/group_views.py
@@ -35,7 +35,7 @@ def edit_group(request):
                  paramCompare=range(1, 1 + USER_NAME_MAX_LENGTH),
                  msgOnFail="Invalid `group_name` length specified " +
                            "(>{length} characters).".format(length=USER_NAME_MAX_LENGTH))
-    verify_param(new_group_name, isEqual=True, httpError=HTTPNotAcceptable,
+    verify_param(new_group_name, notEqual=True, httpError=HTTPNotAcceptable,
                  paramCompare=group.group_name, msgOnFail="Invalid `group_name` must be different than current name.")
     verify_param(models.Group.by_group_name(new_group_name, db_session=request.db), isNone=True, httpError=HTTPConflict,
                  msgOnFail="Group name already exists.")

--- a/magpie/management/resource/resource_formats.py
+++ b/magpie/management/resource/resource_formats.py
@@ -1,5 +1,6 @@
 from api_requests import *
 from models import resource_tree_service
+from services import service_type_dict
 
 
 def format_resource(resource, permissions=None, basic_info=False):

--- a/magpie/management/resource/resource_formats.py
+++ b/magpie/management/resource/resource_formats.py
@@ -15,6 +15,7 @@ def format_resource(resource, permissions=None, basic_info=False):
             u'resource_type': str(res.resource_type),
             u'resource_id': res.resource_id,
             u'parent_id': res.parent_id,
+            u'root_service_id': res.root_service_id,
             u'children': {},
             u'permission_names': list() if perms is None else perms
         }

--- a/magpie/management/resource/resource_formats.py
+++ b/magpie/management/resource/resource_formats.py
@@ -1,4 +1,5 @@
 from api_requests import *
+from models import resource_tree_service
 
 
 def format_resource(resource, permissions=None, basic_info=False):
@@ -41,3 +42,19 @@ def format_resource_tree(children, db_session, resources_perms_dict=None):
         fmt_res_tree[child_id][u'children'] = format_resource_tree(new_children, db_session, resources_perms_dict)
 
     return fmt_res_tree
+
+
+def get_resource_children(resource, db_session):
+    query = resource_tree_service.from_parent_deeper(resource.resource_id, db_session=db_session)
+    tree_struct_dict = resource_tree_service.build_subtree_strut(query)
+    return tree_struct_dict[u'children']
+
+
+def format_resource_with_children(resource, db_session):
+    resource_formatted = format_resource(resource)
+
+    resource_formatted[u'children'] = format_resource_tree(
+        get_resource_children(resource, db_session),
+        db_session=db_session
+    )
+    return resource_formatted

--- a/magpie/management/resource/resource_utils.py
+++ b/magpie/management/resource/resource_utils.py
@@ -54,11 +54,11 @@ def get_resource_root_service(resource, db_session):
 
 
 def create_resource(resource_name, resource_type, parent_id, db_session):
-    verify_param(resource_name, notNone=True, notEmpty=True, httpError=HTTPNotAcceptable,
+    verify_param(resource_name, notNone=True, notEmpty=True, httpError=HTTPBadRequest,
                  msgOnFail="Invalid `resource_name` '" + str(resource_name) + "' specified for child resource creation")
-    verify_param(resource_type, notNone=True, notEmpty=True, httpError=HTTPNotAcceptable,
+    verify_param(resource_type, notNone=True, notEmpty=True, httpError=HTTPBadRequest,
                  msgOnFail="Invalid `resource_type` '" + str(resource_type) + "' specified for child resource creation")
-    verify_param(parent_id, notNone=True, notEmpty=True, httpError=HTTPNotFound,
+    verify_param(parent_id, notNone=True, notEmpty=True, httpError=HTTPBadRequest,
                  msgOnFail="Invalid `parent_id` '" + str(parent_id) + "' specified for child resource creation")
     parent_resource = evaluate_call(lambda: ResourceService.by_resource_id(parent_id, db_session=db_session),
                                     fallback=lambda: db_session.rollback(), httpError=HTTPNotFound,
@@ -96,6 +96,6 @@ def create_resource(resource_name, resource_type, parent_id, db_session):
 
     evaluate_call(lambda: add_resource_in_tree(new_resource, db_session),
                   fallback=lambda: db_session.rollback(),
-                  httpError=HTTPBadRequest, msgOnFail="Failed to insert new resource in service tree using parent id")
+                  httpError=HTTPForbidden, msgOnFail="Failed to insert new resource in service tree using parent id")
     return valid_http(httpSuccess=HTTPCreated, detail="Create resource successful",
                       content=format_resource(new_resource, basic_info=True))

--- a/magpie/management/resource/resource_utils.py
+++ b/magpie/management/resource/resource_utils.py
@@ -1,23 +1,20 @@
-from models import resource_type_dict, resource_tree_service, resource_factory
+from models import resource_factory
 from resource_formats import *
 from ziggurat_definitions import *
 from api_except import *
+from api_requests import get_service_or_resource_types
 
 
-def get_resource_children(resource, db_session):
-    query = resource_tree_service.from_parent_deeper(resource.resource_id, db_session=db_session)
-    tree_struct_dict = resource_tree_service.build_subtree_strut(query)
-    return tree_struct_dict[u'children']
+def check_valid_service_resource_permission(permission_name, service_resource):
+    svc_res_obj, svc_res_type = get_service_or_resource_types(service_resource)
+    verify_param(permission_name, paramCompare=svc_res_obj.permission_names,
+                 isIn=True, httpError=HTTPBadRequest,
+                 msgOnFail="Permission not allowed for that {} type".format(svc_res_type))
 
 
-def format_resource_with_children(resource, db_session):
-    resource_formatted = format_resource(resource)
-
-    resource_formatted[u'children'] = format_resource_tree(
-        get_resource_children(resource, db_session),
-        db_session=db_session
-    )
-    return resource_formatted
+def get_specific_service_resource_permissions(service_resource):
+    svc_res_obj, svc_res_type = get_service_or_resource_types(service_resource)
+    return svc_res_obj.permission_names
 
 
 def crop_tree_with_permission(children, resource_id_list):

--- a/magpie/management/resource/resource_utils.py
+++ b/magpie/management/resource/resource_utils.py
@@ -54,11 +54,11 @@ def get_resource_root_service(resource, db_session):
 
 
 def create_resource(resource_name, resource_type, parent_id, db_session):
-    verify_param(resource_name, notNone=True, notEmpty=True,
+    verify_param(resource_name, notNone=True, notEmpty=True, httpError=HTTPNotAcceptable,
                  msgOnFail="Invalid `resource_name` '" + str(resource_name) + "' specified for child resource creation")
-    verify_param(resource_type, notNone=True, notEmpty=True,
+    verify_param(resource_type, notNone=True, notEmpty=True, httpError=HTTPNotAcceptable,
                  msgOnFail="Invalid `resource_type` '" + str(resource_type) + "' specified for child resource creation")
-    verify_param(parent_id, notNone=True, notEmpty=True,
+    verify_param(parent_id, notNone=True, notEmpty=True, httpError=HTTPNotFound,
                  msgOnFail="Invalid `parent_id` '" + str(parent_id) + "' specified for child resource creation")
     parent_resource = evaluate_call(lambda: ResourceService.by_resource_id(parent_id, db_session=db_session),
                                     fallback=lambda: db_session.rollback(), httpError=HTTPNotFound,

--- a/magpie/management/resource/resource_views.py
+++ b/magpie/management/resource/resource_views.py
@@ -2,6 +2,20 @@ from api_requests import *
 from resource_utils import *
 from common import str2bool
 from register import sync_services_phoenix
+from management.service.service_utils import get_services_by_type
+from management.service.service_formats import format_service_resources
+
+
+@view_config(route_name='resources', request_method='GET')
+def get_resources_view(request):
+    res_json = {}
+    for svc_type in service_type_dict.keys():
+        services = get_services_by_type(svc_type, db_session=request.db)
+        res_json[svc_type] = {}
+        for svc in services:
+            res_json[svc_type][svc.resource_name] = format_service_resources(svc, request.db, display_all=True)
+    res_json = {u'resources': res_json}
+    return valid_http(httpSuccess=HTTPOk, detail="Get resources successful", content=res_json)
 
 
 @view_config(route_name='resource', request_method='GET')

--- a/magpie/management/resource/resource_views.py
+++ b/magpie/management/resource/resource_views.py
@@ -2,6 +2,7 @@ from api_requests import *
 from resource_utils import *
 from common import str2bool
 from register import sync_services_phoenix
+from services import service_type_dict
 from management.service.service_utils import get_services_by_type
 from management.service.service_formats import format_service_resources
 
@@ -20,12 +21,12 @@ def get_resources_view(request):
 
 @view_config(route_name='resource', request_method='GET')
 def get_resource_view(request):
-    res = get_resource_matchdict_checked(request)
-    res_json = evaluate_call(lambda: format_resource_with_children(res, db_session=request.db),
+    resource = get_resource_matchdict_checked(request)
+    res_json = evaluate_call(lambda: format_resource_with_children(resource, db_session=request.db),
                              fallback=lambda: request.db.rollback(), httpError=HTTPInternalServerError,
                              msgOnFail="Failed building resource children json formatted tree",
-                             content=format_resource(res, basic_info=True))
-    return valid_http(httpSuccess=HTTPOk, detail="Get resource successful", content={res.resource_id: res_json})
+                             content=format_resource(resource, basic_info=True))
+    return valid_http(httpSuccess=HTTPOk, detail="Get resource successful", content={resource.resource_id: res_json})
 
 
 @view_config(route_name='resources', request_method='POST')

--- a/magpie/management/resource/resource_views.py
+++ b/magpie/management/resource/resource_views.py
@@ -84,11 +84,11 @@ def update_resource(request):
 
 
 @view_config(route_name='resource_permissions', request_method='GET')
-def get_resource_permissions(request):
-    res = get_resource_matchdict_checked(request, 'resource_id')
-    res_perm = evaluate_call(lambda: resource_type_dict[res.resource_type].permission_names,
+def get_resource_permissions_view(request):
+    resource = get_resource_matchdict_checked(request, 'resource_id')
+    res_perm = evaluate_call(lambda: get_resource_permissions(resource, db_session=request.db),
                              fallback=lambda: request.db.rollback(), httpError=HTTPNotAcceptable,
                              msgOnFail="Invalid resource type to extract permissions",
-                             content=format_resource(res, basic_info=True))
+                             content=format_resource(resource, basic_info=True))
     return valid_http(httpSuccess=HTTPOk, detail="Get resource permissions successful",
                       content={u'permission_names': res_perm})

--- a/magpie/management/service/service_formats.py
+++ b/magpie/management/service/service_formats.py
@@ -28,7 +28,6 @@ def format_service(service, permissions=None):
 
 def format_service_resources(service, db_session, service_perms=None, resources_perms_dict=None, display_all=False):
     service_perms = list() if service_perms is None else service_perms
-    resources_perms_dict = dict() if resources_perms_dict is None else resources_perms_dict
 
     def fmt_svc_res(svc, db, svc_perms, res_perms, show_all):
         tree = get_resource_children(svc, db)

--- a/magpie/management/service/service_formats.py
+++ b/magpie/management/service/service_formats.py
@@ -27,13 +27,12 @@ def format_service(service, permissions=None):
 
 
 def format_service_resources(service, db_session, service_perms=None, resources_perms_dict=None, display_all=False):
-    service_perms = list() if service_perms is None else service_perms
-
     def fmt_svc_res(svc, db, svc_perms, res_perms, show_all):
         tree = get_resource_children(svc, db)
-        if not show_all:
+        if not show_all:            
             tree, resource_id_list_remain = crop_tree_with_permission(tree, res_perms.keys())
 
+        svc_perms = service_type_dict[svc.type].permission_names if svc_perms is None else svc_perms
         svc_res = format_service(svc, svc_perms)
         svc_res[u'resources'] = format_resource_tree(tree, resources_perms_dict=res_perms, db_session=db)
         return svc_res

--- a/magpie/management/service/service_formats.py
+++ b/magpie/management/service/service_formats.py
@@ -1,5 +1,6 @@
 from api_requests import *
 from register import get_twitcher_protected_service_url
+from services import service_type_dict
 from management.resource.resource_utils import (
     get_resource_children,
     format_resource_tree,
@@ -29,7 +30,7 @@ def format_service(service, permissions=None):
 def format_service_resources(service, db_session, service_perms=None, resources_perms_dict=None, display_all=False):
     def fmt_svc_res(svc, db, svc_perms, res_perms, show_all):
         tree = get_resource_children(svc, db)
-        if not show_all:            
+        if not show_all:
             tree, resource_id_list_remain = crop_tree_with_permission(tree, res_perms.keys())
 
         svc_perms = service_type_dict[svc.type].permission_names if svc_perms is None else svc_perms

--- a/magpie/management/service/service_utils.py
+++ b/magpie/management/service/service_utils.py
@@ -23,4 +23,4 @@ def add_service_getcapabilities_perms(service, db_session, group_name=None):
         perm = ResourceService.perm_by_group_and_perm_name(service.resource_id, group.id,
                                                            u'getcapabilities', db_session)
         if perm is None:  # not set, create it
-            create_group_resource_permission(u'getcapabilities', service.resource_id, group.id, db_session)
+            create_group_resource_permission(u'getcapabilities', service, group.id, db_session)

--- a/magpie/management/service/service_views.py
+++ b/magpie/management/service/service_views.py
@@ -5,6 +5,7 @@ from api_requests import *
 from common import str2bool
 from register import sync_services_phoenix
 from models import resource_tree_service
+from services import service_type_dict
 from pyramid.view import view_config
 
 

--- a/magpie/management/service/service_views.py
+++ b/magpie/management/service/service_views.py
@@ -74,7 +74,7 @@ def update_service(request):
     # None/Empty values are accepted in case of unspecified
     svc_name = select_update(get_multiformat_post(request, 'service_name'), service.resource_name)
     svc_url = select_update(get_multiformat_post(request, 'service_url'), service.url)
-    verify_param(svc_name == service.resource_name and svc_url == service.url, isEqual=True, paramCompare=True,
+    verify_param(svc_name == service.resource_name and svc_url == service.url, notEqual=True, paramCompare=True,
                  httpError=HTTPBadRequest, msgOnFail="Current service values are already equal to update values")
 
     if svc_name != service.resource_name:
@@ -158,18 +158,6 @@ def create_service_direct_resource(request):
     if not parent_id:
         parent_id = service.resource_id
     return create_resource(resource_name, resource_type, parent_id=parent_id, db_session=request.db)
-
-
-@view_config(route_name='resources', request_method='GET')
-def get_resources_view(request):
-    res_json = {}
-    for svc_type in service_type_dict.keys():
-        services = get_services_by_type(svc_type, db_session=request.db)
-        res_json[svc_type] = {}
-        for svc in services:
-            res_json[svc_type][svc.resource_name] = format_service_resources(svc, request.db, display_all=True)
-    res_json = {u'resources': res_json}
-    return valid_http(httpSuccess=HTTPOk, detail="Get resources successful", content=res_json)
 
 
 @view_config(route_name='service_type_resource_types', request_method='GET')

--- a/magpie/management/user/user_utils.py
+++ b/magpie/management/user/user_utils.py
@@ -1,6 +1,7 @@
 from magpie import *
 from api_except import *
 from services import service_type_dict
+from management.resource.resource_utils import check_valid_service_resource_permission
 import models
 from ziggurat_definitions import *
 
@@ -37,7 +38,9 @@ def create_user(user_name, password, email, group_name, db_session):
     return valid_http(httpSuccess=HTTPCreated, detail="Add user to db successful")
 
 
-def create_user_resource_permission(permission_name, resource_id, user_id, db_session):
+def create_user_resource_permission(permission_name, resource, user_id, db_session):
+    check_valid_service_resource_permission(permission_name, resource, db_session)
+    resource_id = resource.resource_id
     new_perm = models.UserResourcePermission(resource_id=resource_id, user_id=user_id)
     verify_param(new_perm, notNone=True, httpError=HTTPNotAcceptable,
                  content={u'resource_id': str(resource_id), u'user_id': str(user_id)},
@@ -50,7 +53,9 @@ def create_user_resource_permission(permission_name, resource_id, user_id, db_se
                       content={u'resource_id': resource_id})
 
 
-def delete_user_resource_permission(permission_name, resource_id, user_id, db_session):
+def delete_user_resource_permission(permission_name, resource, user_id, db_session):
+    check_valid_service_resource_permission(permission_name, resource, db_session)
+    resource_id = resource.resource_id
     del_perm = UserResourcePermissionService.get(user_id, resource_id, permission_name, db_session)
     evaluate_call(lambda: db_session.delete(del_perm), fallback=lambda: db_session.rollback(),
                   httpError=HTTPNotFound, msgOnFail="Could not find user resource permission to delete from db",

--- a/magpie/management/user/user_views.py
+++ b/magpie/management/user/user_views.py
@@ -2,7 +2,6 @@ from api_requests import *
 from user_utils import *
 from ziggurat_definitions import *
 from management.service.service_formats import format_service, format_service_resources
-from management.resource.resource_utils import check_valid_service_resource_permission
 
 
 @view_config(route_name='users', request_method='POST')
@@ -171,8 +170,7 @@ def create_user_resource_permission_view(request):
     user = get_user_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, resource)
-    check_valid_service_resource_permission(perm_name, resource)
-    return create_user_resource_permission(perm_name, resource.resource_id, user.id, request.db)
+    return create_user_resource_permission(perm_name, resource, user.id, request.db)
 
 
 @view_config(route_name='user_resource_permission', request_method='DELETE')
@@ -180,8 +178,7 @@ def delete_user_resource_permission_view(request):
     user = get_user_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_matchdict_checked(request, resource)
-    check_valid_service_resource_permission(perm_name, resource)
-    return delete_user_resource_permission(perm_name, resource.resource_id, user.id, request.db)
+    return delete_user_resource_permission(perm_name, resource, user.id, request.db)
 
 
 def get_user_services_runner(request, inherited_group_services_permissions):
@@ -237,8 +234,7 @@ def create_user_service_permission(request):
     user = get_user_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, service)
-    check_valid_service_resource_permission(perm_name, service)
-    return create_user_resource_permission(perm_name, service.resource_id, user.id, request.db)
+    return create_user_resource_permission(perm_name, service, user.id, request.db)
 
 
 @view_config(route_name='user_service_permission', request_method='DELETE')
@@ -246,5 +242,4 @@ def delete_user_service_permission(request):
     user = get_user_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, service)
-    check_valid_service_resource_permission(perm_name, service)
-    return delete_user_resource_permission(perm_name, service.resource_id, user.id, request.db)
+    return delete_user_resource_permission(perm_name, service, user.id, request.db)

--- a/magpie/management/user/user_views.py
+++ b/magpie/management/user/user_views.py
@@ -2,7 +2,7 @@ from api_requests import *
 from user_utils import *
 from ziggurat_definitions import *
 from management.service.service_formats import format_service, format_service_resources
-from management.group.group_utils import check_valid_service_resource_permission
+from management.resource.resource_utils import check_valid_service_resource_permission
 
 
 @view_config(route_name='users', request_method='POST')
@@ -171,7 +171,7 @@ def create_user_resource_permission_view(request):
     user = get_user_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, resource)
-    check_valid_service_resource_permission(perm_name, resource, request.db)
+    check_valid_service_resource_permission(perm_name, resource)
     return create_user_resource_permission(perm_name, resource.resource_id, user.id, request.db)
 
 
@@ -180,7 +180,7 @@ def delete_user_resource_permission_view(request):
     user = get_user_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_matchdict_checked(request, resource)
-    check_valid_service_resource_permission(perm_name, resource, request.db)
+    check_valid_service_resource_permission(perm_name, resource)
     return delete_user_resource_permission(perm_name, resource.resource_id, user.id, request.db)
 
 
@@ -237,7 +237,7 @@ def create_user_service_permission(request):
     user = get_user_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, service)
-    check_valid_service_resource_permission(perm_name, service, request.db)
+    check_valid_service_resource_permission(perm_name, service)
     return create_user_resource_permission(perm_name, service.resource_id, user.id, request.db)
 
 
@@ -246,5 +246,5 @@ def delete_user_service_permission(request):
     user = get_user_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, service)
-    check_valid_service_resource_permission(perm_name, service, request.db)
+    check_valid_service_resource_permission(perm_name, service)
     return delete_user_resource_permission(perm_name, service.resource_id, user.id, request.db)

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -262,7 +262,7 @@ def magpie_add_register_services_perms(services, statuses, curl_cookies, request
         svc_available_perms_url = '{magpie}/services/{svc}/permissions' \
                                   .format(magpie=magpie_url, svc=service_name)
         resp_available_perms = requests.get(svc_available_perms_url, cookies=request_cookies)
-        if resp_available_perms.status_code == 403:
+        if resp_available_perms.status_code == 401:
             raise_log("Invalid credentials, cannot update service permissions")
 
         available_perms = resp_available_perms.json().get('permission_names', [])

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -7,9 +7,13 @@ from pyramid.security import Allow
 
 
 class ServiceI(object):
-    permission_names = []
+    permission_names = []   # global permissions allowed for the service (top-level resource)
     params_expected = []    # derived services must have 'request' at least for 'permission_requested' method
-    resource_types = []
+    resource_types_permissions = {}     # dict of list for each corresponding allowed resource permissions
+
+    @property
+    def resource_types(self):  # allowed resources types under the service
+        return self.resource_types_permissions.keys()
 
     def __init__(self, service, request):
         self.service = service
@@ -51,13 +55,19 @@ class ServiceI(object):
 
 class ServiceWPS(ServiceI):
 
-    permission_names = [u'getcapabilities',
-                        u'describeprocess',
-                        u'execute']
+    permission_names = [
+        u'getcapabilities',
+        u'describeprocess',
+        u'execute'
+    ]
 
-    params_expected = [u'service',
-                       u'request',
-                       u'version']
+    params_expected = [
+        u'service',
+        u'request',
+        u'version'
+    ]
+
+    resource_types_permissions = {}
 
     def __init__(self, service, request):
         super(ServiceWPS, self).__init__(service, request)
@@ -70,28 +80,59 @@ class ServiceWPS(ServiceI):
 
 class ServiceWMS(ServiceI):
 
-    permission_names = [u'getcapabilities',
-                        u'getmap',
-                        u'getfeatureinfo',
-                        u'getlegendgraphic',
-                        u'getmetadata']
+    permission_names = [
+        u'getcapabilities',
+        u'getmap',
+        u'getfeatureinfo',
+        u'getlegendgraphic',
+        u'getmetadata'
+    ]
 
-    params_expected = [u'service',
-                       u'request',
-                       u'version',
-                       u'layers',
-                       u'layername',
-                       u'dataset']
+    params_expected = [
+        u'service',
+        u'request',
+        u'version',
+        u'layers',
+        u'layername',
+        u'dataset'
+    ]
 
-    resource_types = [models.Workspace.resource_type_name]
+    resource_types_permissions = {
+        models.Workspace.resource_type_name: [
+            u'getcapabilities',
+            u'getmap',
+            u'getfeatureinfo',
+            u'getlegendgraphic',
+            u'getmetadata'
+        ]
+    }
 
     def __init__(self, service, request):
         super(ServiceWMS, self).__init__(service, request)
 
+    @property
+    def __acl__(self):
+        raise NotImplementedError
+
 
 class ServiceNCWMS2(ServiceWMS):
-    resource_types = [models.File.resource_type_name,
-                      models.Directory.resource_type_name]
+
+    resource_types_permissions = {
+        models.File.resource_type_name: [
+            u'getcapabilities',
+            u'getmap',
+            u'getfeatureinfo',
+            u'getlegendgraphic',
+            u'getmetadata'
+        ],
+        models.Directory.resource_type_name: [
+            u'getcapabilities',
+            u'getmap',
+            u'getfeatureinfo',
+            u'getlegendgraphic',
+            u'getmetadata'
+        ]
+    }
 
     def __init__(self, service, request):
         super(ServiceNCWMS2, self).__init__(service, request)
@@ -179,18 +220,22 @@ class ServiceGeoserver(ServiceWMS):
 
 class ServiceWFS(ServiceI):
 
-    permission_names = [u'getcapabilities',
-                        u'describefeaturetype',
-                        u'getfeature',
-                        u'lockfeature',
-                        u'transaction']
+    permission_names = [
+        u'getcapabilities',
+        u'describefeaturetype',
+        u'getfeature',
+        u'lockfeature',
+        u'transaction'
+    ]
 
-    params_expected = [u'service',
-                       u'request',
-                       u'version',
-                       u'typenames']
+    params_expected = [
+        u'service',
+        u'request',
+        u'version',
+        u'typenames'
+    ]
 
-    resource_types = []
+    resource_types_permissions = {}
 
     def __init__(self, service, request):
         super(ServiceWFS, self).__init__(service, request)
@@ -221,13 +266,25 @@ class ServiceWFS(ServiceI):
 
 class ServiceTHREDDS(ServiceI):
 
-    permission_names = ['read',
-                        'write']
+    permission_names = [
+        u'read',
+        u'write'
+    ]
 
-    params_expected = [u'request']
+    params_expected = [
+        u'request'
+    ]
 
-    resource_types = [models.Directory.resource_type_name,
-                      models.File.resource_type_name]
+    resource_types_permissions = {
+        models.Directory.resource_type_name: [
+            u'read',
+            u'write'
+        ],
+        models.File.resource_type_name: [
+            u'read',
+            u'write'
+        ],
+    }
 
     def __init__(self, service, request):
         super(ServiceTHREDDS, self).__init__(service, request)
@@ -269,13 +326,25 @@ class ServiceTHREDDS(ServiceI):
 
 class ServiceProjectAPI(ServiceI):
 
-    permission_names = ['read',
-                        'write']
+    permission_names = [
+        u'read',
+        u'write'
+    ]
 
-    params_expected = [u'request']
+    params_expected = [
+        u'request'
+    ]
 
-    resource_types = [models.Directory.resource_type_name,
-                      models.File.resource_type_name]
+    resource_types_permissions = {
+        models.Directory.resource_type_name: [
+            u'read',
+            u'write'
+        ],
+        models.File.resource_type_name: [
+            u'read',
+            u'write'
+        ],
+    }
 
     def __init__(self, service, request):
         super(ServiceProjectAPI, self).__init__(service, request)
@@ -291,12 +360,14 @@ class ServiceProjectAPI(ServiceI):
     pass
 
 
-service_type_dict = {u'wps': ServiceWPS,
-                     u'ncwms': ServiceNCWMS2,
-                     u'geoserverwms': ServiceGeoserver,
-                     u'wfs': ServiceWFS,
-                     u'thredds': ServiceTHREDDS,
-                     u'project-api': ServiceProjectAPI}
+service_type_dict = {
+    u'wps':             ServiceWPS,
+    u'ncwms':           ServiceNCWMS2,
+    u'geoserverwms':    ServiceGeoserver,
+    u'wfs':             ServiceWFS,
+    u'thredds':         ServiceTHREDDS,
+    u'project-api':     ServiceProjectAPI
+}
 
 
 def service_factory(service, request):

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -11,9 +11,11 @@ class ServiceI(object):
     params_expected = []    # derived services must have 'request' at least for 'permission_requested' method
     resource_types_permissions = {}     # dict of list for each corresponding allowed resource permissions
 
-    @property
-    def resource_types(self):  # allowed resources types under the service
-        return self.resource_types_permissions.keys()
+    # make 'property' getter from derived classes
+    class __metaclass__(type):
+        @property
+        def resource_types(cls):  # allowed resources types under the service
+            return cls.resource_types_permissions.keys()
 
     def __init__(self, service, request):
         self.service = service

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -600,7 +600,7 @@ class ManagementViews(object):
 
         if 'delete_child' in self.request.POST:
             resource_id = self.request.POST.get('resource_id')
-            check_response(requests.delete('{url}/services/{res_id}'.format(url=self.magpie_url, res_id=resource_id),
+            check_response(requests.delete('{url}/resources/{res_id}'.format(url=self.magpie_url, res_id=resource_id),
                                            cookies=self.request.cookies))
 
         if 'add_child' in self.request.POST:


### PR DESCRIPTION
## Permissions changes:
- resources and services now display all **applicable**/**permitted** `permission_names` according to service-specific sub-resources permissions
- user and group resources/services still display only **applied** permissions (ie: same ones as ticked in UI)
- added more checks to restrict creation of unsupported resources under a given service
- added more checks to restrict assignation of unsupported permissions under a specific *service-typed* resource
- db migration for new `root_service_id` stored under every sub-resource
    * links are created for existing resources
    * created resources will be updated automatically with proper link to service
- magpie `0.5.1`

addresses issue #40 

## Others: 
- adjusted error message returned when user has insufficient permissions to execute a call, now 401 is returned (instead of 403) and is in JSON format.
