### PR TITLE
tmp fix using pool_threadlocal

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ History
 Unreleased
 ---------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* add ``pool_threadlocal=True`` setting for database session creation to allow further connections across workers
+  (see #201, #202 for further information)
+
 1.3.0 (2019-07-02)
 ---------------------
 

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -3,7 +3,7 @@
 from magpie.constants import get_constant
 from magpie.definitions.alembic_definitions import alembic
 from magpie.definitions.sqlalchemy_definitions import (
-    register, sessionmaker, engine_from_config, ZopeTransactionExtension,
+    register, sessionmaker, engine_from_config,
     configure_mappers, select, Inspector, Session, sa_exc
 )
 from magpie.definitions.pyramid_definitions import asbool
@@ -46,6 +46,7 @@ def get_engine(container=None, prefix="sqlalchemy.", **kwargs):
     settings = get_settings(container or {})
     settings[prefix + "url"] = get_db_url()
     settings[prefix + "pool_pre_ping"] = settings.get(prefix + "pool_pre_ping", True)
+    settings[prefix + "pool_threadlocal"] = True
     kwargs = kwargs or {}
     kwargs["convert_unicode"] = True
     return engine_from_config(settings, prefix, **kwargs)


### PR DESCRIPTION
I found this setting which seems to help a bit.
I am able to add much more users, as the pool is x times the number of workers.

Still, it's more of a patch than anything else.
We should look into avoiding the iterative calls of following function, ran on every create-user submission.

https://github.com/Ouranosinc/Magpie/blob/8fccad35ca3c8b078ae44502d3519b10cfc3801e/magpie/ui/management/views.py#L66-L76

Maybe we could add `GET /users?detail=true`, which would return a list of user-params instead of the flat user-name string list.

@dbyrns What do you think?