### PR TITLE
Service API permissions

### DIFF
--- a/magpie/alembic/env.py
+++ b/magpie/alembic/env.py
@@ -1,6 +1,6 @@
 from __future__ import with_statement
 from alembic import context
-from definitions.sqlalchemy_definitions import engine_from_config, pool, create_engine
+from magpie.definitions.sqlalchemy_definitions import engine_from_config, pool, create_engine
 from logging.config import fileConfig
 from sqlalchemy.schema import MetaData
 import os

--- a/magpie/alembic/versions/2a6c63397399_separate_personal_standard_groups.py
+++ b/magpie/alembic/versions/2a6c63397399_separate_personal_standard_groups.py
@@ -15,7 +15,7 @@ sys.path.insert(0, root_dir)
 
 from alembic import op
 from alembic.context import get_context
-from definitions.sqlalchemy_definitions import *
+from magpie.definitions.sqlalchemy_definitions import *
 from magpie import models
 import register_default_group as def_grp
 

--- a/magpie/alembic/versions/438c27ec1c9_normalize_constraint_and_key_names.py
+++ b/magpie/alembic/versions/438c27ec1c9_normalize_constraint_and_key_names.py
@@ -8,13 +8,20 @@ Create Date: 2015-06-13 21:16:32.358778
 """
 from __future__ import unicode_literals
 
+import os, sys
+cur_file = os.path.abspath(__file__)
+root_dir = os.path.dirname(cur_file)    # version
+root_dir = os.path.dirname(root_dir)    # alembic
+root_dir = os.path.dirname(root_dir)    # magpie
+root_dir = os.path.dirname(root_dir)    # root
+sys.path.insert(0, root_dir)
+
+from magpie.definitions.alembic_definitions import *
+from magpie.definitions.sqlalchemy_definitions import *
+
 # revision identifiers, used by Alembic.
 revision = '438c27ec1c9'
 down_revision = '439766f6104d'
-
-from definitions.alembic import *
-from definitions.sqlalchemy_definitions import *
-
 
 # correct keys for pre 0.5.6 naming convention
 

--- a/magpie/alembic/versions/c352a98d570e_project_api_route_resource.py
+++ b/magpie/alembic/versions/c352a98d570e_project_api_route_resource.py
@@ -1,0 +1,48 @@
+"""project-api route resource
+
+Revision ID: c352a98d570e
+Revises: a395ef9d3fe6
+Create Date: 2018-06-20 13:31:55.666240
+
+"""
+import os, sys
+cur_file = os.path.abspath(__file__)
+root_dir = os.path.dirname(cur_file)    # version
+root_dir = os.path.dirname(root_dir)    # alembic
+root_dir = os.path.dirname(root_dir)    # magpie
+root_dir = os.path.dirname(root_dir)    # root
+sys.path.insert(0, root_dir)
+
+from magpie.definitions.alembic_definitions import *
+from magpie.definitions.sqlalchemy_definitions import *
+from magpie import models
+from magpie.models import *
+
+
+# revision identifiers, used by Alembic.
+revision = 'c352a98d570e'
+down_revision = 'a395ef9d3fe6'
+branch_labels = None
+depends_on = None
+
+Session = sessionmaker()
+
+def change_project_api_resource_type(new_type_name):
+    context = get_context()
+    if isinstance(context.connection.engine.dialect, PGDialect):
+        session = Session(bind=op.get_bind())
+        project_api_svc = models.Service.by_service_name('project-api', db_session=session)
+        project_api_id = project_api_svc.resource_id
+        project_api_res = session.query(models.Resource).filter(models.Resource.root_service_id == project_api_id)
+
+        for res in project_api_res:
+            res.resource_type = 'route'
+
+        session.commit()
+
+def upgrade():
+    change_project_api_resource_type('route')
+
+
+def downgrade():
+    change_project_api_resource_type('directory')

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -174,7 +174,8 @@ ziggurat_model_init(User, Group, UserGroup, GroupPermission, UserPermission,
 
 resource_tree_service = ResourceTreeService(ResourceTreeServicePostgreSQL)
 
-resource_type_dict = {u'service': Service, u'directory': Directory, u'file': File, u'workspace': Workspace}
+resource_type_dict = {u'service': Service, u'directory': Directory, u'file': File, u'workspace': Workspace,
+                      u'route': Route}
 
 
 def resource_factory(**kwargs):

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -161,6 +161,13 @@ class Workspace(Resource):
     resource_type_name = u'workspace'
 
 
+class Route(Resource):
+    __mapper_args__ = {u'polymorphic_identity': u'route'}
+    permission_names = [u'read',
+                        u'write']
+    resource_type_name = u'route'
+
+
 ziggurat_model_init(User, Group, UserGroup, GroupPermission, UserPermission,
                     UserResourcePermission, GroupResourcePermission, Resource,
                     ExternalIdentity, passwordmanager=None)

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -239,6 +239,8 @@ class ServiceAPI(ServiceI):
 
     @property
     def route_acl(self, sub_api_route=None):
+        self.expand_acl(self.service, self.request.user)
+
         route_parts = self.request.path.split('/')
         route_api_base = self.service.resource_name if sub_api_route is None else sub_api_route
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -221,8 +221,7 @@ class ServiceGeoserver(ServiceWMS):
         return self.acl
 
 
-class ServiceGeoserverAPI(ServiceI):
-
+class ServiceAPI(ServiceI):
     permission_names = models.Route.permission_names
 
     params_expected = []
@@ -232,7 +231,7 @@ class ServiceGeoserverAPI(ServiceI):
     }
 
     def __init__(self, service, request):
-        super(ServiceGeoserverAPI, self).__init__(service, request)
+        super(ServiceAPI, self).__init__(service, request)
 
     @property
     def __acl__(self):
@@ -240,7 +239,18 @@ class ServiceGeoserverAPI(ServiceI):
         return self.acl
 
     def permission_requested(self):
+        self.request
         return u'read'
+
+
+class ServiceGeoserverAPI(ServiceAPI):
+    def __init__(self, service, request):
+        super(ServiceGeoserverAPI, self).__init__(service, request)
+
+
+class ServiceProjectAPI(ServiceAPI):
+    def __init__(self, service, request):
+        super(ServiceProjectAPI, self).__init__(service, request)
 
 
 class ServiceWFS(ServiceI):
@@ -346,39 +356,15 @@ class ServiceTHREDDS(ServiceI):
     def permission_requested(self):
         return u'read'
 
-    pass
-
-
-class ServiceProjectAPI(ServiceI):
-
-    permission_names = models.Route.permission_names
-
-    params_expected = []
-
-    resource_types_permissions = {
-        models.Route.resource_type_name: models.Route.permission_names
-    }
-
-    def __init__(self, service, request):
-        super(ServiceProjectAPI, self).__init__(service, request)
-
-    @property
-    def __acl__(self):
-        self.expand_acl(self.service, self.request.user)
-        return self.acl
-
-    def permission_requested(self):
-        return u'read'
-
 
 service_type_dict = {
-    u'wps':             ServiceWPS,
-    u'ncwms':           ServiceNCWMS2,
+    u'geoserver-api':   ServiceGeoserverAPI,
     u'geoserverwms':    ServiceGeoserver,
-    u'geoserver-api':    ServiceGeoserverAPI,
-    u'wfs':             ServiceWFS,
+    u'ncwms':           ServiceNCWMS2,
+    u'project-api':     ServiceProjectAPI,
     u'thredds':         ServiceTHREDDS,
-    u'project-api':     ServiceProjectAPI
+    u'wfs':             ServiceWFS,
+    u'wps':             ServiceWPS,
 }
 
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -223,11 +223,13 @@ class ServiceGeoserver(ServiceWMS):
 
 class ServiceGeoserverAPI(ServiceI):
 
-    permission_names = []
+    permission_names = models.Route.permission_names
 
     params_expected = []
 
-    resource_types_permissions = {}
+    resource_types_permissions = {
+        models.Route.resource_type_name: models.Route.permission_names
+    }
 
     def __init__(self, service, request):
         super(ServiceGeoserverAPI, self).__init__(service, request)
@@ -349,24 +351,12 @@ class ServiceTHREDDS(ServiceI):
 
 class ServiceProjectAPI(ServiceI):
 
-    permission_names = [
-        u'read',
-        u'write'
-    ]
+    permission_names = models.Route.permission_names
 
-    params_expected = [
-        u'request'
-    ]
+    params_expected = []
 
     resource_types_permissions = {
-        models.Directory.resource_type_name: [
-            u'read',
-            u'write'
-        ],
-        models.File.resource_type_name: [
-            u'read',
-            u'write'
-        ],
+        models.Route.resource_type_name: models.Route.permission_names
     }
 
     def __init__(self, service, request):
@@ -385,6 +375,7 @@ service_type_dict = {
     u'wps':             ServiceWPS,
     u'ncwms':           ServiceNCWMS2,
     u'geoserverwms':    ServiceGeoserver,
+    u'geoserver-api':    ServiceGeoserverAPI,
     u'wfs':             ServiceWFS,
     u'thredds':         ServiceTHREDDS,
     u'project-api':     ServiceProjectAPI


### PR DESCRIPTION
## Adds
- service `project-api` route permission validation
- service `geoserver-api` route permission validation

### `project-api`

`https://colibri.crim.ca/twitcher/ows/proxy/project-api/api/Projects`
(aka `https://colibri.crim.ca/project-api/api/Projects`)

### `geoserver-api`

`https://colibri.crim.ca/twitcher/ows/proxy/geoserver-api/**`
(aka `https://colibri.crim.ca/geoserver/rest/**`)

## Requirements

- PR Ouranosinc/PAVICS#88 (providers)
- PR Ouranosinc/PAVICS#91 (geoserver security)
- PR Ouranosinc/Magpie#64 (signin)
- PR Ouranosinc/Magpie#67 (API + unittests)