### PR TITLE
Fix tests + Upgrade ziggurat

### DIFF
--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -2,7 +2,7 @@
 General meta information on the magpie package.
 """
 
-__version__ = '0.7.2'
+__version__ = '0.7.3'
 __author__ = "Francois-Xavier Derue, Francis Charette-Migneault"
 __maintainer__ = "Francis Charette-Migneault"
 __email__ = 'francis.charette-migneault@crim.ca'

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -4,11 +4,42 @@ from magpie.definitions.twitcher_definitions import *
 from magpie.adapter.magpieowssecurity import *
 from magpie.adapter.magpieservice import MagpieServiceStore
 from magpie.models import get_user
+from magpie.constants import get_constant
 from magpie.security import auth_config_from_settings
 from magpie.db import *
 from magpie import __meta__
+from six.moves.urllib.parse import urlparse
+from typing import Dict
 import logging
 logger = logging.getLogger("TWITCHER")
+
+
+def get_admin_cookies(magpie_url, verify=True):
+    # type: (str, bool) -> Dict[str,str]
+    magpie_login_url = '{}/signin'.format(magpie_url)
+    cred = {'user_name': get_constant('MAGPIE_ADMIN_USER'), 'password': get_constant('MAGPIE_ADMIN_PASSWORD')}
+    resp = requests.post(magpie_login_url, data=cred, headers='application/json', verify=verify)
+    if resp.status_code != HTTPOk.code:
+        raise resp.raise_for_status()
+    return dict(auth_tkt=resp.cookies.get('auth_tkt'))
+
+
+def get_magpie_url(registry):
+    # type: (Registry) -> str
+    try:
+        # add 'http' scheme to url if omitted from config since further 'requests' calls fail without it
+        # mostly for testing when only 'localhost' is specified
+        # otherwise twitcher config should explicitly define it in MAGPIE_URL
+        url_parsed = urlparse(registry.settings.get('magpie.url').strip('/'))
+        if url_parsed.scheme in ['http', 'https']:
+            return url_parsed.geturl()
+        else:
+            magpie_url = 'http://{}'.format(url_parsed.geturl())
+            LOGGER.warn("Missing scheme from registry url, new value: '{}'".format(magpie_url))
+            return magpie_url
+    except AttributeError:
+        # If magpie.url does not exist, calling strip fct over None will raise this issue
+        raise ConfigurationError('magpie.url config cannot be found')
 
 
 class MagpieAdapter(AdapterInterface):
@@ -29,7 +60,7 @@ class MagpieAdapter(AdapterInterface):
         return DefaultAdapter().jobstore_factory(registry)
 
     def owssecurity_factory(self, registry):
-        return MagpieOWSSecurity()
+        return MagpieOWSSecurity(registry=registry)
 
     def configurator_factory(self, settings):
         # Disable rpcinterface which is conflicting with postgres db

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger("TWITCHER")
 class MagpieOWSSecurity(OWSSecurityInterface):
 
     def __init__(self, registry):
-        super(MagpieOWSSecurity, self).__init__(registry=registry)
+        super(MagpieOWSSecurity, self).__init__()
         self.magpie_url = get_magpie_url(registry)
         self.twitcher_ssl_verify = asbool(registry.settings.get('twitcher.ows_proxy_ssl_verify', True))
         self.twitcher_protected_path = registry.settings.get('twitcher.ows_proxy_protected_path', '/ows')

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -3,7 +3,7 @@ from magpie.definitions.pyramid_definitions import *
 from magpie.services import service_factory
 from magpie.models import Service
 from magpie.api.api_except import evaluate_call, verify_param
-from magpie.adapter import get_magpie_url
+from magpie.adapter.utils import get_magpie_url
 import requests
 import logging
 LOGGER = logging.getLogger("TWITCHER")

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -3,6 +3,7 @@ from magpie.definitions.pyramid_definitions import *
 from magpie.services import service_factory
 from magpie.models import Service
 from magpie.api.api_except import evaluate_call, verify_param
+from magpie.adapter import get_magpie_url
 import requests
 import logging
 LOGGER = logging.getLogger("TWITCHER")
@@ -10,10 +11,15 @@ LOGGER = logging.getLogger("TWITCHER")
 
 class MagpieOWSSecurity(OWSSecurityInterface):
 
+    def __init__(self, registry):
+        super(MagpieOWSSecurity, self).__init__(registry=registry)
+        self.magpie_url = get_magpie_url(registry)
+        self.twitcher_ssl_verify = asbool(registry.settings.get('twitcher.ows_proxy_ssl_verify', True))
+        self.twitcher_protected_path = registry.settings.get('twitcher.ows_proxy_protected_path', '/ows')
+
     def check_request(self, request):
-        twitcher_protected_path = request.registry.settings.get('twitcher.ows_proxy_protected_path', '/ows')
-        if request.path.startswith(twitcher_protected_path):
-            service_name = parse_service_name(request.path, twitcher_protected_path)
+        if request.path.startswith(self.twitcher_protected_path):
+            service_name = parse_service_name(request.path, self.twitcher_protected_path)
             service = evaluate_call(lambda: Service.by_service_name(service_name, db_session=request.db),
                                     fallback=lambda: request.db.rollback(),
                                     httpError=HTTPForbidden, msgOnFail="Service query by name refused by db")
@@ -34,8 +40,7 @@ class MagpieOWSSecurity(OWSSecurityInterface):
                 if not has_permission:
                     raise OWSAccessForbidden("Not authorized to access this resource.")
 
-    @staticmethod
-    def update_request_cookies(request):
+    def update_request_cookies(self, request):
         """
         Ensure login of the user and update the request cookies if twitcher is in a special configuration.
         Only update if Magpie `auth_tkt` is missing and can be retrieved from `access_token` in `Authorization` header.
@@ -43,14 +48,13 @@ class MagpieOWSSecurity(OWSSecurityInterface):
         """
         not_default = get_twitcher_configuration(request.registry.settings) != TWITCHER_CONFIGURATION_DEFAULT
         if not_default and 'Authorization' in request.headers and 'auth_tkt' not in request.cookies:
-            ssl_verify = asbool(request.registry.settings.get('twitcher.ows_proxy_ssl_verify', True))
             magpie_url = request.registry.settings.get('magpie.url')
             magpie_prov = request.params.get('provider', 'WSO2')
             magpie_auth = '{host}/providers/{provider}/signin'.format(host=magpie_url, provider=magpie_prov)
             headers = request.headers
             headers['Homepage-Route'] = '/session'
             headers['Accept'] = 'application/json'
-            auth_resp = requests.get(magpie_auth, headers=headers, verify=ssl_verify)
+            auth_resp = requests.get(magpie_auth, headers=headers, verify=self.twitcher_ssl_verify)
             if auth_resp.status_code != HTTPOk.code:
                 raise auth_resp.raise_for_status()
             if not auth_resp.json().get('authenticated') or 'auth_tkt' not in auth_resp.request._cookies:

--- a/magpie/adapter/magpieservice.py
+++ b/magpie/adapter/magpieservice.py
@@ -4,7 +4,7 @@ Store adapters to read data from magpie.
 
 from magpie.definitions.twitcher_definitions import *
 from magpie.definitions.pyramid_definitions import HTTPOk, asbool
-from magpie.adapter import get_admin_cookies, get_magpie_url
+from magpie.adapter.utils import get_admin_cookies, get_magpie_url
 import requests
 import logging
 LOGGER = logging.getLogger("TWITCHER")

--- a/magpie/adapter/magpieservice.py
+++ b/magpie/adapter/magpieservice.py
@@ -2,14 +2,12 @@
 Store adapters to read data from magpie.
 """
 
-from six.moves.urllib.parse import urlparse
-import logging
-import requests
-import json
-LOGGER = logging.getLogger("TWITCHER")
-
 from magpie.definitions.twitcher_definitions import *
-from magpie.definitions.pyramid_definitions import ConfigurationError, HTTPOk
+from magpie.definitions.pyramid_definitions import HTTPOk, asbool
+from magpie.adapter import get_admin_cookies, get_magpie_url
+import requests
+import logging
+LOGGER = logging.getLogger("TWITCHER")
 
 
 class MagpieServiceStore(ServiceStore):
@@ -17,19 +15,9 @@ class MagpieServiceStore(ServiceStore):
     Registry for OWS services. Uses magpie to fetch service url and attributes.
     """
     def __init__(self, registry):
-        try:
-            # add 'http' scheme to url if omitted from config since further 'requests' calls fail without it
-            # mostly for testing when only 'localhost' is specified
-            # otherwise twitcher config should explicitly define it in MAGPIE_URL
-            url_parsed = urlparse(registry.settings.get('magpie.url').strip('/'))
-            if url_parsed.scheme in ['http', 'https']:
-                self.magpie_url = url_parsed.geturl()
-            else:
-                self.magpie_url = 'http://{}'.format(url_parsed.geturl())
-                LOGGER.warn("Missing scheme from MagpieServiceStore url, new value: '{}'".format(self.magpie_url))
-        except AttributeError:
-            #If magpie.url does not exist, calling strip fct over None will raise this issue
-            raise ConfigurationError('magpie.url config cannot be found')
+        self.magpie_url = get_magpie_url(registry)
+        self.twitcher_ssl_verify = asbool(registry.settings.get('twitcher.ows_proxy_ssl_verify', True))
+        self.magpie_admin_token = get_admin_cookies(self.magpie_url, self.twitcher_ssl_verify)
 
     def save_service(self, service, overwrite=True, request=None):
         """
@@ -47,19 +35,19 @@ class MagpieServiceStore(ServiceStore):
         """
         Lists all services registered in magpie.
         """
-        my_services = []
-        path = '/users/current/services?inherit=True&cascade=True'
-        response = requests.get('{url}{path}'.format(url=self.magpie_url, path=path),
-                                cookies=request.cookies)
-        if response.status_code != HTTPOk.code:
-            raise response.raise_for_status()
-        services = json.loads(response.text)
-        for service_type in services['services']:
-            for key, service in services['services'][service_type].items():
-                my_services.append(Service(url=service['service_url'],
-                                           name=service['service_name'],
-                                           type=service['service_type']))
-        return my_services
+        # obtain admin access since 'service_url' is only provided on admin routes
+        services = []
+        path = '{}/services'.format(self.magpie_url)
+        resp = requests.get(path, cookies=self.magpie_admin_token, headers={'Accept': 'application/json'})
+        if resp.status_code != HTTPOk.code:
+            raise resp.raise_for_status()
+        json_body = resp.json()
+        for service_type in json_body['services']:
+            for key, service in json_body['services'][service_type].items():
+                services.append(Service(url=service['service_url'],
+                                        name=service['service_name'],
+                                        type=service['service_type']))
+        return services
 
     def fetch_by_name(self, name, request=None):
         """

--- a/magpie/adapter/utils.py
+++ b/magpie/adapter/utils.py
@@ -11,7 +11,7 @@ def get_admin_cookies(magpie_url, verify=True):
     # type: (str, bool) -> Dict[str,str]
     magpie_login_url = '{}/signin'.format(magpie_url)
     cred = {'user_name': get_constant('MAGPIE_ADMIN_USER'), 'password': get_constant('MAGPIE_ADMIN_PASSWORD')}
-    resp = requests.post(magpie_login_url, data=cred, headers='application/json', verify=verify)
+    resp = requests.post(magpie_login_url, data=cred, headers={'Accept': 'application/json'}, verify=verify)
     if resp.status_code != HTTPOk.code:
         raise resp.raise_for_status()
     return dict(auth_tkt=resp.cookies.get('auth_tkt'))

--- a/magpie/adapter/utils.py
+++ b/magpie/adapter/utils.py
@@ -1,0 +1,35 @@
+from magpie.constants import get_constant
+from magpie.definitions.pyramid_definitions import HTTPOk, ConfigurationError, Registry
+from six.moves.urllib.parse import urlparse
+from typing import Dict
+import requests
+import logging
+LOGGER = logging.getLogger("TWITCHER")
+
+
+def get_admin_cookies(magpie_url, verify=True):
+    # type: (str, bool) -> Dict[str,str]
+    magpie_login_url = '{}/signin'.format(magpie_url)
+    cred = {'user_name': get_constant('MAGPIE_ADMIN_USER'), 'password': get_constant('MAGPIE_ADMIN_PASSWORD')}
+    resp = requests.post(magpie_login_url, data=cred, headers='application/json', verify=verify)
+    if resp.status_code != HTTPOk.code:
+        raise resp.raise_for_status()
+    return dict(auth_tkt=resp.cookies.get('auth_tkt'))
+
+
+def get_magpie_url(registry):
+    # type: (Registry) -> str
+    try:
+        # add 'http' scheme to url if omitted from config since further 'requests' calls fail without it
+        # mostly for testing when only 'localhost' is specified
+        # otherwise twitcher config should explicitly define it in MAGPIE_URL
+        url_parsed = urlparse(registry.settings.get('magpie.url').strip('/'))
+        if url_parsed.scheme in ['http', 'https']:
+            return url_parsed.geturl()
+        else:
+            magpie_url = 'http://{}'.format(url_parsed.geturl())
+            LOGGER.warn("Missing scheme from registry url, new value: '{}'".format(magpie_url))
+            return magpie_url
+    except AttributeError:
+        # If magpie.url does not exist, calling strip fct over None will raise this issue
+        raise ConfigurationError('magpie.url config cannot be found')

--- a/magpie/api/api_rest_schemas.py
+++ b/magpie/api/api_rest_schemas.py
@@ -1381,19 +1381,39 @@ class UserGroups_POST_CreatedResponseSchema(colander.MappingSchema):
 class UserGroups_POST_GroupNotFoundResponseSchema(colander.MappingSchema):
     description = "Can't find the group to assign to."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotFound.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
 class UserGroups_POST_ForbiddenResponseSchema(colander.MappingSchema):
     description = "Group query by name refused by db."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPForbidden.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
+
+
+class UserGroups_POST_RelationshipForbiddenResponseSchema(colander.MappingSchema):
+    description = "User-Group relationship creation refused by db."
+    header = HeaderResponseSchema()
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
+
+
+class UserGroups_POST_ConflictResponseBodySchema(ErrorResponseBodySchema):
+    param = ErrorVerifyParamBodySchema()
+    user_name = colander.SchemaNode(
+        colander.String(),
+        description="Name of the user in the user-group relationship",
+        example="toto",
+    )
+    group_name = colander.SchemaNode(
+        colander.String(),
+        description="Name of the group in the user-group relationship",
+        example="users",
+    )
 
 
 class UserGroups_POST_ConflictResponseSchema(colander.MappingSchema):
     description = "User already belongs to this group."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPConflict.code, description=description)
+    body = UserGroups_POST_ConflictResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
 class UserGroup_DELETE_RequestSchema(colander.MappingSchema):
@@ -1410,7 +1430,7 @@ class UserGroup_DELETE_OkResponseSchema(colander.MappingSchema):
 class UserGroup_DELETE_NotFoundResponseSchema(colander.MappingSchema):
     description = "Invalid user-group combination for delete."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotFound.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
 class UserResources_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -1479,7 +1499,7 @@ class UserResourcePermissions_GET_NotAcceptableResourceTypeResponseSchema(coland
 class UserResourcePermissions_GET_NotFoundResponseSchema(colander.MappingSchema):
     description = "Specified user not found to obtain resource permissions."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotFound.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
 class UserResourcePermissions_POST_RequestBodySchema(colander.MappingSchema):
@@ -1645,31 +1665,31 @@ class UserServicePermissions_GET_OkResponseSchema(colander.MappingSchema):
 class UserServicePermissions_GET_NotFoundResponseSchema(colander.MappingSchema):
     description = "Could not find permissions using specified `service_name` and `user_name`."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotFound.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
 class Group_MatchDictCheck_ForbiddenResponseSchema(colander.MappingSchema):
     description = "Group query by name refused by db."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPForbidden.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
 class Group_MatchDictCheck_NotFoundResponseSchema(colander.MappingSchema):
     description = "Group name not found in db."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotFound.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
 class Groups_CheckInfo_NotFoundResponseSchema(colander.MappingSchema):
     description = "User name not found in db."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotFound.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
 class Groups_CheckInfo_ForbiddenResponseSchema(colander.MappingSchema):
     description = "Failed to obtain groups of user."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPForbidden.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
 class Groups_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -1685,7 +1705,7 @@ class Groups_GET_OkResponseSchema(colander.MappingSchema):
 class Groups_GET_ForbiddenResponseSchema(colander.MappingSchema):
     description = "Obtain group names refused by db."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPForbidden.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
 class Groups_POST_RequestSchema(colander.MappingSchema):
@@ -1717,7 +1737,7 @@ class Groups_POST_ForbiddenAddResponseSchema(colander.MappingSchema):
 class Groups_POST_ConflictResponseSchema(colander.MappingSchema):
     description = "Group name matches an already existing group name."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPConflict.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
 class Group_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -1733,7 +1753,7 @@ class Group_GET_OkResponseSchema(colander.MappingSchema):
 class Group_GET_NotFoundResponseSchema(colander.MappingSchema):
     description = "Group name was not found."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotFound.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
 class Group_PUT_RequestSchema(colander.MappingSchema):
@@ -1749,26 +1769,26 @@ class Group_PUT_OkResponseSchema(colander.MappingSchema):
 class Group_PUT_Name_NotAcceptableResponseSchema(colander.MappingSchema):
     description = "Invalid `group_name` value specified."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotAcceptable.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotAcceptable.code, description=description)
 
 
 class Group_PUT_Size_NotAcceptableResponseSchema(colander.MappingSchema):
     description = "Invalid `group_name` length specified (>{length} characters)." \
         .format(length=MAGPIE_USER_NAME_MAX_LENGTH)
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotAcceptable.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotAcceptable.code, description=description)
 
 
 class Group_PUT_Same_NotAcceptableResponseSchema(colander.MappingSchema):
     description = "Invalid `group_name` must be different than current name."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPNotAcceptable.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPNotAcceptable.code, description=description)
 
 
 class Group_PUT_ConflictResponseSchema(colander.MappingSchema):
     description = "Group name already exists."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPConflict.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
 class Group_DELETE_RequestSchema(colander.MappingSchema):
@@ -1785,7 +1805,7 @@ class Group_DELETE_OkResponseSchema(colander.MappingSchema):
 class Group_DELETE_ForbiddenResponseSchema(colander.MappingSchema):
     description = "Delete group forbidden by db."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPOk.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
 class GroupUsers_GET_OkResponseSchema(colander.MappingSchema):
@@ -1797,7 +1817,7 @@ class GroupUsers_GET_OkResponseSchema(colander.MappingSchema):
 class GroupUsers_GET_ForbiddenResponseSchema(colander.MappingSchema):
     description = "Failed to obtain group user names from db."
     header = HeaderResponseSchema()
-    body = BaseResponseBodySchema(code=HTTPForbidden.code, description=description)
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
 class GroupServices_GET_ResponseBodySchema(BaseResponseBodySchema):

--- a/magpie/api/api_rest_schemas.py
+++ b/magpie/api/api_rest_schemas.py
@@ -1708,8 +1708,13 @@ class Groups_GET_ForbiddenResponseSchema(colander.MappingSchema):
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
-class Groups_POST_RequestSchema(colander.MappingSchema):
+class Groups_POST_RequestBodySchema(colander.MappingSchema):
     group_name = colander.SchemaNode(colander.String(), description="Name of the group to create.")
+
+
+class Groups_POST_RequestSchema(colander.MappingSchema):
+    header = HeaderRequestSchema()
+    body = Groups_POST_RequestBodySchema()
 
 
 class Groups_POST_ResponseBodySchema(BaseResponseBodySchema):

--- a/magpie/api/login/login.py
+++ b/magpie/api/login/login.py
@@ -52,9 +52,9 @@ def sign_in(request):
     verify_provider(provider_name)
 
     if provider_name in MAGPIE_INTERNAL_PROVIDERS.keys():
-        signin_internal_url = '{host}{path}'.format(host=request.application_url, path='/signin_internal')
+        signin_internal_url = request.route_url('ziggurat.routes.sign_in')
         signin_internal_data = {u'user_name': user_name, u'password': password, u'provider_name': provider_name}
-        signin_response = requests.post(signin_internal_url, data=signin_internal_data, allow_redirects=True)
+        signin_response = requests.post(signin_internal_url, data=signin_internal_data, allow_redirects=True, verify=False)
 
         if signin_response.status_code == HTTPOk.code:
             pyramid_response = Response(body=signin_response.content, headers=signin_response.headers)

--- a/magpie/api/management/group/group_utils.py
+++ b/magpie/api/management/group/group_utils.py
@@ -61,7 +61,8 @@ def create_group_resource_permission(permission_name, resource, group, db_sessio
 
 def get_group_resources_permissions_dict(group, db_session, resource_ids=None, resource_types=None):
     def get_grp_res_perm(grp, db, res_ids, res_types):
-        res_perms_tup = grp.resources_with_possible_perms(resource_ids=res_ids, resource_types=res_types, db_session=db)
+        res_perms_tup = GroupService.resources_with_possible_perms(
+            grp, resource_ids=res_ids, resource_types=res_types, db_session=db)
         res_perms_dict = {}
         for res_perm in res_perms_tup:
             if res_perm.resource.resource_id not in res_perms_dict:
@@ -115,7 +116,7 @@ def delete_group_resource_permission(permission_name, resource, group, db_sessio
 def get_group_services(resources_permissions_dict, db_session):
     grp_svc_dict = {}
     for res_id, perms in resources_permissions_dict.items():
-        svc = models.Service.by_resource_id(resource_id=res_id, db_session=db_session)
+        svc = ResourceService.by_resource_id(resource_id=res_id, db_session=db_session)
         svc_type = str(svc.type)
         svc_name = str(svc.resource_name)
         if svc_type not in grp_svc_dict:
@@ -146,7 +147,7 @@ def get_group_services_permissions(group, db_session, resource_ids=None):
                                                          db_session=db_ses, resource_ids=res_ids)
         grp_svc_perms = []
         for res_id, res_perm in res_perms.items():
-            svc = models.Service.by_resource_id(res_id, db_session=db_ses)
+            svc = ResourceService.by_resource_id(res_id, db_session=db_ses)
             grp_svc_perms.append((svc, res_perm))
         return grp_svc_perms
 

--- a/magpie/api/management/group/group_views.py
+++ b/magpie/api/management/group/group_views.py
@@ -54,7 +54,7 @@ def edit_group(request):
                  msgOnFail=Group_PUT_Size_NotAcceptableResponseSchema.description)
     verify_param(new_group_name, notEqual=True, httpError=HTTPNotAcceptable,
                  paramCompare=group.group_name, msgOnFail=Group_PUT_Same_NotAcceptableResponseSchema.description)
-    verify_param(models.Group.by_group_name(new_group_name, db_session=request.db), isNone=True, httpError=HTTPConflict,
+    verify_param(GroupService.by_group_name(new_group_name, db_session=request.db), isNone=True, httpError=HTTPConflict,
                  msgOnFail=Group_PUT_ConflictResponseSchema.description)
     group.group_name = new_group_name
     return valid_http(httpSuccess=HTTPOk, detail=Group_PUT_OkResponseSchema.description)

--- a/magpie/api/management/resource/resource_formats.py
+++ b/magpie/api/management/resource/resource_formats.py
@@ -1,5 +1,6 @@
 from magpie.definitions.pyramid_definitions import *
-from magpie.models import resource_tree_service, Service
+from magpie.definitions.ziggurat_definitions import ResourceService
+from magpie.models import resource_tree_service
 from magpie.services import service_type_dict
 from magpie.api.api_except import evaluate_call
 
@@ -70,7 +71,7 @@ def format_resource_tree(children, db_session, resources_perms_dict=None, intern
             else:
                 service_id = resource.root_service_id
                 if service_id not in internal_svc_res_perm_dict:
-                    service = Service.by_resource_id(service_id, db_session=db_session)
+                    service = ResourceService.by_resource_id(service_id, db_session=db_session)
                     internal_svc_res_perm_dict[service_id] = service_type_dict[service.type].resource_types_permissions
 
             perms = internal_svc_res_perm_dict[service_id][resource.resource_type]

--- a/magpie/api/management/resource/resource_utils.py
+++ b/magpie/api/management/resource/resource_utils.py
@@ -2,9 +2,7 @@ from magpie.common import str2bool
 from magpie.models import resource_factory, resource_type_dict, resource_tree_service
 from magpie.services import service_type_dict
 from magpie.register import sync_services_phoenix
-from magpie.definitions.pyramid_definitions import *
 from magpie.definitions.ziggurat_definitions import *
-from magpie.api.api_rest_schemas import *
 from magpie.api.api_requests import *
 from magpie.api.api_except import verify_param, evaluate_call, raise_http, valid_http
 from magpie.api.management.resource.resource_formats import format_resource
@@ -98,7 +96,7 @@ def get_resource_permissions(resource, db_session):
         return service_type_dict[service.type].permission_names
 
     # otherwise obtain root level service to infer sub-resource permissions
-    service = models.Service.by_resource_id(resource.root_service_id, db_session=db_session)
+    service = ResourceService.by_resource_id(resource.root_service_id, db_session=db_session)
     verify_param(service.resource_type, isEqual=True, httpError=HTTPNotAcceptable,
                  paramName=u'resource_type', paramCompare=u'service',
                  msgOnFail=UserResourcePermissions_GET_NotAcceptableRootServiceResponseSchema.description)

--- a/magpie/api/management/service/service_formats.py
+++ b/magpie/api/management/service/service_formats.py
@@ -10,7 +10,6 @@ def format_service(service, permissions=None, show_private_url=False):
     def fmt_svc(svc, perms):
         svc_info = {
             u'public_url': str(get_twitcher_protected_service_url(svc.resource_name)),
-            u'service_url': str(svc.url),
             u'service_name': str(svc.resource_name),
             u'service_type': str(svc.type),
             u'service_sync_type': svc.sync_type,

--- a/magpie/api/management/service/service_views.py
+++ b/magpie/api/management/service/service_views.py
@@ -39,7 +39,7 @@ def get_services_runner(request):
         services = get_services_by_type(service_type, db_session=request.db)
         json_response[service_type] = {}
         for service in services:
-            json_response[service_type][service.resource_name] = format_service(service, show_private_url=False)
+            json_response[service_type][service.resource_name] = format_service(service, show_private_url=True)
 
     return valid_http(httpSuccess=HTTPOk, detail=Services_GET_OkResponseSchema.description,
                       content={u'services': json_response})

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -109,9 +109,9 @@ def get_user_services(user, db_session, cascade_resources=False,
 
     services = {}
     for resource_id, perms in res_perm_dict.items():
-        svc = models.Service.by_resource_id(resource_id=resource_id, db_session=db_session)
+        svc = ResourceService.by_resource_id(resource_id=resource_id, db_session=db_session)
         if svc.resource_type != 'service' and cascade_resources:
-            svc = models.Service.by_resource_id(resource_id=svc.root_service_id, db_session=db_session)
+            svc = ResourceService.by_resource_id(resource_id=svc.root_service_id, db_session=db_session)
             perms = service_type_dict[svc.type].permission_names
         if svc.type not in services:
             services[svc.type] = {}
@@ -132,7 +132,7 @@ def get_user_service_permissions(user, service, db_session, inherit_groups_permi
     if service.owner_user_id == user.id:
         permission_names = service_type_dict[service.type].permission_names
     else:
-        svc_perm_tuple_list = service.perms_for_user(user, db_session=db_session)
+        svc_perm_tuple_list = ResourceService.perms_for_user(service, user, db_session=db_session)
         if not inherit_groups_permissions:
             svc_perm_tuple_list = filter_user_permission(svc_perm_tuple_list, user)
         permission_names = [permission.perm_name for permission in svc_perm_tuple_list]
@@ -155,8 +155,8 @@ def get_user_resources_permissions_dict(user, db_session, resource_types=None,
     """
     verify_param(user, notNone=True, httpError=HTTPNotFound,
                  msgOnFail=UserResourcePermissions_GET_NotFoundResponseSchema.description)
-    res_perm_tuple_list = user.resources_with_possible_perms(resource_ids=resource_ids,
-                                                             resource_types=resource_types, db_session=db_session)
+    res_perm_tuple_list = UserService.resources_with_possible_perms(
+        user, resource_ids=resource_ids,resource_types=resource_types, db_session=db_session)
     if not inherit_groups_permissions:
         res_perm_tuple_list = filter_user_permission(res_perm_tuple_list, user)
     resources_permissions_dict = {}

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -78,8 +78,7 @@ def get_user_view(request):
 def delete_user(request):
     """Delete a user by name."""
     user = get_user_matchdict_checked_or_logged(request)
-    db = request.db
-    evaluate_call(lambda: db.delete(user), fallback=lambda: db.rollback(),
+    evaluate_call(lambda: request.db.delete(user), fallback=lambda: request.db.rollback(),
                   httpError=HTTPForbidden, msgOnFail=User_DELETE_ForbiddenResponseSchema.description)
     return valid_http(httpSuccess=HTTPOk, detail=User_DELETE_OkResponseSchema.description)
 
@@ -301,7 +300,8 @@ def get_user_inherited_services_view(request):
 @LoggedUserServiceInheritedPermissionsAPI.get(schema=UserServicePermissions_GET_RequestSchema,
                                               tags=[LoggedUserTag], api_security=SecurityEveryoneAPI,
                                               response_schemas=LoggedUserServicePermissions_GET_responses)
-@view_config(route_name=UserServiceInheritedPermissionsAPI.name, request_method='GET', permission=NO_PERMISSION_REQUIRED)
+@view_config(route_name=UserServiceInheritedPermissionsAPI.name, request_method='GET',
+             permission=NO_PERMISSION_REQUIRED)
 def get_user_service_inherited_permissions_view(request):
     """List all permissions a user has on a service using all his inherited user and groups permissions."""
     LOGGER.warn("Route deprecated: [{0}], Instead Use: [{1}]"

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -80,6 +80,7 @@ def get_db_session_from_config_ini(config_ini_path, ini_main_section_name='app:m
 
 def get_settings_from_config_ini(config_ini_path, ini_main_section_name='app:magpie_app'):
     parser = configparser.ConfigParser()
+    parser.optionxform = lambda option: option  # preserve case of config (ziggurat requires it for 'User' model)
     parser.read([config_ini_path])
     settings = dict(parser.items(ini_main_section_name))
     return settings

--- a/magpie/definitions/pyramid_definitions.py
+++ b/magpie/definitions/pyramid_definitions.py
@@ -19,6 +19,7 @@ from pyramid.httpexceptions import (
     HTTPInternalServerError,
 )
 from pyramid.settings import asbool
+from pyramid.registry import Registry
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
 from pyramid.response import Response, FileResponse
 from pyramid.view import (

--- a/magpie/definitions/pyramid_definitions.py
+++ b/magpie/definitions/pyramid_definitions.py
@@ -7,6 +7,7 @@ from pyramid.httpexceptions import (
     HTTPCreated,
     HTTPFound,
     HTTPTemporaryRedirect,
+    HTTPMovedPermanently,
     HTTPBadRequest,
     HTTPUnauthorized,
     HTTPForbidden,

--- a/magpie/helpers/register_default_users.py
+++ b/magpie/helpers/register_default_users.py
@@ -12,17 +12,17 @@ def register_user_with_group(user_name, group_name, email, password, db_session)
     if not GroupService.by_group_name(group_name, db_session=db_session):
         new_group = models.Group(group_name=group_name)
         db_session.add(new_group)
-    registered_group = models.Group.by_group_name(group_name=group_name, db_session=db_session)
+    registered_group = GroupService.by_group_name(group_name=group_name, db_session=db_session)
 
     registered_user = UserService.by_user_name(user_name, db_session=db_session)
     if not registered_user:
         new_user = models.User(user_name=user_name, email=email)
-        new_user.set_password(password)
-        new_user.regenerate_security_code()
+        UserService.set_password(new_user, password)
+        UserService.regenerate_security_code(new_user)
         db_session.add(new_user)
         registered_user = UserService.by_user_name(user_name, db_session=db_session)
     else:
-        print_log(user_name+' already exist', level=logging.DEBUG)
+        print_log('User `{}` already exist'.format(user_name), level=logging.DEBUG)
 
     try:
         # ensure the reference between user/group exists (user joined the group)

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -85,7 +85,8 @@ class RootFactory(object):
     def __init__(self, request):
         self.__acl__ = []
         if request.user:
-            for outcome, perm_user, perm_name in permission_to_pyramid_acls(request.user.permissions):
+            permissions = UserService.permissions(request.user, request.db)
+            for outcome, perm_user, perm_name in permission_to_pyramid_acls(permissions):
                 self.__acl__.append((outcome, perm_user, perm_name))
 
 

--- a/magpie/owsrequest.py
+++ b/magpie/owsrequest.py
@@ -5,19 +5,42 @@ The OWSRequest is based on pywps code:
 * https://github.com/geopython/pywps/blob/master/pywps/app/WPSRequest.py
 """
 
+from magpie.api.api_except import raise_http
+from pyramid.httpexceptions import HTTPMethodNotAllowed
+from requests import Request
 import lxml.etree
-from pyramid.httpexceptions import HTTPBadRequest
+import json
 import logging
 logger = logging.getLogger(__name__)
 
 
 def ows_parser_factory(request):
-    if request.method == 'GET':
-        return Get(request)
-    elif request.method == 'POST':
-        return Post(request)
+    # type: (Request) -> OWSParser
+    """
+    Retrieve the appropriate OWS Request parser using the Content-Type header.
+    Default to JSON if no Content-Type is specified or if it is 'text/plain' but can be parsed as JSON.
+    Otherwise, use the GET/POST WPS parsers.
+    """
+    content_type = request.headers.get('Content-Type', 'application/json')
+    if content_type == 'text/plain':
+        try:
+            if request.body:
+                # raises if parsing fails
+                json.loads(request.body)
+            content_type = 'application/json'
+        except ValueError:
+            pass
+    if content_type == 'application/json':
+        return JSONParser(request)
     else:
-        raise HTTPBadRequest()
+        if request.method == 'GET':
+            return WPSGet(request)
+        elif request.method == 'POST':
+            return WPSPost(request)
+
+    # method not supported, raise using the specified content type header
+    raise_http(httpError=HTTPMethodNotAllowed, contentType=content_type,
+               detail="Method not implemented by Magpie OWSParser.")
 
 
 class OWSParser(object):
@@ -35,17 +58,16 @@ class OWSParser(object):
         raise NotImplementedError
 
 
-class Get(OWSParser):
+class WPSGet(OWSParser):
 
     def _request_params(self):
         new_params = {}
         for param in self.request.params:
-            # new_params[param.lower()] = self.request.params.getone(param)
             new_params[param.lower()] = self.request.params[param].lower()
         return new_params
 
     def __init__(self, request):
-        super(Get, self).__init__(request)
+        super(WPSGet, self).__init__(request)
         self.all_params = self._request_params()
 
     def _get_param_value(self, param):
@@ -65,10 +87,10 @@ def lxml_strip_ns(tree):
             node.tag = node.tag.split('}', 1)[1]
 
 
-class Post(OWSParser):
+class WPSPost(OWSParser):
 
     def __init__(self, request):
-        super(Post, self).__init__(request)
+        super(WPSPost, self).__init__(request)
         try:
             self.document = lxml.etree.fromstring(self.request.body)
             lxml_strip_ns(self.document)
@@ -82,3 +104,9 @@ class Post(OWSParser):
             return self.document.tag.lower()
         else:
             return None
+
+
+class JSONParser(OWSParser):
+    def _get_param_value(self, param):
+        param = param or ''  # in case None
+        return self.params.get(param.lower(), '').lower()

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -2,6 +2,7 @@ from magpie.services import service_type_dict
 from magpie.common import make_dirs, print_log, raise_log, bool2str
 from magpie.constants import get_constant
 from magpie import models
+from magpie.definitions.ziggurat_definitions import UserService, UserResourcePermissionService
 import os
 import time
 import yaml
@@ -355,7 +356,7 @@ def magpie_register_services_with_db_session(services_dict, db_session, push_to_
                                              force_update=False, update_getcapabilities_permissions=False):
     existing_services_names = [n[0] for n in db_session.query(models.Service.resource_name)]
     magpie_anonymous_user = get_constant('MAGPIE_ANONYMOUS_USER')
-    anonymous_user = models.User.by_user_name(magpie_anonymous_user, db_session=db_session)
+    anonymous_user = UserService.by_user_name(magpie_anonymous_user, db_session=db_session)
 
     for svc_name, svc_values in services_dict.items():
         svc_new_url = os.path.expandvars(svc_values['url'])
@@ -386,7 +387,7 @@ def magpie_register_services_with_db_session(services_dict, db_session, push_to_
             print_log("Cannot update 'getcapabilities' permission of non existing anonymous user", level=logging.WARN)
         elif update_getcapabilities_permissions and 'getcapabilities' in service_type_dict[svc_type].permission_names:
             svc = db_session.query(models.Service.resource_id).filter_by(resource_name=svc_name).first()
-            svc_perm_getcapabilities = models.UserResourcePermissionService.by_resource_user_and_perm(
+            svc_perm_getcapabilities = UserResourcePermissionService.by_resource_user_and_perm(
                 user_id=anonymous_user.id, perm_name='getcapabilities',
                 resource_id=svc.resource_id, db_session=db_session
             )

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -39,7 +39,7 @@ class ServiceI(object):
             # Custom acl
 
             if user:
-                permissions = resource.perms_for_user(user)
+                permissions = ResourceService.perms_for_user(resource, user, db_session=self.request.db)
                 for outcome, perm_user, perm_name in permission_to_pyramid_acls(permissions):
                     self.acl.append((outcome, perm_user, perm_name,))
             else:
@@ -47,7 +47,7 @@ class ServiceI(object):
                 if user is None:
                     raise Exception('No Anonymous user in the database')
                 else:
-                    permissions = resource.perms_for_user(user)
+                    permissions = ResourceService.perms_for_user(resource, user, db_session=self.request.db)
                     for outcome, perm_user, perm_name in permission_to_pyramid_acls(permissions):
                         self.acl.append((outcome, EVERYONE, perm_name,))
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -2,14 +2,18 @@ from magpie.constants import get_constant
 from magpie.definitions.ziggurat_definitions import *
 from magpie.definitions.pyramid_definitions import EVERYONE, ALLOW
 from magpie.api.api_except import *
+from magpie.owsrequest import *
 from magpie import models
-from owsrequest import *
+from typing import List, Dict
 
 
 class ServiceI(object):
-    permission_names = []   # global permissions allowed for the service (top-level resource)
-    params_expected = []    # derived services must have 'request' at least for 'permission_requested' method
-    resource_types_permissions = {}     # dict of list for each corresponding allowed resource permissions
+    # required request parameters for the service
+    params_expected = []                # type: List[str]
+    # global permissions allowed for the service (top-level resource)
+    permission_names = []               # type: List[str]
+    # dict of list for each corresponding allowed resource permissions
+    resource_types_permissions = {}     # type: Dict[str,List[str]]
 
     # make 'property' getter from derived classes
     class __metaclass__(type):
@@ -36,7 +40,6 @@ class ServiceI(object):
         if resource:
             for ace in resource.__acl__:
                 self.acl.append(ace)
-            # Custom acl
 
             if user:
                 permissions = ResourceService.perms_for_user(resource, user, db_session=self.request.db)
@@ -154,7 +157,6 @@ class ServiceNCWMS2(ServiceWMS):
             # https://colibri.crim.ca/twitcher/ows/proxy/ncWMS2/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0&DATASET=outputs/ouranos/subdaily/aet/pcp/aet_pcp_1961.nc
             if 'dataset' in self.parser.params.keys():
                 netcdf_file = self.parser.params['dataset']
-            # replace output/ with birdhouse/
 
         elif permission_requested == 'getmap':
             # https://colibri.crim.ca/ncWMS2/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=TRUE&ABOVEMAXCOLOR=extend&STYLES=default-scalar%2Fseq-Blues&LAYERS=outputs/ouranos/subdaily/aet/pcp/aet_pcp_1961.nc/PCP&EPSG=4326

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -325,9 +325,11 @@ class ManagementViews(object):
 
             if requires_update_name:
                 # re-fetch user groups as current user-group will have changed on new user_name
-                user_info[u'own_groups'] = self.get_user_groups(user_info[u'user_name'])
+                user_name = user_info[u'user_name']
+                user_info[u'own_groups'] = self.get_user_groups(user_name)
                 # return immediately with updated URL to user with new name
-                return HTTPFound(self.request.route_url('edit_user', **user_info))
+                users_url = self.request.route_url('edit_user', user_name=user_name, cur_svc_type=cur_svc_type)
+                return HTTPMovedPermanently(location=users_url)
 
             # edits to groups checkboxes
             if is_edit_group_membership:

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ threddsclient==0.3.4
 humanize
 requests_file
 webtest
+typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Sphinx==1.3.1
 #cryptography==1.9
 PyYAML>=3.11
 pyramid==1.8.3
-ziggurat-foundations==0.7.1
+ziggurat-foundations==0.8.1
 pyramid_tm==2.2
 pyramid_chameleon==0.3
 pyramid_mako>=1.0.2
@@ -20,7 +20,7 @@ psycopg2>=2.7.1
 lxml>=3.7
 bcrypt==3.1.3
 futures==3.1.1
-zope.sqlalchemy
+zope.sqlalchemy==1.0
 gunicorn==19.8.1
 alembic==0.9.6
 paste
@@ -32,3 +32,4 @@ colander
 threddsclient==0.3.4
 humanize
 requests_file
+webtest

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -33,7 +33,7 @@ class TestMagpieAPI_NoAuth_Interface(unittest.TestCase):
     @unittest.skipUnless(runner.MAGPIE_TEST_LOGIN, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('login'))
     def test_GetSession_Anonymous(self):
         resp = utils.test_request(self.url, 'GET', '/session', headers=self.json_headers)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_equal(json_body['authenticated'], False)
         if LooseVersion(self.version) >= LooseVersion('0.6.3'):
             utils.check_val_not_in('user', json_body)
@@ -44,7 +44,7 @@ class TestMagpieAPI_NoAuth_Interface(unittest.TestCase):
 
     def test_GetVersion(self):
         resp = utils.test_request(self.url, 'GET', '/version', headers=self.json_headers)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('db_version', json_body)
         utils.check_val_is_in('version', json_body)
         # server not necessarily at latest version, ensure at least format
@@ -58,7 +58,7 @@ class TestMagpieAPI_NoAuth_Interface(unittest.TestCase):
     def test_GetCurrentUser(self):
         logged_user = get_constant('MAGPIE_LOGGED_USER')
         resp = utils.test_request(self.url, 'GET', '/users/{}'.format(logged_user), headers=self.json_headers)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         if LooseVersion(self.version) >= LooseVersion('0.6.3'):
             utils.check_val_equal(json_body['user']['user_name'], self.usr)
         else:
@@ -125,11 +125,10 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
 
         cls.test_service_name = u'project-api'
         cls.test_service_type = cls.test_services_info[cls.test_service_name]['type']
-        utils.check_val_is_in(cls.test_service_type, cls.test_services_info)
 
-        resp = utils.test_request(cls.url, 'GET', '/services/project-api',
+        resp = utils.test_request(cls.url, 'GET', '/services/{}'.format(cls.test_service_name),
                                   headers=cls.json_headers, cookies=cls.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         cls.test_service_resource_id = json_body[cls.test_service_name]['resource_id']
 
         cls.test_resource_name = u'magpie-unittest-resource'
@@ -167,7 +166,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     @unittest.skipUnless(runner.MAGPIE_TEST_LOGIN, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('login'))
     def test_GetSession_Administrator(self):
         resp = utils.test_request(self.url, 'GET', '/session', headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_equal(json_body['authenticated'], True)
         if LooseVersion(self.version) >= LooseVersion('0.6.3'):
             utils.check_val_is_in('user', json_body)
@@ -185,7 +184,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('users'))
     def test_GetUsers(self):
         resp = utils.test_request(self.url, 'GET', '/users', headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('user_names', json_body)
         utils.check_val_type(json_body['user_names'], list)
         utils.check_val_equal(len(json_body['user_names']) > 1, True)     # should have more than only 'anonymous'
@@ -198,7 +197,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     @unittest.skipUnless(runner.MAGPIE_TEST_DEFAULTS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('defaults'))
     def test_ValidateDefaultUsers(self):
         resp = utils.test_request(self.url, 'GET', '/users', headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         users = json_body['user_names']
         utils.check_val_is_in(get_constant('MAGPIE_ANONYMOUS_USER'), users)
         utils.check_val_is_in(get_constant('MAGPIE_ADMIN_USER'), users)
@@ -207,7 +206,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def check_GetUserResourcesPermissions(cls, user_name):
         route = '/users/{usr}/resources/{res_id}/permissions'.format(res_id=cls.test_service_resource_id, usr=user_name)
         resp = utils.test_request(cls.url, 'GET', route, headers=cls.json_headers, cookies=cls.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('permission_names', json_body)
         utils.check_val_type(json_body['permission_names'], list)
 
@@ -226,7 +225,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetCurrentUserGroups(self):
         resp = utils.test_request(self.url, 'GET', '/users/current/groups',
                                   headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('group_names', json_body)
         utils.check_val_type(json_body['group_names'], list)
         utils.check_val_is_in(get_constant('MAGPIE_ADMIN_GROUP'), json_body['group_names'])
@@ -236,7 +235,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetUserInheritedResources(self):
         route = '/users/{usr}/inherited_resources'.format(usr=self.usr)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('resources', json_body)
         utils.check_val_type(json_body['resources'], dict)
         service_types = utils.get_service_types_for_version(self.version)
@@ -268,13 +267,17 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetUserServices(self):
         route = '/users/{usr}/services'.format(usr=self.usr)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('services', json_body)
         services = json_body['services']
         utils.check_val_type(services, dict)
         service_types = utils.get_service_types_for_version(self.version)
-        utils.check_all_equal(services.keys(), service_types, any_order=True)
+        # as of version '0.7.0', visible services depend on the connected user permissions,
+        # so all services types not necessarily returned in the response
+        if LooseVersion(self.version) < LooseVersion('0.7.0'):
+            utils.check_all_equal(services.keys(), service_types, any_order=True)
         for svc_type in services:
+            utils.check_val_is_in(svc_type, service_types)  # one of valid service types
             for svc in services[svc_type]:
                 svc_dict = services[svc_type][svc]
                 utils.check_val_type(svc_dict, dict)
@@ -304,7 +307,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetUserServiceResources(self):
         route = '/users/{usr}/services/{svc}/resources'.format(usr=self.usr, svc=self.test_service_name)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('service', json_body)
         svc_dict = json_body['service']
         utils.check_val_type(svc_dict, dict)
@@ -352,7 +355,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
 
         route = '/users/{usr}'.format(usr=self.test_user_name)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         if LooseVersion(self.version) >= LooseVersion('0.6.3'):
             utils.check_val_is_in('user', json_body)
             utils.check_val_is_in('user_name', json_body['user'])
@@ -376,7 +379,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         route = '/users/{usr}'.format(usr=self.test_user_name)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers,
                                   cookies=self.cookies, expect_errors=True)
-        utils.check_response_basic_info(resp, 404)
+        utils.check_response_basic_info(resp, 404, expected_method='GET')
 
     @pytest.mark.users
     @unittest.skipUnless(runner.MAGPIE_TEST_USERS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('users'))
@@ -385,7 +388,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         logged_user = get_constant('MAGPIE_LOGGED_USER')
         resp = utils.test_request(self.url, 'GET', '/users/{}'.format(logged_user),
                                   headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         if LooseVersion(self.version) >= LooseVersion('0.6.3'):
             utils.check_val_equal(json_body['user']['user_name'], self.usr)
         else:
@@ -397,7 +400,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     @unittest.skipUnless(runner.MAGPIE_TEST_DEFAULTS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('defaults'))
     def test_ValidateDefaultGroups(self):
         resp = utils.test_request(self.url, 'GET', '/groups', headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         groups = json_body['group_names']
         utils.check_val_is_in(get_constant('MAGPIE_ANONYMOUS_GROUP'), groups)
         utils.check_val_is_in(get_constant('MAGPIE_USERS_GROUP'), groups)
@@ -409,7 +412,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         route = '/users/{usr}/groups'.format(usr=get_constant('MAGPIE_ADMIN_USER'))
         data = {'group_name': get_constant('MAGPIE_ANONYMOUS_GROUP')}
         resp = utils.test_request(self.url, 'POST', route, headers=self.json_headers, cookies=self.cookies, data=data)
-        utils.check_response_basic_info(resp, 201)
+        utils.check_response_basic_info(resp, 201, expected_method='POST')
 
     @pytest.mark.groups
     @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
@@ -417,7 +420,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         route = '/users/{usr}/groups'.format(usr=get_constant('MAGPIE_ADMIN_USER'))
         data = {'group_name': 'not_found'}
         resp = utils.test_request(self.url, 'POST', route, headers=self.json_headers, cookies=self.cookies, data=data)
-        utils.check_response_basic_info(resp, 404)
+        utils.check_response_basic_info(resp, 404, expected_method='POST')
 
     @pytest.mark.groups
     @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
@@ -425,14 +428,14 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         route = '/users/{usr}/groups'.format(usr=get_constant('MAGPIE_ADMIN_USER'))
         data = {'group_name': get_constant('MAGPIE_ADMIN_GROUP')}
         resp = utils.test_request(self.url, 'POST', route, headers=self.json_headers, cookies=self.cookies, data=data)
-        utils.check_response_basic_info(resp, 409)
+        utils.check_response_basic_info(resp, 409, expected_method='POST')
 
     @pytest.mark.groups
     @unittest.skipUnless(runner.MAGPIE_TEST_GROUPS, reason=runner.MAGPIE_TEST_DISABLED_MESSAGE('groups'))
     def test_GetGroupUsers(self):
         route = '/groups/{grp}/users'.format(grp=get_constant('MAGPIE_ADMIN_GROUP'))
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('user_names', json_body)
         utils.check_val_type(json_body['user_names'], list)
         utils.check_val_is_in(get_constant('MAGPIE_ADMIN_USER'), json_body['user_names'])
@@ -443,7 +446,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetGroupServices(self):
         route = '/users/{grp}/services'.format(grp=self.grp)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('services', json_body)
         services = json_body['services']
         utils.check_val_type(services, dict)
@@ -479,7 +482,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetGroupServiceResources(self):
         route = '/groups/{grp}/services/{svc}/resources'.format(grp=self.grp, svc=self.test_service_name)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in('service', json_body)
         svc_dict = json_body['service']
         utils.check_val_type(svc_dict, dict)
@@ -509,7 +512,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
     def test_GetServiceResources(self):
         route = '/services/{svc}/resources'.format(svc=self.test_service_name)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         svc_dict = json_body[self.test_service_name]
         utils.check_val_is_in(self.test_service_name, json_body)
         utils.check_val_type(json_body[self.test_service_name], dict)
@@ -541,7 +544,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
             service_perms = service_type_dict[svc['service_type']].permission_names
             route = '/services/{svc}/permissions'.format(svc=svc_name)
             resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-            json_body = utils.check_response_basic_info(resp, 200)
+            json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
             utils.check_val_is_in('permission_names', json_body)
             utils.check_val_type(json_body['permission_names'], list)
             utils.check_all_equal(json_body['permission_names'], service_perms, any_order=True)
@@ -618,7 +621,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         child_resource_id = json_body['resource_id']
         route = '/resources/{res_id}'.format(res_id=child_resource_id)
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         utils.check_val_is_in(str(child_resource_id), json_body)
         resource_body = json_body[str(child_resource_id)]
         utils.check_val_equal(resource_body['root_service_id'], service_root_id)
@@ -637,7 +640,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         data = {"resource_name": self.test_resource_name, "resource_type": self.test_resource_type}
         resp = utils.test_request(self.url, 'POST', route, headers=self.json_headers,
                                   cookies=self.cookies, json=data, expect_errors=True)
-        json_body = utils.check_response_basic_info(resp, 409)
+        json_body = utils.check_response_basic_info(resp, 409, expected_method='POST')
         utils.check_error_param_structure(json_body, version=self.version,
                                           isParamValueLiteralUnicode=True, paramCompareExists=True,
                                           paramValue=self.test_resource_name, paramName=u'resource_name')
@@ -670,7 +673,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         services_list_getcap = [svc for svc in services_list if 'getcapabilities' in svc['permission_names']]
         route = '/users/{usr}/services'.format(usr=get_constant('MAGPIE_ANONYMOUS_USER'))
         resp = utils.test_request(self.url, 'GET', route, headers=self.json_headers, cookies=self.cookies)
-        json_body = utils.check_response_basic_info(resp, 200)
+        json_body = utils.check_response_basic_info(resp, 200, expected_method='GET')
         services_body = json_body['services']
         for svc in services_list_getcap:
             svc_name = svc['service_name']
@@ -697,7 +700,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         }
         resp = utils.test_request(self.url, 'POST', '/resources',
                                   headers=self.json_headers, cookies=self.cookies, data=data)
-        json_body = utils.check_response_basic_info(resp, 201)
+        json_body = utils.check_response_basic_info(resp, 201, expected_method='POST')
         utils.check_post_resource_structure(json_body, self.test_resource_name, self.test_resource_type,
                                             self.test_resource_name, self.version)
 
@@ -715,7 +718,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         }
         resp = utils.test_request(self.url, 'POST', '/resources',
                                   headers=self.json_headers, cookies=self.cookies, data=data)
-        json_body = utils.check_response_basic_info(resp, 201)
+        json_body = utils.check_response_basic_info(resp, 201, expected_method='POST')
         utils.check_post_resource_structure(json_body, self.test_resource_name, self.test_resource_type,
                                             self.test_resource_name, self.version)
 
@@ -736,7 +739,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         }
         resp = utils.test_request(self.url, 'POST', '/resources',
                                   headers=self.json_headers, cookies=self.cookies, data=data)
-        json_body = utils.check_response_basic_info(resp, 201)
+        json_body = utils.check_response_basic_info(resp, 201, expected_method='POST')
         utils.check_post_resource_structure(json_body, self.test_resource_name, self.test_resource_type,
                                             self.test_resource_name, self.version)
 
@@ -749,7 +752,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
         }
         resp = utils.test_request(self.url, 'POST', '/resources',
                                   headers=self.json_headers, cookies=self.cookies, data=data, expect_errors=True)
-        json_body = utils.check_response_basic_info(resp, 422)
+        json_body = utils.check_response_basic_info(resp, 422, expected_method='POST')
         utils.check_error_param_structure(json_body, paramName='parent_id', paramValue=repr(None), version=self.version)
 
     @pytest.mark.resources
@@ -763,7 +766,7 @@ class TestMagpieAPI_AdminAuth_Interface(unittest.TestCase):
 
         route = '/resources/{res_id}'.format(res_id=resource_id)
         resp = utils.test_request(self.url, 'DELETE', route, headers=self.json_headers, cookies=self.cookies)
-        utils.check_response_basic_info(resp, 200)
+        utils.check_response_basic_info(resp, 200, expected_method='DELETE')
         utils.TestSetup.check_NonExistingTestResource(self)
 
 

--- a/tests/test_magpie_api.py
+++ b/tests/test_magpie_api.py
@@ -36,6 +36,7 @@ class TestMagpieAPI_NoAuth_Local(ti.TestMagpieAPI_NoAuth_Interface):
         cls.version = __meta__.__version__
         cls.cookies = None
         cls.usr = get_constant('MAGPIE_ANONYMOUS_USER')
+        cls.grp = get_constant('MAGPIE_ANONYMOUS_GROUP')
 
 
 @pytest.mark.api
@@ -67,6 +68,7 @@ class TestMagpieAPI_AdminAuth_Local(ti.TestMagpieAPI_AdminAuth_Interface):
     def setUpClass(cls):
         cls.app = utils.get_test_magpie_app()
         cls.url = cls.app  # to simplify calls of TestSetup (all use .url)
+        cls.grp = get_constant('MAGPIE_ADMIN_GROUP')
         cls.usr = get_constant('MAGPIE_TEST_ADMIN_USERNAME')
         cls.pwd = get_constant('MAGPIE_TEST_ADMIN_PASSWORD')
         cls.json_headers = utils.get_headers_content_type(cls.app, 'application/json')
@@ -75,8 +77,8 @@ class TestMagpieAPI_AdminAuth_Local(ti.TestMagpieAPI_AdminAuth_Interface):
         # TODO: fix UI views so that they can be 'found' directly in the WebTest.TestApp
         # NOTE: localhost magpie has to be running for following login call to work
         cls.headers, cls.cookies = utils.check_or_try_login_user(cls.app, cls.usr, cls.pwd,
-                                                                 use_ui_form_submit=True, version=cls.version)
-        cls.require = "cannot run tests without logged in '{}' user".format(get_constant('MAGPIE_ADMIN_GROUP'))
+                                                                 use_ui_form_submit=False, version=cls.version)
+        cls.require = "cannot run tests without logged in '{}' user".format(cls.grp)
         cls.check_requirements()
         cls.get_test_values()
 
@@ -97,6 +99,7 @@ class TestMagpieAPI_NoAuth_Remote(ti.TestMagpieAPI_NoAuth_Interface):
         cls.json_headers = utils.get_headers_content_type(cls.url, 'application/json')
         cls.cookies = None
         cls.usr = get_constant('MAGPIE_ANONYMOUS_USER')
+        cls.grp = get_constant('MAGPIE_ANONYMOUS_GROUP')
         cls.version = utils.TestSetup.get_Version(cls)
 
 
@@ -127,11 +130,12 @@ class TestMagpieAPI_AdminAuth_Remote(ti.TestMagpieAPI_AdminAuth_Interface):
 
     @classmethod
     def setUpClass(cls):
+        cls.grp = get_constant('MAGPIE_ADMIN_GROUP')
         cls.usr = get_constant('MAGPIE_TEST_ADMIN_USERNAME')
         cls.pwd = get_constant('MAGPIE_TEST_ADMIN_PASSWORD')
         cls.url = get_constant('MAGPIE_TEST_REMOTE_SERVER_URL')
         cls.headers, cls.cookies = utils.check_or_try_login_user(cls.url, cls.usr, cls.pwd)
-        cls.require = "cannot run tests without logged in '{}' user".format(get_constant('MAGPIE_ADMIN_GROUP'))
+        cls.require = "cannot run tests without logged in '{}' user".format(cls.grp)
         cls.json_headers = utils.get_headers_content_type(cls.url, 'application/json')
         cls.version = utils.TestSetup.get_Version(cls)
         cls.check_requirements()


### PR DESCRIPTION
- fixes multiple broken unittests
- move to ziggurat 0.8.1, which uses Service classes for db queries
- document deprecation in swagger to alert users
- adjust magpie adapter using admin query for valid operations by non-admin users
- magpie version 0.7.3