### PR TITLE
Change sqlalchemy engine creation default values

### DIFF
--- a/magpie/db.py
+++ b/magpie/db.py
@@ -41,8 +41,7 @@ def get_db_url(username=None, password=None, db_host=None, db_port=None, db_name
 
 def get_engine(settings, prefix='sqlalchemy.'):
     settings[prefix + 'url'] = get_db_url()
-    settings[prefix + 'pool_size'] = 20
-    settings[prefix + 'max_overflow'] = 100
+    settings[prefix + 'pool_pre_ping'] = settings.get(prefix + 'pool_pre_ping', True)
     return engine_from_config(settings, prefix)
 
 


### PR DESCRIPTION
- Leave pool_size and max_overflow to their default values (5 and 10)

I think that we should not enforce a value of 20 for the connection pool size. The user can now overwrite this setting in the config. 

- Use pool_pre_ping when not set to False in config.

The main problem I encountered was that when the database restarts, connections in the pool are no longer valid. This means that a 500 error will happen when the next query is attempted.

From sqlalchemy docs:

> Pessimistic testing of connections upon checkout is achievable by using the Pool.pre_ping argument, available from create_engine() via the create_engine.pool_pre_ping argument:

> engine = create_engine("mysql+pymysql://user:pw@host/db", pool_pre_ping=True)

> The “pre ping” feature will normally emit SQL equivalent to “SELECT 1” each time a connection is checked out from the pool; if an error is raised that is detected as a “disconnect” situation, the connection will be immediately recycled, and all other pooled connections older than the current time are invalidated, so that the next time they are checked out, they will also be recycled before use.

