### PR TITLE
Issue 60 signin routes

### DIFF
--- a/docs/magpie-rest-api.yaml
+++ b/docs/magpie-rest-api.yaml
@@ -133,6 +133,8 @@ paths:
                 $ref: '#/components/responses/Providers_GET_200'
   /groups:
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Get list of group names
@@ -150,6 +152,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Groups_GET_403'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Create a group
@@ -179,6 +183,8 @@ paths:
                 $ref: '#/components/responses/Group_POST_409'
   '/groups/{group_name}':
     put:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Update a group by name
@@ -221,6 +227,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Group_PUT_409'
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Delete a group by name
@@ -260,6 +268,8 @@ paths:
                   - $ref: '#/components/responses/NotFound_404'
   '/groups/{group_name}/users':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: List all user from group
@@ -279,6 +289,8 @@ paths:
                 $ref: '#/components/responses/GroupUsers_GET_200'
   '/groups/{group_name}/resources':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: List all resources a group has permission on
@@ -298,6 +310,8 @@ paths:
                 $ref: '#/components/responses/GroupResources_GET_200'
   '/groups/{group_name}/resources/{resource_id}/permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: List all permissions a group has on a specific resource
@@ -340,6 +354,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Resource_MatchDictCheck_406'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Create a permission on a specific resource for that group
@@ -394,6 +410,8 @@ paths:
                 $ref: '#/components/responses/GroupResourceOrServicePermission_POST_409'
   '/groups/{group_name}/resources/{resource_id}/permissions/{permission_name}':
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Delete a permission on a resource for a group
@@ -434,6 +452,8 @@ paths:
                 $ref: '#/components/responses/NotFound_404'
   '/groups/{group_name}/services':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: List all services a group has permission on
@@ -453,6 +473,8 @@ paths:
                 $ref: '#/components/responses/GroupServices_GET_200'
   '/groups/{group_name}/services/{service_name}/permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: List all permissions a group has on a specific service
@@ -483,6 +505,8 @@ paths:
               schema:
                 $ref: '#/components/responses/NotFound_404'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Create a permission on a service for a group
@@ -519,6 +543,8 @@ paths:
                 $ref: '#/components/responses/NotFound_404'
   '/groups/{group_name}/services/{service_name}/permissions/{permission_name}':
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: Delete a permission on a service for a group
@@ -557,6 +583,8 @@ paths:
                 $ref: '#/components/responses/NotFound_404'
   '/groups/{group_name}/services/{service_name}/resources':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Group
       summary: List all resources under a service a group has permission on
@@ -588,6 +616,8 @@ paths:
                 $ref: '#/components/responses/NotFound_404'
   /users:
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all users registered
@@ -605,6 +635,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Users_GET_403'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Create a new user
@@ -640,6 +672,8 @@ paths:
                 $ref: '#/components/responses/User_MatchDictCheck_409'
   '/users/{user_name}':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Get user information by name
@@ -670,6 +704,8 @@ paths:
               schema:
                 $ref: '#/components/responses/NotFound_404'
     put:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Update user informations by user name
@@ -711,6 +747,8 @@ paths:
               schema:
                 $ref: '#/components/responses/User_PUT_409'
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Delete a user by name
@@ -736,6 +774,8 @@ paths:
                 $ref: '#/components/responses/NotFound_404'
   '/users/{user_name}/groups':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all groups a user belongs to
@@ -761,6 +801,8 @@ paths:
               schema:
                 $ref: '#/components/responses/NotFound_404'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Assign a user to a group
@@ -797,6 +839,8 @@ paths:
                 $ref: '#/components/responses/UserGroup_POST_409'
   '/users/{user_name}/groups/{group_name}':
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Remove user from a group
@@ -839,6 +883,8 @@ paths:
                   - $ref: '#/components/responses/Group_MatchDictCheck_404'
   '/users/{user_name}/inherited_resources':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all resources a user has permission on with his inherited user and groups permissions
@@ -864,6 +910,8 @@ paths:
                 $ref: '#/components/responses/NotFound_404'
   '/users/{user_name}/resources':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all resources a user has direct permission on (not including his groups permissions)
@@ -889,6 +937,8 @@ paths:
                 $ref: '#/components/responses/NotFound_404'
   '/users/{user_name}/resources/{resource_id}/inherited_permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all permissions a user has on a specific resource with his inherited user and groups permissions
@@ -915,6 +965,8 @@ paths:
                 $ref: '#/components/responses/UserResourcePermissions_GET_200'
   '/users/{user_name}/resources/{resource_id}/permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all direct permissions a user has on a specific resource (not including his groups permissions)
@@ -940,6 +992,8 @@ paths:
               schema:
                 $ref: '#/components/responses/UserResourcePermissions_GET_200'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Create a permission on specific resource for a user
@@ -970,6 +1024,8 @@ paths:
             user
   '/users/{user_name}/resources/{resource_id}/permissions/{permission_name}':
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Delete a permission on a resource for a user
@@ -999,6 +1055,8 @@ paths:
           description: permission not found
   '/users/{user_name}/inherited_services':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all services a user has permission on with his inherited user and groups permissions
@@ -1018,6 +1076,8 @@ paths:
                 $ref: '#/components/responses/UserServices_GET_200'
   '/users/{user_name}/services':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all services a user has direct permission on (not including his groups permissions)
@@ -1037,6 +1097,8 @@ paths:
                 $ref: '#/components/responses/UserServices_GET_200'
   '/users/{user_name}/services/{service_name}/inherited_permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all permissions a user has on a service using all his inherited user and groups permissions
@@ -1062,6 +1124,8 @@ paths:
                 $ref: '#/components/responses/UserServicePermissions_GET_200'
   '/users/{user_name}/services/{service_name}/permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all direct permissions a user has on a service (not including his groups permissions)
@@ -1086,6 +1150,8 @@ paths:
               schema:
                 $ref: '#/components/responses/UserServicePermissions_GET_200'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Create a permission on a service for a user
@@ -1116,6 +1182,8 @@ paths:
                 $ref: '#/components/responses/UserServicePermissions_POST_201'
   '/users/{user_name}/services/{service_name}/permissions/{permission_name}':
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: Delete a permission on a service for a user
@@ -1145,6 +1213,8 @@ paths:
           description: permission not found
   '/users/{user_name}/services/{service_name}/inherited_resources':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all resources under a service a user has permission on using all his inherited user and groups permissions
@@ -1191,6 +1261,8 @@ paths:
                   - $ref: '#/components/responses/Service_MatchDictCheck_404'
   '/users/{user_name}/services/{service_name}/resources':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - User
       summary: List all resources under a service a user has direct permission on (not including his groups permissions)
@@ -1696,6 +1768,8 @@ paths:
                   - $ref: '#/components/responses/Service_MatchDictCheck_404'
   /resources:
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Resource
       summary: List all resources registered in the database
@@ -1707,6 +1781,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Resources_GET_200'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - Resource
       summary: Register a new resource
@@ -1760,6 +1836,8 @@ paths:
                 $ref: '#/components/responses/Resources_POST_500'
   '/resources/{resource_id}':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Resource
       summary: Get resource info
@@ -1796,6 +1874,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Resource_MatchDictCheck_406'
     put:
+      security:
+        - cookieAuth: []
       tags:
         - Resource
       summary: Rename resource
@@ -1831,6 +1911,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Resource_MatchDictCheck_406'
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - Resource
       summary: Unregister resource from the database
@@ -1868,6 +1950,8 @@ paths:
                 $ref: '#/components/responses/Resource_MatchDictCheck_406'
   '/resources/{resource_id}/permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Resource
       summary: List all possible permissions for a resource
@@ -1905,6 +1989,8 @@ paths:
                 $ref: '#/components/responses/Resource_MatchDictCheck_406'
   /services:
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: List all services registered
@@ -1923,6 +2009,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Resources_GET_200'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: Register a new service
@@ -1958,6 +2046,8 @@ paths:
                 $ref: '#/components/responses/Matchdict_422'
   '/services/types/{service_type}':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: List all a service filtered by type
@@ -1977,6 +2067,8 @@ paths:
                 $ref: '#/components/responses/ServicesFilteredType_GET_200'
   '/services/{service_name}':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: Get service info
@@ -1995,6 +2087,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Service_GET_200'
     put:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: Update service information (name or URL)
@@ -2045,6 +2139,8 @@ paths:
               schema:
                 $ref: '#/components/responses/Service_PUT_409'
     delete:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: Unregister a service from the database
@@ -2062,6 +2158,8 @@ paths:
           description: service not found
   '/services/{service_name}/resources':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: List all resources registered under a service
@@ -2086,6 +2184,8 @@ paths:
               schema:
                 $ref: '#/components/responses/ServiceResources_GET_404'
     post:
+      security:
+        - cookieAuth: []
       tags:
         - Resource
         - Service
@@ -2123,6 +2223,8 @@ paths:
                 $ref: '#/components/responses/Services_POST_409'
   '/services/{service_name}/permissions':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: List all possible permissions for a service
@@ -2154,6 +2256,8 @@ paths:
                 $ref: '#/components/responses/ServicePermissions_GET_406'
   '/services/types/{service_type}/resources/types':
     get:
+      security:
+        - cookieAuth: []
       tags:
         - Service
       summary: List all resource type for a specific service type
@@ -2178,6 +2282,11 @@ paths:
               schema:
                 $ref: '#/components/responses/ServiceTypeResourceTypes_GET_404'
 components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: auth_tkt
   schemas:
     Base:
       type: object
@@ -2192,6 +2301,9 @@ components:
           type: string
         type:
           type: string
+    AuthHeaders:
+      type: string
+      example: auth_tkt=abcde12345; Path=/
     ErrorDetail:
       type: object
       required:
@@ -2691,20 +2803,20 @@ components:
               - github
     Signin_POST_200:
       description: sign in success
+      headers:
+        Set-Cookie:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/AuthHeaders'
       content:
         application/json:
           schema:
             allOf:
               - $ref: '#/components/schemas/Base'
-              - type: object
-                properties:
-                  headers:
-                    type: string
           example:
             code: 200
             type: application/json
             detail: Login successful
-            headers: <login headers>
     Signin_POST_400:
       description: sign in invalid input
       content:
@@ -4558,5 +4670,5 @@ components:
             code: 200
             type: application/json
             detail: Get version successful
-            version: "0.5.3"
+            version: "0.5.4"
             db_version: "a395ef9d3fe6"

--- a/magpie/login/__init__.py
+++ b/magpie/login/__init__.py
@@ -6,7 +6,9 @@ def includeme(config):
     logger.info('Adding login ...')
     # Add all the rest api routes
     config.add_route('session', '/session')
+    config.add_route('signin_internal', '/signin_internal')
     config.add_route('signin_external', '/signin_external')
+    config.add_route('signin', '/signin')
     config.add_route('signout', '/signout')
     config.add_route('providers', '/providers')
     config.add_route('external_login', 'providers/{provider_name}/signin')

--- a/magpie/login/__init__.py
+++ b/magpie/login/__init__.py
@@ -6,7 +6,7 @@ def includeme(config):
     logger.info('Adding login ...')
     # Add all the rest api routes
     config.add_route('session', '/session')
-    config.add_route('signin_internal', '/signin_internal')
+    #config.add_route('signin_internal', '/signin_internal')
     config.add_route('signin_external', '/signin_external')
     config.add_route('signin', '/signin')
     config.add_route('signout', '/signout')

--- a/magpie/login/__init__.py
+++ b/magpie/login/__init__.py
@@ -6,7 +6,7 @@ def includeme(config):
     logger.info('Adding login ...')
     # Add all the rest api routes
     config.add_route('session', '/session')
-    #config.add_route('signin_internal', '/signin_internal')
+    #config.add_route('signin_internal', '/signin_internal') # added via 'magpie.ini' configs
     config.add_route('signin_external', '/signin_external')
     config.add_route('signin', '/signin')
     config.add_route('signout', '/signout')

--- a/magpie/login/login.py
+++ b/magpie/login/login.py
@@ -7,6 +7,7 @@ from security import authomatic
 from api_requests import *
 from magpie import *
 from management.user.user_utils import create_user
+import requests
 
 
 internal_providers = [u'ziggurat']
@@ -44,7 +45,7 @@ def sign_in_external(request):
 @view_config(route_name='signin_internal', request_method='POST', permission=NO_PERMISSION_REQUIRED)
 def sign_in_internal(request):
     # special route 'ziggurat_foundations.ext.pyramid.sign_in'
-    return request.route_url('sign_in')
+    return request.route_url('sign_in', **request.json())
 
 
 @view_config(route_name='signin', request_method='POST', permission=NO_PERMISSION_REQUIRED)
@@ -58,7 +59,7 @@ def sign_in(request):
                  content={u'provider_name': str(provider_name), u'providers': providers})
 
     if provider_name in internal_providers:
-        return request.route_url('signin_internal', user_name=user_name, password=password)
+        return requests.post('signin_internal', data={u'user_name': user_name, u'password': password}, allow_redirects=True)
 
     elif provider_name in external_providers:
         return evaluate_call(lambda: sign_in_external(request, {u'user_name': user_name,

--- a/magpie/login/login.py
+++ b/magpie/login/login.py
@@ -15,29 +15,6 @@ import requests
 
 
 external_providers_config = {
-
-    #'tw': { # Your internal provider name
-
-        # Provider class
-    #    'class_': oauth1.Twitter,
-
-        # Twitter is an AuthorizationProvider so we need to set several other properties too:
-    #    'consumer_key': '########################',
-    #    'consumer_secret': '########################',
-    #},
-
-    #'fb': {
-
-    #    'class_': oauth2.Facebook,
-
-        # Facebook is an AuthorizationProvider too.
-    #    'consumer_key': '########################',
-    #    'consumer_secret': '########################',
-
-        # But it is also an OAuth 2.0 provider and it needs scope.
-    #    'scope': ['user_about_me', 'email', 'publish_stream'],
-    #},
-
     'openid': {
         'class_': openid.OpenID,    # OpenID provider dependent on the python-openid package.
     },
@@ -91,12 +68,6 @@ def sign_in_external(request):
     return HTTPFound(location=external_login_route, headers=request.response.headers)
 
 
-#@view_config(route_name='signin_internal', request_method='POST', permission=NO_PERMISSION_REQUIRED)
-#def sign_in_internal(request):
-#    # special route 'ziggurat_foundations.ext.pyramid.sign_in'
-#    return request.route_url('sign_in', **request.json())
-
-
 @view_config(route_name='signin', request_method='POST', permission=NO_PERMISSION_REQUIRED)
 def sign_in(request):
     provider_name = get_value_multiformat_post_checked(request, 'provider_name')
@@ -108,7 +79,6 @@ def sign_in(request):
                  content={u'provider_name': str(provider_name), u'providers': providers})
 
     if provider_name in internal_providers:
-        #try:
         signin_internal_url = '{}/signin_internal'.format(request.application_url)
         signin_internal_data = {u'user_name': user_name, u'password': password}
         signin_response = requests.post(signin_internal_url, data=signin_internal_data, allow_redirects=True)
@@ -118,23 +88,7 @@ def sign_in(request):
             for cookie in signin_response.cookies:
                 pyramid_response.set_cookie(name=cookie.name, value=cookie.value, overwrite=True)
             return pyramid_response
-        raise_http(httpError=HTTPBadRequest, detail="Login failure.")
-
-            #elif signin_response.status_code in [HTTPBadRequest.code, HTTPNotAcceptable.code]:
-            #    return_data[u'invalid_username'] = True
-            #    return add_template_data(self.request, return_data)
-            #elif response.status_code == HTTPUnauthorized.code:
-            #    return_data[u'invalid_password'] = True
-            #    return add_template_data(self.request, return_data)
-
-            #resp = evaluate_call(lambda: requests.post('{}/sign_in'.format(request.application_url),
-            #                                           data={u'user_name': user_name, u'password': password}),
-            #                     httpError=HTTPBadRequest, msgOnFail="Invalid credentials.")
-            #if resp.status_code == HTTPOk.code:
-            #    return valid_http(httpSuccess=HTTPOk, detail="Login successful.")
-            #raise_http(httpError=HTTPBadRequest, detail="Failed login.")
-        #except Exception as e:
-        #    print(e)
+        raise_http(httpError=HTTPUnauthorized, detail="Login failure.")
 
     elif provider_name in external_providers:
         return evaluate_call(lambda: sign_in_external(request, {u'user_name': user_name,
@@ -152,12 +106,9 @@ def sign_out(request):
 
 
 @view_config(context=ZigguratSignInSuccess, permission=NO_PERMISSION_REQUIRED)
-def login_success_ziggu(request):
+def login_success_ziggurat(request):
     # headers contains login authorization cookie
-    try:
-        return valid_http(httpSuccess=HTTPOk, detail="Login successful", httpKWArgs={'headers': request.context.headers})
-    except Exception as e:
-        print(e)
+    return valid_http(httpSuccess=HTTPOk, detail="Login successful.", httpKWArgs={'headers': request.context.headers})
 
 
 def new_user_external(external_user_name, external_id, email, provider_name, db_session):
@@ -216,9 +167,8 @@ def login_failure(request, reason=None):
 
 
 @view_config(context=ZigguratSignOut, permission=NO_PERMISSION_REQUIRED)
-def sign_out_ziggu(request):
-    return valid_http(httpSuccess=HTTPOk, detail="Sign out successful.",
-                      httpKWArgs={'headers': forget(request)})
+def sign_out_ziggurat(request):
+    return valid_http(httpSuccess=HTTPOk, detail="Sign out successful.", httpKWArgs={'headers': forget(request)})
 
 
 @view_config(route_name='external_login', permission=NO_PERMISSION_REQUIRED)

--- a/magpie/login/login.py
+++ b/magpie/login/login.py
@@ -60,12 +60,15 @@ def sign_in(request):
 
     if provider_name in internal_providers:
         try:
-            resp = evaluate_call(lambda: requests.post('{}/sign_in'.format(request.application_url),
-                                                       data={u'user_name': user_name, u'password': password}),
-                                 httpError=HTTPBadRequest, msgOnFail="Invalid credentials.")
-            if resp.status_code == HTTPOk.code:
-                return valid_http(httpSuccess=HTTPOk, detail="Login successful.")
-            raise_http(httpError=HTTPBadRequest, detail="Failed login.")
+            signin_internal_url = '{}/signin_internal'.format(request.application_url)
+            signin_internal_data = {u'user_name': user_name, u'password': password}
+            return requests.post(signin_internal_url, data=signin_internal_data, allow_redirects=True)
+            #resp = evaluate_call(lambda: requests.post('{}/sign_in'.format(request.application_url),
+            #                                           data={u'user_name': user_name, u'password': password}),
+            #                     httpError=HTTPBadRequest, msgOnFail="Invalid credentials.")
+            #if resp.status_code == HTTPOk.code:
+            #    return valid_http(httpSuccess=HTTPOk, detail="Login successful.")
+            #raise_http(httpError=HTTPBadRequest, detail="Failed login.")
         except Exception as e:
             print(e)
 

--- a/magpie/login/login.py
+++ b/magpie/login/login.py
@@ -1,4 +1,6 @@
 from authomatic.adapters import WebObAdapter
+from authomatic.providers import oauth1, oauth2, openid
+from authomatic import Authomatic
 from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 from pyramid.security import forget, remember
 from ziggurat_foundations.ext.pyramid.sign_in import ZigguratSignInBadAuth, ZigguratSignInSuccess, ZigguratSignOut
@@ -10,14 +12,51 @@ from management.user.user_utils import create_user
 import requests
 
 
+external_providers_config = {
+
+    #'tw': { # Your internal provider name
+
+        # Provider class
+    #    'class_': oauth1.Twitter,
+
+        # Twitter is an AuthorizationProvider so we need to set several other properties too:
+    #    'consumer_key': '########################',
+    #    'consumer_secret': '########################',
+    #},
+
+    #'fb': {
+
+    #    'class_': oauth2.Facebook,
+
+        # Facebook is an AuthorizationProvider too.
+    #    'consumer_key': '########################',
+    #    'consumer_secret': '########################',
+
+        # But it is also an OAuth 2.0 provider and it needs scope.
+    #    'scope': ['user_about_me', 'email', 'publish_stream'],
+    #},
+
+    'openid': {
+        'class_': openid.OpenID,    # OpenID provider dependent on the python-openid package.
+    },
+    'github': {
+        'class_': oauth2.GitHub,
+    },
+    'dkrz': {
+    },
+    'ipsl': {
+    },
+    'badc': {
+    },
+    'pcmdi': {
+    },
+    'smhi': {
+    },
+}
+
+external_providers_authomatic = Authomatic(config=external_providers_config, secret=os.getenv('MAGPIE_SECRET'))
+external_providers = external_providers_config.keys()
 internal_providers = [u'ziggurat']
-external_providers = [u'openid',
-                      u'dkrz',
-                      u'ipsl',
-                      u'badc',
-                      u'pcmdi',
-                      u'smhi',
-                      u'github']
 providers = internal_providers + external_providers
 
 
@@ -175,13 +214,14 @@ def sign_out_ziggu(request):
 
 @view_config(route_name='external_login', permission=NO_PERMISSION_REQUIRED)
 def authomatic_login(request):
-    _authomatic = authomatic(request)
+    #_authomatic = authomatic(request)
     open_id_provider_name = request.matchdict.get('provider_name')
 
     # Start the login procedure.
 
     response = Response()
-    result = _authomatic.login(WebObAdapter(request, response), open_id_provider_name)
+    result = external_providers_authomatic.login(WebObAdapter(request, response), open_id_provider_name)
+    #result = _authomatic.login(WebObAdapter(request, response), open_id_provider_name)
 
     if result:
         if result.error:

--- a/magpie/login/login.py
+++ b/magpie/login/login.py
@@ -1,6 +1,8 @@
 from authomatic.adapters import WebObAdapter
 from authomatic.providers import oauth1, oauth2, openid
-from authomatic import Authomatic
+from authomatic import Authomatic, provider_id
+import authomatic
+
 from pyramid.security import NO_PERMISSION_REQUIRED, Authenticated
 from pyramid.security import forget, remember
 from ziggurat_foundations.ext.pyramid.sign_in import ZigguratSignInBadAuth, ZigguratSignInSuccess, ZigguratSignOut
@@ -41,6 +43,14 @@ external_providers_config = {
     },
     'github': {
         'class_': oauth2.GitHub,
+        'consumer_key': '##########',
+        'consumer_secret': '##########',
+        'id': provider_id(),
+        'scope': oauth2.GitHub.user_info_scope,
+        '_apis': {
+            'Get your events': ('GET', 'https://api.github.com/users/{user.username}/events'),
+            'Get your watched repos': ('GET', 'https://api.github.com/user/subscriptions'),
+        },
     },
     'dkrz': {
     },
@@ -104,11 +114,10 @@ def sign_in(request):
         signin_response = requests.post(signin_internal_url, data=signin_internal_data, allow_redirects=True)
 
         if signin_response.status_code == HTTPOk.code:
-            pyr_res = Response(body=signin_response.content, headers=signin_response.headers)
+            pyramid_response = Response(body=signin_response.content, headers=signin_response.headers)
             for cookie in signin_response.cookies:
-                pyr_res.set_cookie(name=cookie.name, value=cookie.value, overwrite=True)
-            return valid_http(httpSuccess=HTTPOk, detail="Login successful.",
-                              httpKWArgs={u'headers': pyr_res.headers})
+                pyramid_response.set_cookie(name=cookie.name, value=cookie.value, overwrite=True)
+            return pyramid_response
         raise_http(httpError=HTTPBadRequest, detail="Login failure.")
 
             #elif signin_response.status_code in [HTTPBadRequest.code, HTTPNotAcceptable.code]:

--- a/magpie/magpie.ini
+++ b/magpie/magpie.ini
@@ -33,7 +33,7 @@ ziggurat_foundations.sign_in.username_key = user_name
 ziggurat_foundations.sign_in.password_key = password
 ziggurat_foundations.sign_in.came_from_key = came_from
 ziggurat_foundations.session_provider_callable = models:get_session_callable
-ziggurat_foundations.sign_in.sign_in_pattern = /signin_internal
+ziggurat_foundations.sign_in.sign_in_pattern = /sign_in
 
 magpie.max_restart = 5
 

--- a/magpie/magpie.ini
+++ b/magpie/magpie.ini
@@ -33,7 +33,7 @@ ziggurat_foundations.sign_in.username_key = user_name
 ziggurat_foundations.sign_in.password_key = password
 ziggurat_foundations.sign_in.came_from_key = came_from
 ziggurat_foundations.session_provider_callable = models:get_session_callable
-ziggurat_foundations.sign_in.sign_in_pattern = /sign_in
+ziggurat_foundations.sign_in.sign_in_pattern = /signin_internal
 
 magpie.max_restart = 5
 

--- a/magpie/magpie.ini
+++ b/magpie/magpie.ini
@@ -33,7 +33,7 @@ ziggurat_foundations.sign_in.username_key = user_name
 ziggurat_foundations.sign_in.password_key = password
 ziggurat_foundations.sign_in.came_from_key = came_from
 ziggurat_foundations.session_provider_callable = models:get_session_callable
-ziggurat_foundations.sign_in.sign_in_pattern = /signin
+ziggurat_foundations.sign_in.sign_in_pattern = /signin_internal
 
 magpie.max_restart = 5
 

--- a/magpie/ui/login/templates/login.mako
+++ b/magpie/ui/login/templates/login.mako
@@ -5,6 +5,19 @@
 <li><a href="${request.route_url('login')}">Log in</a></li>
 </%block>
 
+%if invalid_credentials:
+<div class="alert danger visible" id="Login_CredentialsAlert">
+    <h3 class="alert_title danger">Invalid Credentials!</h3>
+    <p>
+        Incorrect username or password.
+    </p>
+    <form action="${request.path}" method="post">
+        <input type="submit" class="button cancel" name="close" value="Close"
+               onclick="this.parentElement.style.display='none';">
+    </form>
+</div>
+%endif
+
 <h1>Log in</h1>
 
 <form class="new_item_form" action="${request.route_url('login')}" method="post">
@@ -17,26 +30,14 @@
             <div class="input_container">
                 <td><input type="text" name="user_name" value="${user_name}" class="equal_width"></td>
             </div>
-            %if invalid_username:
-                <td><p class="alert_form_error">
-                    <img src="${request.static_url('ui.home:static/warning_exclamation.png')}" /> unknown </p>
-                </td>
-            %else:
-                <td><p class="alert_form_error">&nbsp;</p></td> <!-- empty cell to keep table shape consistent -->
-            %endif
+            <td><p class="alert_form_error">&nbsp;</p></td> <!-- empty cell to keep table shape consistent -->
         </tr>
         <tr>
             <td>Password:</td>
             <div class="input_container">
                 <td><input type="password" name="password" value="" class="equal_width"></td>
             </div>
-            %if invalid_password:
-                <td><p class="alert_form_error">
-                    <img src="${request.static_url('ui.home:static/warning_exclamation.png')}" /> incorrect </p>
-                </td>
-            %else:
-                <td><p class="alert_form_error">&nbsp;</p></td> <!-- empty cell to keep table shape consistent -->
-            %endif
+            <td><p class="alert_form_error">&nbsp;</p></td> <!-- empty cell to keep table shape consistent -->
         </tr>
         <tr><td class="centered" colspan="2"><input type="submit" value="Sign In" name="submit" id="submit"></td></tr>
     </table>
@@ -52,7 +53,7 @@
             <div class="input_container">
                 <td><input type="text" name="user_name" class="equal_width"></td>
             </div>
-            <td> <!-- padding --> </td>
+            <td><p class="alert_form_error">&nbsp;</p></td> <!-- empty cell to keep table shape consistent -->
         </tr>
         <tr>
             <td>Provider:</td>

--- a/magpie/ui/login/views.py
+++ b/magpie/ui/login/views.py
@@ -33,35 +33,20 @@ class ManagementViews(object):
 
         try:
             if 'submit' in self.request.POST:
-                provider_name = self.request.POST.get('provider_name', 'ziggurat')
-                # Local login
-                if provider_name == 'ziggurat':
-                    new_location = self.magpie_url + '/signin'
-                    data_to_send = {}
-                    for key in self.request.POST:
-                        data_to_send[key] = self.request.POST.get(key)
+                signin_url = '{}/signin'.format(self.magpie_url)
+                data_to_send = {}
+                for key in self.request.POST:
+                    data_to_send[key] = self.request.POST.get(key)
 
-                    response = requests.post(new_location, data=data_to_send, allow_redirects=True)
-                    if response.status_code == HTTPOk.code:
-                        pyr_res = Response(body=response.content, headers=response.headers)
-                        for cookie in response.cookies:
-                            pyr_res.set_cookie(name=cookie.name, value=cookie.value, overwrite=True)
-                        return HTTPFound(location=self.request.route_url('home'), headers=pyr_res.headers)
-                    else:
-                        return_data[u'invalid_credentials'] = True
-                        return add_template_data(self.request, return_data)
-                else:
-                    # External login
-                    external_url = self.magpie_url + '/signin_external'
-                    data_to_send = {}
-                    for key in self.request.POST:
-                        data_to_send[key] = self.request.POST.get(key)
-                    response = requests.post(external_url, data=data_to_send, allow_redirects=True)
-                    pyr_res = Response(body=response.content, status=response.status_code, headers=response.headers)
+                response = requests.post(signin_url, data=data_to_send, allow_redirects=True)
+                if response.status_code == HTTPOk.code:
+                    pyr_res = Response(body=response.content, headers=response.headers)
                     for cookie in response.cookies:
                         pyr_res.set_cookie(name=cookie.name, value=cookie.value, overwrite=True)
-                    return pyr_res
-
+                    return HTTPFound(location=self.request.route_url('home'), headers=pyr_res.headers)
+                else:
+                    return_data[u'invalid_credentials'] = True
+                    return add_template_data(self.request, return_data)
         except Exception as e:
             return HTTPInternalServerError(detail=repr(e))
 

--- a/magpie/ui/login/views.py
+++ b/magpie/ui/login/views.py
@@ -47,7 +47,7 @@ class ManagementViews(object):
                         pyr_res = Response(body=response.content, headers=response.headers)
                         for cookie in response.cookies:
                             pyr_res.set_cookie(name=cookie.name, value=cookie.value, overwrite=True)
-                            return HTTPFound(location=self.request.route_url('home'), headers=pyr_res.headers)
+                        return HTTPFound(location=self.request.route_url('home'), headers=pyr_res.headers)
                     elif response.status_code in [HTTPBadRequest.code, HTTPNotAcceptable.code]:
                         return_data[u'invalid_username'] = True
                         return add_template_data(self.request, return_data)

--- a/magpie/ui/login/views.py
+++ b/magpie/ui/login/views.py
@@ -27,8 +27,7 @@ class ManagementViews(object):
     def login(self):
         return_data = {
             u'external_providers': self.get_external_providers(),
-            u'invalid_username': False,
-            u'invalid_password': False,
+            u'invalid_credentials': False,
             u'user_name': self.request.POST.get('user_name', u''),
         }
 
@@ -48,13 +47,9 @@ class ManagementViews(object):
                         for cookie in response.cookies:
                             pyr_res.set_cookie(name=cookie.name, value=cookie.value, overwrite=True)
                         return HTTPFound(location=self.request.route_url('home'), headers=pyr_res.headers)
-                    elif response.status_code in [HTTPBadRequest.code, HTTPNotAcceptable.code]:
-                        return_data[u'invalid_username'] = True
+                    else:
+                        return_data[u'invalid_credentials'] = True
                         return add_template_data(self.request, return_data)
-                    elif response.status_code == HTTPUnauthorized.code:
-                        return_data[u'invalid_password'] = True
-                        return add_template_data(self.request, return_data)
-                        #return Response(body=response.content, status=response.status_code, headers=response.headers)
                 else:
                     # External login
                     external_url = self.magpie_url + '/signin_external'


### PR DESCRIPTION
# PR is WIP

address issue #60 

## Done
- no more signin internal/external from UI, all under API
- same `/signin` route for internal/external API
- `signin_internal` is auto-managed by ziggurat for login
- `signin_external` uses the authomatic login, but none really works...
- invalid credentials banner instead of specific info about login failure (issue #59)

## Mapping
- `/signin` (provider_name='ziggurat') => `/signin_internal`
- `/signin` (provider_name=*external provider*) => `/signin_external` => `/providers/{provider}/signin`

## Still under investigation
- preserve/remove the additional `/providers/{provider}/signin` ? (do everything in `/signin_external`)
- add verification & validation of *token* (?) with external providers
- UI login from a central location (pavics-frontend) ?

## Possible workaround to avoid many sign in routes 
  `/signin` could maybe be used to first (always) attempt login locally via the auto ziggurat mapping, then on failure, check if an external provider was specified and, if so, run the corresponding operation...   
  would remove any need of   `/signin_internal` / `/signin_external` 
