### PR TITLE
resolve 500 on group resource permission delete

### DIFF
--- a/magpie/management/group/group_formats.py
+++ b/magpie/management/group/group_formats.py
@@ -1,8 +1,13 @@
 from api_requests import *
 
 
-def format_group(group):
-    def fmt_grp(grp):
+def format_group(group, basic_info=False):
+    def fmt_grp(grp, info):
+        if info:
+            return {
+                u'group_name': str(grp.group_name),
+                u'group_id': grp.id,
+            }
         return {
             u'group_name': str(grp.group_name),
             u'description': str(grp.description),
@@ -12,6 +17,6 @@ def format_group(group):
         }
 
     return evaluate_call(
-        lambda: fmt_grp(group), httpError=HTTPInternalServerError,
+        lambda: fmt_grp(group, basic_info), httpError=HTTPInternalServerError,
         msgOnFail="Failed to format group", content={u'group': repr(group)}
     )

--- a/magpie/management/group/group_utils.py
+++ b/magpie/management/group/group_utils.py
@@ -5,7 +5,7 @@ from services import service_type_dict
 from management.resource.resource_utils import check_valid_service_resource_permission
 from management.resource.resource_formats import format_resource
 from management.service.service_formats import format_service_resources, format_service
-from group_formats import *
+from management.group.group_formats import *
 from ziggurat_definitions import *
 
 

--- a/magpie/management/group/group_utils.py
+++ b/magpie/management/group/group_utils.py
@@ -3,6 +3,7 @@ from api_except import *
 from models import resource_tree_service, resource_type_dict
 from services import service_type_dict
 from management.resource.resource_utils import check_valid_service_resource_permission
+from management.resource.resource_formats import format_resource
 from management.service.service_formats import format_service_resources, format_service
 from group_formats import *
 from ziggurat_definitions import *
@@ -33,16 +34,25 @@ def get_group_resources(group, db_session):
     return json_response
 
 
-def create_group_resource_permission(permission_name, resource, group_id, db_session):
+def create_group_resource_permission(permission_name, resource, group, db_session):
     resource_id = resource.resource_id
     check_valid_service_resource_permission(permission_name, resource, db_session)
-    perm_content = {u'permission_name': str(permission_name), u'resource_id': resource_id, u'group_id': group_id}
-    new_perm = evaluate_call(lambda: models.GroupResourcePermission(resource_id=resource_id, group_id=group_id),
+    perm_content = {u'permission_name': str(permission_name),
+                    u'resource': format_resource(resource, basic_info=True),
+                    u'group': format_group(group, basic_info=True)}
+    create_perm = evaluate_call(
+        lambda: GroupResourcePermissionService.get(group.id, resource_id, permission_name, db_session=db_session),
+        fallback=lambda: db_session.rollback(), httpError=HTTPForbidden,
+        msgOnFail="Get group resource permission failed", content=perm_content
+    )
+    verify_param(create_perm, isNone=True, httpError=HTTPConflict,
+                 msgOnFail="Group resource permission already exists.", content=perm_content)
+    new_perm = evaluate_call(lambda: models.GroupResourcePermission(resource_id=resource_id, group_id=group.id),
                              fallback=lambda: db_session.rollback(), httpError=HTTPForbidden,
                              msgOnFail="Create group resource permission failed", content=perm_content)
     new_perm.perm_name = permission_name
-    evaluate_call(lambda: db_session.add(new_perm), fallback=lambda: db_session.rollback(), httpError=HTTPConflict,
-                  msgOnFail="Add group resource permission refused by db", content=perm_content)
+    evaluate_call(lambda: db_session.add(new_perm), fallback=lambda: db_session.rollback(), httpError=HTTPForbidden,
+                  msgOnFail="Add group resource permission refused by db.", content=perm_content)
     return valid_http(httpSuccess=HTTPCreated, detail="Create group resource permission successful",
                       content=perm_content)
 
@@ -81,15 +91,19 @@ def get_group_resource_permissions(group, resource, db_session):
                          content={u'group': repr(group), u'resource': repr(resource)})
 
 
-def delete_group_resource_permission(permission_name, resource, group_id, db_session):
+def delete_group_resource_permission(permission_name, resource, group, db_session):
     resource_id = resource.resource_id
-    check_valid_service_resource_permission(permission_name, resource_id, db_session)
-    perm_content = {u'permission_name': str(permission_name), u'resource_id': resource_id, u'group_id': group_id}
+    check_valid_service_resource_permission(permission_name, resource, db_session)
+    perm_content = {u'permission_name': str(permission_name),
+                    u'resource': format_resource(resource, basic_info=True),
+                    u'group': format_group(group, basic_info=True)}
     del_perm = evaluate_call(
-        lambda: GroupResourcePermissionService.get(group_id, resource_id, permission_name, db_session=db_session),
+        lambda: GroupResourcePermissionService.get(group.id, resource_id, permission_name, db_session=db_session),
         fallback=lambda: db_session.rollback(), httpError=HTTPForbidden,
         msgOnFail="Get group resource permission failed", content=perm_content
     )
+    verify_param(del_perm, notNone=True, httpError=HTTPNotFound,  content=perm_content,
+                 msgOnFail="Permission not found for corresponding group and resource.")
     evaluate_call(lambda: db_session.delete(del_perm), fallback=lambda: db_session.rollback(), httpError=HTTPForbidden,
                   msgOnFail="Delete group resource permission refused by db", content=perm_content)
     return valid_http(httpSuccess=HTTPOk, detail="Delete group resource permission successful")

--- a/magpie/management/group/group_views.py
+++ b/magpie/management/group/group_views.py
@@ -86,7 +86,7 @@ def create_group_service_permission(request):
     group = get_group_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, service)
-    return create_group_resource_permission(perm_name, service, group.id, db_session=request.db)
+    return create_group_resource_permission(perm_name, service, group, db_session=request.db)
 
 
 @view_config(route_name='group_service_permission', request_method='DELETE')
@@ -94,7 +94,7 @@ def delete_group_service_permission(request):
     group = get_group_matchdict_checked(request)
     service = get_service_matchdict_checked(request)
     perm_name = get_permission_matchdict_checked(request, service)
-    return delete_group_resource_permission(perm_name, service, group.id, db_session=request.db)
+    return delete_group_resource_permission(perm_name, service, group, db_session=request.db)
 
 
 @view_config(route_name='group_resources', request_method='GET')
@@ -120,7 +120,7 @@ def create_group_resource_permission_view(request):
     group = get_group_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_multiformat_post_checked(request, resource)
-    return create_group_resource_permission(perm_name, resource, group.id, db_session=request.db)
+    return create_group_resource_permission(perm_name, resource, group, db_session=request.db)
 
 
 @view_config(route_name='group_resource_permission', request_method='DELETE')
@@ -128,7 +128,7 @@ def delete_group_resource_permission_view(request):
     group = get_group_matchdict_checked(request)
     resource = get_resource_matchdict_checked(request)
     perm_name = get_permission_matchdict_checked(request, resource)
-    return delete_group_resource_permission(perm_name, resource, group.id, db_session=request.db)
+    return delete_group_resource_permission(perm_name, resource, group, db_session=request.db)
 
 
 @view_config(route_name='group_service_resources', request_method='GET')

--- a/magpie/management/service/service_utils.py
+++ b/magpie/management/service/service_utils.py
@@ -23,4 +23,4 @@ def add_service_getcapabilities_perms(service, db_session, group_name=None):
         perm = ResourceService.perm_by_group_and_perm_name(service.resource_id, group.id,
                                                            u'getcapabilities', db_session)
         if perm is None:  # not set, create it
-            create_group_resource_permission(u'getcapabilities', service, group.id, db_session)
+            create_group_resource_permission(u'getcapabilities', service, group, db_session)


### PR DESCRIPTION
- fixes the recent issue found by @Renaud009 (https://crim-ca.slack.com/archives/C0Q42FF5F/p1528984613000111)
- add group service created/delete better checks to fix id access
- verify for conflicts during perm creation or not found on delete
- add more details about conflict/notfound parameters