### PR TITLE
Hide private url

### DIFF
--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -2,7 +2,7 @@
 General meta information on the magpie package.
 """
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 __author__ = "Francois-Xavier Derue, Francis Charette-Migneault"
 __maintainer__ = "Francis Charette-Migneault"
 __email__ = 'francis.charette-migneault@crim.ca'

--- a/magpie/api/api_rest_schemas.py
+++ b/magpie/api/api_rest_schemas.py
@@ -520,7 +520,7 @@ class ResourceBodySchema(colander.MappingSchema):
         default=colander.null,  # if no parent
         missing=colander.drop   # if not returned (basic_info = True)
     )
-    permission_names = PermissionListSchema()
+    permission_names = PermissionListSchema(example=['read', 'write'])
     permission_names.default = colander.null  # if no parent
     permission_names.missing = colander.drop  # if not returned (basic_info = True)
 
@@ -749,7 +749,7 @@ class Resources_POST_ConflictResponseSchema(colander.MappingSchema):
 
 
 class ResourcePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
-    permission_names = PermissionListSchema()
+    permission_names = PermissionListSchema(example=['read', 'write'])
 
 
 class ResourcePermissions_GET_OkResponseSchema(colander.MappingSchema):
@@ -1002,7 +1002,7 @@ class Service_DELETE_ForbiddenResponseSchema(colander.MappingSchema):
 
 
 class ServicePermissions_ResponseBodySchema(BaseResponseBodySchema):
-    permission_names = PermissionListSchema()
+    permission_names = PermissionListSchema(example=['read', 'write'])
 
 
 class ServicePermissions_GET_OkResponseSchema(colander.MappingSchema):
@@ -1411,7 +1411,7 @@ class UserResources_GET_NotFoundResponseSchema(colander.MappingSchema):
 
 
 class UserResourcePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
-    permission_names = PermissionListSchema()
+    permission_names = PermissionListSchema(example=['read', 'write'])
 
 
 class UserResourcePermissions_GET_OkResponseSchema(colander.MappingSchema):
@@ -1609,7 +1609,7 @@ class UserServicePermissions_GET_RequestSchema(colander.MappingSchema):
 
 
 class UserServicePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
-    permission_names = PermissionListSchema()
+    permission_names = PermissionListSchema(example=['read', 'write'])
 
 
 class UserServicePermissions_GET_OkResponseSchema(colander.MappingSchema):
@@ -1798,7 +1798,7 @@ class GroupServices_InternalServerErrorResponseSchema(colander.MappingSchema):
 
 
 class GroupServicePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
-    permission_names = PermissionListSchema()
+    permission_names = PermissionListSchema(example=['read', 'write'])
 
 
 class GroupServicePermissions_GET_OkResponseSchema(colander.MappingSchema):
@@ -1914,7 +1914,7 @@ class GroupResources_GET_InternalServerErrorResponseSchema(colander.MappingSchem
 
 
 class GroupResourcePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
-    permissions_names = PermissionListSchema()
+    permissions_names = PermissionListSchema(example=['read', 'write'])
 
 
 class GroupResourcePermissions_GET_OkResponseSchema(colander.MappingSchema):

--- a/magpie/api/management/group/group_utils.py
+++ b/magpie/api/management/group/group_utils.py
@@ -29,7 +29,8 @@ def get_group_resources(group, db_session):
             db_session=db_session,
             service_perms=svc_perms,
             resources_perms_dict=res_perm_dict,
-            display_all=False
+            display_all=False,
+            show_private_url=False,
         )
     return json_response
 
@@ -119,7 +120,7 @@ def get_group_services(resources_permissions_dict, db_session):
         svc_name = str(svc.resource_name)
         if svc_type not in grp_svc_dict:
             grp_svc_dict[svc_type] = {}
-        grp_svc_dict[svc_type][svc_name] = format_service(svc, perms)
+        grp_svc_dict[svc_type][svc_name] = format_service(svc, perms, show_private_url=False)
     return grp_svc_dict
 
 

--- a/magpie/api/management/group/group_views.py
+++ b/magpie/api/management/group/group_views.py
@@ -189,7 +189,8 @@ def get_group_service_resources_view(request):
         db_session=request.db,
         service_perms=svc_perms,
         resources_perms_dict=res_perms,
-        display_all=False
+        display_all=False,
+        show_private_url=False,
     )
     return valid_http(httpSuccess=HTTPOk, detail=GroupServiceResources_GET_OkResponseSchema.description,
                       content={u'service': svc_res_json})

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -18,7 +18,8 @@ def get_resources_view(request):
         services = get_services_by_type(svc_type, db_session=request.db)
         res_json[svc_type] = {}
         for svc in services:
-            res_json[svc_type][svc.resource_name] = format_service_resources(svc, request.db, display_all=True)
+            res_json[svc_type][svc.resource_name] = format_service_resources(
+                svc, request.db, display_all=True, show_private_url=False)
     res_json = {u'resources': res_json}
     return valid_http(httpSuccess=HTTPOk, detail=Resources_GET_OkResponseSchema.description, content=res_json)
 

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -116,7 +116,7 @@ def get_user_services(user, db_session, cascade_resources=False,
         if svc.type not in services:
             services[svc.type] = {}
         if svc.resource_name not in services[svc.type]:
-            services[svc.type][svc.resource_name] = format_service(svc, perms)
+            services[svc.type][svc.resource_name] = format_service(svc, perms, show_private_url=False)
 
     if not format_as_list:
         return services

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -162,7 +162,8 @@ def get_user_resources_runner(request, inherited_group_resources_permissions=Tru
                 db_session=db,
                 service_perms=svc_perms,
                 resources_perms_dict=res_perms_dict,
-                display_all=False
+                display_all=False,
+                show_private_url=False,
             )
         return json_res
 
@@ -381,7 +382,8 @@ def get_user_service_resource_permissions_runner(request, inherit_groups_permiss
         db_session=request.db,
         service_perms=service_perms,
         resources_perms_dict=resources_perms_dict,
-        display_all=False
+        display_all=False,
+        show_private_url=False,
     )
     return valid_http(httpSuccess=HTTPOk, detail=UserServiceResources_GET_OkResponseSchema.description,
                       content={u'service': user_svc_res_json})

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -248,7 +248,6 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
                 utils.check_val_is_in('resource_id', svc_dict)
                 utils.check_val_is_in('service_name', svc_dict)
                 utils.check_val_is_in('service_type', svc_dict)
-                utils.check_val_is_in('service_sync_type', svc_dict)
                 utils.check_val_is_in('service_url', svc_dict)
                 utils.check_val_is_in('public_url', svc_dict)
                 utils.check_val_is_in('permission_names', svc_dict)
@@ -257,22 +256,78 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
                 utils.check_val_type(svc_dict['service_name'], six.string_types)
                 utils.check_val_type(svc_dict['service_url'], six.string_types)
                 utils.check_val_type(svc_dict['service_type'], six.string_types)
-                utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
                 utils.check_val_type(svc_dict['public_url'], six.string_types)
                 utils.check_val_type(svc_dict['permission_names'], list)
                 utils.check_val_type(svc_dict['resources'], dict)
+                if LooseVersion(self.version) >= LooseVersion('0.7.0'):
+                    utils.check_val_is_in('service_sync_type', svc_dict)
+                    utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
 
     @pytest.mark.users
-    @pytest.mark.defaults
     @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('users'))
-    @unittest.skipUnless(runner.MAGPIE_TEST_DEFAULTS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('defaults'))
-    def test_ValidateDefaultGroups(self):
-        resp = utils.test_request(self.url, 'GET', '/groups', headers=self.json_headers, cookies=self.cookies)
+    def test_GetUserServices(self):
+        route = '/users/{usr}/services'.format(usr=self.usr)
+        resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
         json_body = utils.check_response_basic_info(resp, 200)
-        groups = json_body['group_names']
-        utils.check_val_is_in(get_constant('MAGPIE_ANONYMOUS_GROUP'), groups)
-        utils.check_val_is_in(get_constant('MAGPIE_USERS_GROUP'), groups)
-        utils.check_val_is_in(get_constant('MAGPIE_ADMIN_GROUP'), groups)
+        utils.check_val_is_in('services', json_body)
+        services = json_body['services']
+        utils.check_val_type(services, dict)
+        service_types = utils.get_service_types_for_version(self.version)
+        utils.check_all_equal(services.keys(), service_types, any_order=True)
+        for svc_type in services:
+            for svc in services[svc_type]:
+                svc_dict = services[svc_type][svc]
+                utils.check_val_type(svc_dict, dict)
+                utils.check_val_is_in('resource_id', svc_dict)
+                utils.check_val_is_in('service_name', svc_dict)
+                utils.check_val_is_in('service_type', svc_dict)
+                utils.check_val_is_in('public_url', svc_dict)
+                utils.check_val_is_in('permission_names', svc_dict)
+                utils.check_val_is_in('resources', svc_dict)
+                utils.check_val_type(svc_dict['resource_id'], int)
+                utils.check_val_type(svc_dict['service_name'], six.string_types)
+                utils.check_val_type(svc_dict['service_type'], six.string_types)
+                utils.check_val_type(svc_dict['public_url'], six.string_types)
+                utils.check_val_type(svc_dict['permission_names'], list)
+                utils.check_val_type(svc_dict['resources'], dict)
+                if LooseVersion(self.version) >= LooseVersion('0.7.0'):
+                    utils.check_val_is_in('service_sync_type', svc_dict)
+                    utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
+                if LooseVersion(self.version) >= LooseVersion('0.7.1'):
+                    utils.check_val_not_in('service_url', svc_dict)
+                else:
+                    utils.check_val_is_in('service_url', svc_dict)
+                    utils.check_val_type(svc_dict['service_url'], six.string_types)
+
+    @pytest.mark.users
+    @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('users'))
+    def test_GetUserServiceResources(self):
+        route = '/users/{usr}/services/{svc}/resources'.format(usr=self.usr, svc=self.test_service_name)
+        resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
+        json_body = utils.check_response_basic_info(resp, 200)
+        utils.check_val_is_in('service', json_body)
+        svc_dict = json_body['service']
+        utils.check_val_type(svc_dict, dict)
+        utils.check_val_is_in('resource_id', svc_dict)
+        utils.check_val_is_in('service_name', svc_dict)
+        utils.check_val_is_in('service_type', svc_dict)
+        utils.check_val_is_in('public_url', svc_dict)
+        utils.check_val_is_in('permission_names', svc_dict)
+        utils.check_val_is_in('resources', svc_dict)
+        utils.check_val_type(svc_dict['resource_id'], int)
+        utils.check_val_type(svc_dict['service_name'], six.string_types)
+        utils.check_val_type(svc_dict['service_type'], six.string_types)
+        utils.check_val_type(svc_dict['public_url'], six.string_types)
+        utils.check_val_type(svc_dict['permission_names'], list)
+        utils.check_val_type(svc_dict['resources'], dict)
+        if LooseVersion(self.version) >= LooseVersion('0.7.0'):
+            utils.check_val_is_in('service_sync_type', svc_dict)
+            utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
+        if LooseVersion(self.version) >= LooseVersion('0.7.1'):
+            utils.check_val_not_in('service_url', svc_dict)
+        else:
+            utils.check_val_is_in('service_url', svc_dict)
+            utils.check_val_type(svc_dict['service_url'], six.string_types)
 
     @pytest.mark.users
     @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('users'))
@@ -319,7 +374,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetUser_missing(self):
         utils.TestSetup.check_NonExistingTestUser(self)
         route = '/users/{usr}'.format(usr=self.test_user_name)
-        resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, 
+        resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers,
                                   cookies=self.cookies, expect_errors=True)
         utils.check_response_basic_info(resp, 404)
 
@@ -335,6 +390,18 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
             utils.check_val_equal(json_body['user']['user_name'], self.usr)
         else:
             utils.check_val_equal(json_body['user_name'], self.usr)
+
+    @pytest.mark.groups
+    @pytest.mark.defaults
+    @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
+    @unittest.skipUnless(runner.MAGPIE_TEST_DEFAULTS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('defaults'))
+    def test_ValidateDefaultGroups(self):
+        resp = utils.test_request(self.url, 'GET', '/groups', headers=self.json_headers, cookies=self.cookies)
+        json_body = utils.check_response_basic_info(resp, 200)
+        groups = json_body['group_names']
+        utils.check_val_is_in(get_constant('MAGPIE_ANONYMOUS_GROUP'), groups)
+        utils.check_val_is_in(get_constant('MAGPIE_USERS_GROUP'), groups)
+        utils.check_val_is_in(get_constant('MAGPIE_ADMIN_GROUP'), groups)
 
     @pytest.mark.groups
     @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
@@ -383,7 +450,6 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         utils.check_val_is_in('resource_id', svc_dict)
         utils.check_val_is_in('service_name', svc_dict)
         utils.check_val_is_in('service_type', svc_dict)
-        utils.check_val_is_in('service_sync_type', svc_dict)
         utils.check_val_is_in('service_url', svc_dict)
         utils.check_val_is_in('public_url', svc_dict)
         utils.check_val_is_in('permission_names', svc_dict)
@@ -392,10 +458,12 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         utils.check_val_type(svc_dict['service_name'], six.string_types)
         utils.check_val_type(svc_dict['service_url'], six.string_types)
         utils.check_val_type(svc_dict['service_type'], six.string_types)
-        utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
         utils.check_val_type(svc_dict['public_url'], six.string_types)
         utils.check_val_type(svc_dict['permission_names'], list)
         utils.check_resource_children(svc_dict['resources'], svc_dict['resource_id'], svc_dict['resource_id'])
+        if LooseVersion(self.version) >= LooseVersion('0.7.0'):
+            utils.check_val_is_in('service_sync_type', svc_dict)
+            utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
 
     @pytest.mark.services
     @unittest.skipUnless(runner.MAGPIE_TEST_SERVICES, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('services'))
@@ -541,6 +609,8 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         for svc in services_list_getcap:
             svc_name = svc['service_name']
             svc_type = svc['service_type']
+            if LooseVersion(self.version) >= LooseVersion('0.7.1'):
+                utils.check_val_not_in('service_url', svc, msg="Services under user routes shouldn't show private url.")
             anonymous = get_constant('MAGPIE_ANONYMOUS_USER')
             msg = "Service `{name}` of type `{type}` is expected to have `{perm}` permissions for user `{usr}`" \
                   .format(name=svc_name, type=svc_type, perm='getcapabilities', usr=anonymous)

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -438,6 +438,72 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         utils.check_val_is_in(get_constant('MAGPIE_ADMIN_USER'), json_body['user_names'])
         utils.check_val_is_in(self.usr, json_body['user_names'])
 
+    @pytest.mark.groups
+    @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
+    def test_GetGroupServices(self):
+        route = '/users/{grp}/services'.format(grp=self.grp)
+        resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
+        json_body = utils.check_response_basic_info(resp, 200)
+        utils.check_val_is_in('services', json_body)
+        services = json_body['services']
+        utils.check_val_type(services, dict)
+        service_types = utils.get_service_types_for_version(self.version)
+        utils.check_all_equal(services.keys(), service_types, any_order=True)
+        for svc_type in services:
+            for svc in services[svc_type]:
+                svc_dict = services[svc_type][svc]
+                utils.check_val_type(svc_dict, dict)
+                utils.check_val_is_in('resource_id', svc_dict)
+                utils.check_val_is_in('service_name', svc_dict)
+                utils.check_val_is_in('service_type', svc_dict)
+                utils.check_val_is_in('public_url', svc_dict)
+                utils.check_val_is_in('permission_names', svc_dict)
+                utils.check_val_is_in('resources', svc_dict)
+                utils.check_val_type(svc_dict['resource_id'], int)
+                utils.check_val_type(svc_dict['service_name'], six.string_types)
+                utils.check_val_type(svc_dict['service_type'], six.string_types)
+                utils.check_val_type(svc_dict['public_url'], six.string_types)
+                utils.check_val_type(svc_dict['permission_names'], list)
+                utils.check_val_type(svc_dict['resources'], dict)
+                if LooseVersion(self.version) >= LooseVersion('0.7.0'):
+                    utils.check_val_is_in('service_sync_type', svc_dict)
+                    utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
+                if LooseVersion(self.version) >= LooseVersion('0.7.1'):
+                    utils.check_val_not_in('service_url', svc_dict)
+                else:
+                    utils.check_val_is_in('service_url', svc_dict)
+                    utils.check_val_type(svc_dict['service_url'], six.string_types)
+
+    @pytest.mark.groups
+    @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
+    def test_GetGroupServiceResources(self):
+        route = '/groups/{grp}/services/{svc}/resources'.format(grp=self.grp, svc=self.test_service_name)
+        resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
+        json_body = utils.check_response_basic_info(resp, 200)
+        utils.check_val_is_in('service', json_body)
+        svc_dict = json_body['service']
+        utils.check_val_type(svc_dict, dict)
+        utils.check_val_is_in('resource_id', svc_dict)
+        utils.check_val_is_in('service_name', svc_dict)
+        utils.check_val_is_in('service_type', svc_dict)
+        utils.check_val_is_in('public_url', svc_dict)
+        utils.check_val_is_in('permission_names', svc_dict)
+        utils.check_val_is_in('resources', svc_dict)
+        utils.check_val_type(svc_dict['resource_id'], int)
+        utils.check_val_type(svc_dict['service_name'], six.string_types)
+        utils.check_val_type(svc_dict['service_type'], six.string_types)
+        utils.check_val_type(svc_dict['public_url'], six.string_types)
+        utils.check_val_type(svc_dict['permission_names'], list)
+        utils.check_val_type(svc_dict['resources'], dict)
+        if LooseVersion(self.version) >= LooseVersion('0.7.0'):
+            utils.check_val_is_in('service_sync_type', svc_dict)
+            utils.check_val_type(svc_dict['service_sync_type'], six.string_types)
+        if LooseVersion(self.version) >= LooseVersion('0.7.1'):
+            utils.check_val_not_in('service_url', svc_dict)
+        else:
+            utils.check_val_is_in('service_url', svc_dict)
+            utils.check_val_type(svc_dict['service_url'], six.string_types)
+
     @pytest.mark.services
     @unittest.skipUnless(runner.MAGPIE_TEST_SERVICES, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('services'))
     def test_GetServiceResources(self):


### PR DESCRIPTION
resolves #108 

Hide value `service_url` under routes `/groups/...` and `/users/...` (especially for `/users/current/...` with public access) so that service unprotected url is not available.
Value `public_url` (proxy) is still returned (the one to be used by users).
Only admins can access `service_url` under `/services` routes. 

- [ ] tag Magpie `0.7.1` when merged

