### PR TITLE
Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:2.7-alpine
 MAINTAINER Francis Charette-Migneault
 
-ARG MAGPIE_DIR=/opt/local/src/magpie
+# the cron service depends on the $MAGPIE_DIR environment variable
+ENV MAGPIE_DIR=/opt/local/src/magpie
 ENV MAGPIE_ENV_DIR=$MAGPIE_DIR/env
 WORKDIR $MAGPIE_DIR
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER Francis Charette-Migneault
 ARG MAGPIE_DIR=/opt/local/src/magpie
 ENV MAGPIE_ENV_DIR=$MAGPIE_DIR/env
 WORKDIR $MAGPIE_DIR
-COPY ./ $MAGPIE_DIR
 
 # magpie cron service
 ADD magpie-cron /etc/cron.d/magpie-cron
@@ -12,6 +11,9 @@ RUN chmod 0644 /etc/cron.d/magpie-cron
 RUN touch ~/magpie_cron_status.log
 # set /etc/environment so that cron runs using the environment variables set by docker
 RUN env >> /etc/environment
+
+COPY magpie/__init__.py magpie/__meta__.py ./magpie/
+COPY requirements* setup.py README.rst HISTORY.rst ./
 
 RUN apk update && apk add \
         bash \
@@ -28,6 +30,8 @@ RUN apk update && apk add \
     pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir -e $MAGPIE_DIR && \
     apk --purge del .build-deps
+
+COPY ./ $MAGPIE_DIR
 
 # equivalent of `make install` without conda env and pre-installed packages
 RUN pip install --no-dependencies -e $MAGPIE_DIR

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -69,7 +69,7 @@ def create_user(user_name, password, email, group_name, db_session):
                          content={u'user': uf.format_user(new_user, [group_name])})
 
 
-def create_user_resource_permission(permission_name, resource, user_id, db_session):
+def create_user_resource_permission(permission_name, resource, user, db_session):
     # type: (Str, models.Resource, models.User, Session) -> HTTPException
     """
     Creates a permission on a user/resource combination if it is permitted and not conflicting.
@@ -78,16 +78,16 @@ def create_user_resource_permission(permission_name, resource, user_id, db_sessi
     check_valid_service_resource_permission(permission_name, resource, db_session)
     resource_id = resource.resource_id
     existing_perm = UserResourcePermissionService.by_resource_user_and_perm(
-        user_id=user_id, resource_id=resource_id, perm_name=permission_name, db_session=db_session)
+        user_id=user.id, resource_id=resource_id, perm_name=permission_name, db_session=db_session)
     ax.verify_param(existing_perm, isNone=True, httpError=HTTPConflict,
-                    content={u'resource_id': resource_id, u'user_id': user_id, u'permission_name': permission_name},
+                    content={u'resource_id': resource_id, u'user_id': user.id, u'permission_name': permission_name},
                     msgOnFail=s.UserResourcePermissions_POST_ConflictResponseSchema.description)
 
     # noinspection PyArgumentList
-    new_perm = models.UserResourcePermission(resource_id=resource_id, user_id=user_id, perm_name=permission_name)
-    usr_res_data = {u'resource_id': resource_id, u'user_id': user_id, u'permission_name': permission_name}
+    new_perm = models.UserResourcePermission(resource_id=resource_id, user_id=user.id, perm_name=permission_name)
+    usr_res_data = {u'resource_id': resource_id, u'user_id': user.id, u'permission_name': permission_name}
     ax.verify_param(new_perm, notNone=True, httpError=HTTPNotAcceptable,
-                    content={u'resource_id': resource_id, u'user_id': user_id},
+                    content={u'resource_id': resource_id, u'user_id': user.id},
                     msgOnFail=s.UserResourcePermissions_POST_NotAcceptableResponseSchema.description)
     ax.evaluate_call(lambda: db_session.add(new_perm), fallback=lambda: db_session.rollback(),
                      httpError=HTTPForbidden, content=usr_res_data,

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -268,7 +268,7 @@ def create_user_resource_permission_view(request):
     user = ar.get_user_matchdict_checked_or_logged(request)
     resource = ar.get_resource_matchdict_checked(request)
     perm_name = ar.get_permission_multiformat_post_checked(request, resource)
-    return uu.create_user_resource_permission(perm_name, resource, user.id, request.db)
+    return uu.create_user_resource_permission(perm_name, resource, user, request.db)
 
 
 @s.UserResourcePermissionAPI.delete(schema=s.UserResourcePermission_DELETE_RequestSchema(), tags=[s.UsersTag],
@@ -282,7 +282,7 @@ def delete_user_resource_permission_view(request):
     user = ar.get_user_matchdict_checked_or_logged(request)
     resource = ar.get_resource_matchdict_checked(request)
     perm_name = ar.get_permission_matchdict_checked(request, resource)
-    return uu.delete_user_resource_permission(perm_name, resource, user.id, request.db)
+    return uu.delete_user_resource_permission(perm_name, resource, user, request.db)
 
 
 @s.UserServicesAPI.get(tags=[s.UsersTag], schema=s.UserServices_GET_RequestSchema,

--- a/magpie/common.py
+++ b/magpie/common.py
@@ -8,10 +8,9 @@ from requests.structures import CaseInsensitiveDict
 from distutils.dir_util import mkpath
 # noinspection PyProtectedMember
 from logging import _loggerClass as LoggerType
-# noinspection PyCompatibility
-import configparser
 import types
 import six
+from six.moves import configparser
 import sys
 import os
 import logging

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -2,4 +2,3 @@
 python-openid
 # futures is required for gunicorn threads in python 2.7
 futures
-configparser

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -2,3 +2,4 @@
 python-openid
 # futures is required for gunicorn threads in python 2.7
 futures
+configparser

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,2 +1,4 @@
 # authomatic doesn't properly install valid version of openid
 python-openid
+# futures is required for gunicorn threads in python 2.7
+futures


### PR DESCRIPTION
CHANGE:
- in the Dockerfile, don't reinstall dependencies when there is only a code change

FIX:
- futures is required for gunicorn threads in python 2.7
- add configparser for python 2.7
- change MAGPIE_DIR from ARG to ENV in Dockerfile
- create_user_resource_permission takes a models.User, not a user id 