### PR TITLE
Fix assigning a user to a group in api and ui

### DIFF
--- a/magpie/api/api_rest_schemas.py
+++ b/magpie/api/api_rest_schemas.py
@@ -1325,6 +1325,18 @@ class UserGroups_POST_CreatedResponseSchema(colander.MappingSchema):
     body = UserGroups_POST_ResponseBodySchema(code=HTTPCreated.code, description=description)
 
 
+class UserGroups_POST_GroupNotFoundResponseSchema(colander.MappingSchema):
+    description = "Can't find the group to assign to."
+    header = HeaderResponseSchema()
+    body = BaseBodySchema(code=HTTPNotFound.code, description=description)
+
+
+class UserGroups_POST_ForbiddenResponseSchema(colander.MappingSchema):
+    description = "Group query by name refused by db."
+    header = HeaderResponseSchema()
+    body = BaseBodySchema(code=HTTPForbidden.code, description=description)
+
+
 class UserGroups_POST_ConflictResponseSchema(colander.MappingSchema):
     description = "User already belongs to this group."
     header = HeaderResponseSchema()

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -294,11 +294,13 @@ class ManagementViews(object):
                 selected_groups = self.request.POST.getall('member')
                 removed_groups = list(set(own_groups) - set(selected_groups))
                 new_groups = list(set(selected_groups) - set(own_groups))
-                url_group = '{url}/users/{usr}/groups/{grp}'.format(url=self.magpie_url, usr=user_name, grp='{grp}')
                 for group in removed_groups:
-                    check_response(requests.delete(url_group.format(grp=group), cookies=self.request.cookies))
+                    url_group = '{url}/users/{usr}/groups/{grp}'.format(url=self.magpie_url, usr=user_name, grp=group)
+                    check_response(requests.delete(url_group, cookies=self.request.cookies))
                 for group in new_groups:
-                    check_response(requests.post(url_group.format(grp=group), cookies=self.request.cookies))
+                    url_group = '{url}/users/{usr}/groups'.format(url=self.magpie_url, usr=user_name)
+                    data = {'group_name': group}
+                    check_response(requests.post(url_group, data=data, cookies=self.request.cookies))
                 user_info[u'own_groups'] = self.get_user_groups(user_name)
 
         # display resources permissions per service type tab
@@ -382,11 +384,13 @@ class ManagementViews(object):
         removed_members = list(set(current_members) - set(selected_members))
         new_members = list(set(selected_members) - set(current_members))
 
-        url_base = '{url}/users/{usr}/groups/{grp}'.format(url=self.magpie_url, usr='{usr}', grp=group_name)
-        for user in removed_members:
-            check_response(requests.delete(url_base.format(usr=user), cookies=self.request.cookies))
-        for user in new_members:
-            check_response(requests.post(url_base.format(usr=user), cookies=self.request.cookies))
+        for user_name in removed_members:
+            url_group = '{url}/users/{usr}/groups/{grp}'.format(url=self.magpie_url, usr=user_name, grp=group_name)
+            check_response(requests.delete(url_group, cookies=self.request.cookies))
+        for user_name in new_members:
+            url_group = '{url}/users/{usr}/groups'.format(url=self.magpie_url, usr=user_name)
+            data = {'group_name': group_name}
+            check_response(requests.post(url_group, data=data, cookies=self.request.cookies))
 
     def edit_user_or_group_resource_permissions(self, user_or_group_name, resource_id, is_user=False):
         usr_grp_type = 'users' if is_user else 'groups'

--- a/providers.cfg
+++ b/providers.cfg
@@ -21,7 +21,7 @@ providers:
     type: wps
 
   thredds:
-    url: http://${HOSTNAME}:8083/thredds
+    url: http://colibri.crim.ca:8083/thredds
     title: Thredds
     public: true
     c4i: false
@@ -42,7 +42,7 @@ providers:
     type: geoserverwms
 
   geoserver:
-    url: http://${HOSTNAME}:8087/geoserver
+    url: http://colibri.crim.ca:8087/geoserver
     title: geoserver
     public: true
     c4i: false
@@ -56,14 +56,14 @@ providers:
     type: access
 
   geoserver-api:
-    url: http://${HOSTNAME}:8087/geoserver/rest/
+    url: http://colibri.crim.ca:8087/geoserver/rest/
     title: geoserver-api
     public: true
     c4i: false
     type: geoserver-api
 
   project-api:
-    url: http://${HOSTNAME}:3005
+    url: http://hirondelle.crim.ca:3005
     title: project-api
     public: true
     c4i: false

--- a/providers.cfg
+++ b/providers.cfg
@@ -21,7 +21,7 @@ providers:
     type: wps
 
   thredds:
-    url: http://colibri.crim.ca:8083/thredds
+    url: http://${HOSTNAME}:8083/thredds
     title: Thredds
     public: true
     c4i: false
@@ -42,7 +42,7 @@ providers:
     type: geoserverwms
 
   geoserver:
-    url: http://colibri.crim.ca:8087/geoserver
+    url: http://${HOSTNAME}:8087/geoserver
     title: geoserver
     public: true
     c4i: false
@@ -56,14 +56,14 @@ providers:
     type: access
 
   geoserver-api:
-    url: http://colibri.crim.ca:8087/geoserver/rest/
+    url: http://${HOSTNAME}:8087/geoserver/rest/
     title: geoserver-api
     public: true
     c4i: false
     type: geoserver-api
 
   project-api:
-    url: http://hirondelle.crim.ca:3005
+    url: http://${HOSTNAME}:3005
     title: project-api
     public: true
     c4i: false

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -336,6 +336,30 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
 
     @pytest.mark.groups
     @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
+    def test_PostUserGroup_assign(self):
+        route = '/users/{usr}/groups'.format(usr=get_constant('MAGPIE_ADMIN_USER'))
+        data = {'group_name': get_constant('MAGPIE_ANONYMOUS_GROUP')}
+        resp = utils.test_request(self.url, 'POST', route, headers=self.json_headers, cookies=self.cookies, data=data)
+        utils.check_response_basic_info(resp, 201)
+
+    @pytest.mark.groups
+    @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
+    def test_PostUserGroup_not_found(self):
+        route = '/users/{usr}/groups'.format(usr=get_constant('MAGPIE_ADMIN_USER'))
+        data = {'group_name': 'not_found'}
+        resp = utils.test_request(self.url, 'POST', route, headers=self.json_headers, cookies=self.cookies, data=data)
+        utils.check_response_basic_info(resp, 404)
+
+    @pytest.mark.groups
+    @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
+    def test_PostUserGroup_conflict(self):
+        route = '/users/{usr}/groups'.format(usr=get_constant('MAGPIE_ADMIN_USER'))
+        data = {'group_name': get_constant('MAGPIE_ADMIN_GROUP')}
+        resp = utils.test_request(self.url, 'POST', route, headers=self.json_headers, cookies=self.cookies, data=data)
+        utils.check_response_basic_info(resp, 409)
+
+    @pytest.mark.groups
+    @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
     def test_GetGroupUsers(self):
         route = '/groups/{grp}/users'.format(grp=get_constant('MAGPIE_ADMIN_GROUP'))
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)


### PR DESCRIPTION
There was a bug in the UI and api when trying to add a user to a group in both the "edit group" view and the "edit user" view.

From the UI, the POST route was: `/users/{user_name}/groups/{group_name}`
I changed it to: `/users/{user_name}/groups` with the group_name in the post data

Also, I had to change the view of the `/users/{user_name}/groups` because it was expecting a group_name in the `matchdict`