### PR TITLE
update adapter to match twitcher-ogc-0.4.x

### DIFF
--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -2,7 +2,7 @@
 General meta information on the magpie package.
 """
 
-__version__ = '0.7.13'
+__version__ = '0.8.0'
 __author__ = "Francois-Xavier Derue, Francis Charette-Migneault"
 __maintainer__ = "Francis Charette-Migneault"
 __email__ = 'francis.charette-migneault@crim.ca'

--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -2,7 +2,7 @@
 General meta information on the magpie package.
 """
 
-__version__ = '0.7.12'
+__version__ = '0.7.13'
 __author__ = "Francois-Xavier Derue, Francis Charette-Migneault"
 __maintainer__ = "Francis Charette-Migneault"
 __email__ = 'francis.charette-migneault@crim.ca'

--- a/magpie/definitions/pyramid_definitions.py
+++ b/magpie/definitions/pyramid_definitions.py
@@ -17,6 +17,7 @@ from pyramid.httpexceptions import (
     HTTPConflict,
     HTTPUnprocessableEntity,
     HTTPInternalServerError,
+    HTTPNotImplemented,
 )
 from pyramid.registry import Registry
 from pyramid.settings import asbool


### PR DESCRIPTION
## required for latest end-2-end tests: 
http://ci.corpo.crim.ca:8081/job/OGC_Twitcher_EMS_end2end/117 (Twitcher ogc-0.4.x)

## deploy
- [ ] update of ems server `env.local` to magpie `0.8.0`