### PR TITLE
close div for browsers that won't interpret the auto-closing forward …

### DIFF
--- a/magpie/ui/management/templates/edit_group.mako
+++ b/magpie/ui/management/templates/edit_group.mako
@@ -106,7 +106,7 @@
     %endfor
 
     <div class="current_tab_panel">
-        <div class="clear"/>
+        <div class="clear"></div>
         %if error_message:
             <div class="alert danger visible">${error_message}</div>
         %endif

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -159,7 +159,7 @@
                     <div class="panel_title">Resources</div>
                 </div>
                 <div>
-                    <div class="clear"/>
+                    <div class="clear"></div>
                     <div class="tree">
                         ${tree.render_tree(render_item, resources)}
                     </div>

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -162,7 +162,7 @@
     %endfor
 
     <div class="current_tab_panel">
-        <div class="clear"/>
+        <div class="clear"></div>
         %if error_message:
             <div class="alert danger visible">${error_message}</div>
         %endif

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -41,7 +41,7 @@ li.Collapsed {
 <%def name="render_tree(item_renderer, tree, level = 0)">
     <ul>
      %for key in tree:
-        <div class="clear"/>
+         <div class="clear"></div>
         <form id="resource_${tree[key]['id']}_${tree[key].get('remote_id', '')}" action="${request.path}" method="post">
             % if tree[key]['children']:
             <li class="Expanded">


### PR DESCRIPTION
Really just a small change, but self closing divs are not correctly interpreted by browsers in the context of Magpie right now, which leads to scrambled html when looping over collections (eg each line in the permissions list html is a children of the previous list element instead of its sibbling).