### PR TITLE
service 'access'

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,9 @@ History
 * move many source files around to regroup by API/UI functionality
 * auto-generation of swagger REST API documentation
 * unit tests
+* validation of permitted resource types children under specific parent service or resource
+* ServiceAPI to filter read/write of specific GET,POST,etc on route parts
+* ServiceAccess to filter top-level route read/write access of a generic service URL
 
 0.5.x
 ---------------------

--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -3,7 +3,7 @@ General meta information on the magpie package.
 """
 
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 __author__ = "Francois-Xavier Derue, Francis Charette Migneault"
 __email__ = 'francis.charette-migneault@crim.ca'

--- a/magpie/api/management/resource/resource_formats.py
+++ b/magpie/api/management/resource/resource_formats.py
@@ -1,9 +1,7 @@
 from definitions.pyramid_definitions import *
 from models import resource_tree_service, Service
 from services import service_type_dict
-
-# import without 'from' otherwise circular import error occurs
-import api.api_except
+from api.api_except import evaluate_call
 
 
 def format_resource(resource, permissions=None, basic_info=False):

--- a/magpie/api/management/resource/resource_formats.py
+++ b/magpie/api/management/resource/resource_formats.py
@@ -2,8 +2,8 @@ from definitions.pyramid_definitions import *
 from models import resource_tree_service, Service
 from services import service_type_dict
 
-# import indirectly from magpie->api_except instead of directly 'api_except' to avoid circular imports
-from magpie import evaluate_call
+# import without 'from' otherwise circular import error occurs
+import api.api_except
 
 
 def format_resource(resource, permissions=None, basic_info=False):

--- a/magpie/api/management/resource/resource_utils.py
+++ b/magpie/api/management/resource/resource_utils.py
@@ -32,11 +32,18 @@ def check_valid_service_resource(parent_resource, resource_type, db_session):
     :param db_session:
     :return: root Service if all checks were successful
     """
+    parent_type = parent_resource.resource_type_name
+    verify_param(resource_type_dict[parent_type].child_resource_allowed, isEqual=True,
+                 paramCompare=True, httpError=HTTPNotAcceptable,
+                 msgOnFail="Child resource not allowed for specified parent resource type `{}`".format(parent_type))
     root_service = get_resource_root_service(parent_resource, db_session=db_session)
     verify_param(root_service, notNone=True, httpError=HTTPInternalServerError,
                  msgOnFail="Failed retrieving `root_service` from db")
     verify_param(root_service.resource_type, isEqual=True, httpError=HTTPInternalServerError, paramCompare=u'service',
                  msgOnFail="Invalid `root_service` retrieved from db is not a service")
+    verify_param(service_type_dict[root_service.type].child_resource_allowed, isEqual=True,
+                 paramCompare=True, httpError=HTTPNotAcceptable,
+                 msgOnFail="Child resource not allowed for specified service type `{}`".format(root_service.type))
     verify_param(resource_type, isIn=True, httpError=HTTPNotAcceptable,
                  paramCompare=service_type_dict[root_service.type].resource_types,
                  msgOnFail="Invalid `resource_type` specified for service type `{}`".format(root_service.type))

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -39,6 +39,7 @@ class Resource(ResourceMixin, Base):
 
     # example implementation of ACLS for pyramid application
     permission_names = []
+    child_resource_allowed = True
 
     # reference to top-most service under which the resource is nested
     # if the resource is the service, id is None (NULL)
@@ -139,6 +140,7 @@ class File(Resource):
                         u'getlegendgraphic',
                         u'getmetadata']
     resource_type_name = u'file'
+    child_resource_allowed = False
 
 
 class Directory(Resource):
@@ -174,8 +176,13 @@ ziggurat_model_init(User, Group, UserGroup, GroupPermission, UserPermission,
 
 resource_tree_service = ResourceTreeService(ResourceTreeServicePostgreSQL)
 
-resource_type_dict = {u'service': Service, u'directory': Directory, u'file': File, u'workspace': Workspace,
-                      u'route': Route}
+resource_type_dict = {
+    Service.resource_type_name:     Service,
+    Directory.resource_type_name:   Directory,
+    File.resource_type_name:        File,
+    Workspace.resource_type_name:   Workspace,
+    Route.resource_type_name:       Route,
+}
 
 
 def resource_factory(**kwargs):

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -222,6 +222,27 @@ class ServiceGeoserver(ServiceWMS):
         return self.acl
 
 
+class ServiceAccess(ServiceI):
+    permission_names = models.Route.permission_names
+    params_expected = []
+    resource_types_permissions = {
+        models.Route.resource_type_name: models.Route.permission_names
+    }
+
+    def __init__(self, service, request):
+        super(ServiceAccess, self).__init__(service, request)
+
+    @property
+    def __acl__(self):
+        self.expand_acl(self.service, self.request.user)
+        return self.acl
+
+    def permission_requested(self):
+        if self.request.method == 'GET':
+            return u'read'
+        return u'write'
+
+
 class ServiceAPI(ServiceI):
     permission_names = models.Route.permission_names
 
@@ -388,6 +409,7 @@ class ServiceTHREDDS(ServiceI):
 
 
 service_type_dict = {
+    u'access':          ServiceAccess,
     u'geoserver-api':   ServiceGeoserverAPI,
     u'geoserverwms':    ServiceGeoserver,
     u'ncwms':           ServiceNCWMS2,

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -229,7 +229,7 @@ class ServiceGeoserver(ServiceWMS):
 
 
 class ServiceAccess(ServiceI):
-    permission_names = models.Route.permission_names
+    permission_names = ['access']
     params_expected = []
     resource_types_permissions = {}
 
@@ -242,9 +242,7 @@ class ServiceAccess(ServiceI):
         return self.acl
 
     def permission_requested(self):
-        if self.request.method == 'GET':
-            return u'read'
-        return u'write'
+        return 'access'
 
 
 class ServiceAPI(ServiceI):

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -14,7 +14,7 @@
             % else:
                 <div class="tree_button"><input type="submit" value="Add child" name="add_child" class="button disabled" disabled></div>
             % endif
-        % elif len(resources_types) > 0:
+        % elif not service_no_child:
             <div class="tree_button"><input type="submit" value="Add child" name="add_child"></div>
         % else:
             <div class="tree_button"><input type="submit" value="Add child" name="add_child" class="button disabled" disabled></div>

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -2,6 +2,7 @@ import requests
 from definitions.pyramid_definitions import *
 from magpie import USER_NAME_MAX_LENGTH, ANONYMOUS_USER, USER_GROUP
 from services import service_type_dict
+from models import resource_type_dict
 from ui.management import check_response
 from ui.home import add_template_data
 import register
@@ -610,18 +611,15 @@ class ManagementViews(object):
                 id=raw_resources['resource_id'],
                 permission_names=[],
                 children=self.resource_tree_parser(raw_resources['resources'], {}))
-            url_resources_types = '{url}/services/types/{type}/resources/types' \
-                                  .format(url=self.magpie_url, type=cur_svc_type)
-            res_resources_types = check_response(requests.get(url_resources_types, cookies=self.request.cookies))
-            raw_resources_types = res_resources_types.json()['resource_types']
             raw_resources_id_type = self.get_resource_types()
         except Exception as e:
             raise HTTPBadRequest(detail='Bad Json response [Exception: ' + repr(e) + ']')
 
         service_info['resources'] = resources
-        service_info['resources_types'] = raw_resources_types
         service_info['resources_id_type'] = raw_resources_id_type
-        service_info['resources_no_child'] = {u'file'}
+        service_info['resources_no_child'] = [res for res in resource_type_dict
+                                              if not resource_type_dict[res].child_resource_allowed]
+        service_info['service_no_child'] = not service_type_dict[cur_svc_type].child_resource_allowed
         return add_template_data(self.request, service_info)
 
     @view_config(route_name='add_resource', renderer='templates/add_resource.mako')

--- a/providers.cfg
+++ b/providers.cfg
@@ -48,6 +48,13 @@ providers:
     c4i: false
     type: wfs
 
+  geoserver-web:
+    url: http://${HOSTNAME}:8087/geoserver/web/
+    title: geoserver-web
+    public: true
+    c4i: false
+    type: access
+
   geoserver-api:
     url: http://${HOSTNAME}:8087/geoserver/rest/
     title: geoserver-api


### PR DESCRIPTION
## changes

- `ServiceAccess` with single permission `access` to control root path URL
   (sub routes under service are all evaluated only based on the root service user access)
- service new parameter `child_resource_allowed ` to block sub-resource creation under service
