### PR TITLE
Gunicorn access logs

### DIFF
--- a/magpie/magpie.ini
+++ b/magpie/magpie.ini
@@ -52,6 +52,7 @@ document_root = %(here)s/ui/swagger
 [server:main]
 use = egg:gunicorn#main
 host = localhost
+logconfig = %(here)s/magpie.ini
 port=2001
 timeout=10
 workers=3
@@ -63,7 +64,7 @@ threads=4
 ###
 
 [loggers]
-keys = root, magpie
+keys = root, magpie, gunicorn
 
 [handlers]
 keys = console
@@ -79,6 +80,11 @@ handlers = console
 level =  INFO
 handlers = console
 qualname = magpie
+
+[logger_gunicorn]
+level = INFO
+handlers = console
+qualname = gunicorn
 
 [handler_console]
 class = StreamHandler


### PR DESCRIPTION
This prints the gunicorn access logs to stdout.

I don't know what you think, but I think this helps debugging...