### PR TITLE
set `use_tweens` to True when using the `invoke_subrequest` pyramid method

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ History
 Unreleased
 ---------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* add ``use_tweens=True`` to ``request.invoke_subrequest`` calls in order to properly handle the nested database
+  transaction states with the manager (#203). Automatically provides ``pool_threadlocal`` functionality added in
+  ``1.3.1`` as per implementation of ``pyramid_tm`` (#201).
+
 1.3.1 (2019-07-05)
 ---------------------
 

--- a/magpie/api/login/login.py
+++ b/magpie/api/login/login.py
@@ -87,7 +87,7 @@ def sign_in(request):
         signin_internal_data = {u"user_name": user_name, u"password": password, u"provider_name": provider_name}
         signin_sub_request = Request.blank(signin_internal_path, base_url=request.application_url,
                                            headers={"Accept": CONTENT_TYPE_JSON}, POST=signin_internal_data)
-        signin_response = request.invoke_subrequest(signin_sub_request)
+        signin_response = request.invoke_subrequest(signin_sub_request, use_tweens=True)
         if signin_response.status_code == HTTPOk.code:
             return convert_response(signin_response)
         login_failure(request, s.Signin_POST_UnauthorizedResponseSchema.description)

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -47,7 +47,7 @@ def get_engine(container=None, prefix="sqlalchemy.", **kwargs):
     # type: (Optional[AnySettingsContainer], Str, Any) -> Engine
     settings = get_settings(container or {})
     settings[prefix + "url"] = get_db_url()
-    settings[prefix + "pool_pre_ping"] = settings.get(prefix + "pool_pre_ping", True)
+    settings.setdefault(prefix + "pool_pre_ping", True)
     kwargs = kwargs or {}
     kwargs["convert_unicode"] = True
     return engine_from_config(settings, prefix, **kwargs)

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -86,7 +86,7 @@ def get_tm_session(session_factory, transaction_manager):
 def get_db_session_from_settings(settings=None, **kwargs):
     # type: (Optional[AnySettingsContainer], Any) -> Session
     session_factory = get_session_factory(get_engine(settings, **kwargs))
-    db_session = get_tm_session(session_factory, transaction)
+    db_session = get_tm_session(session_factory, transaction.manager)
     return db_session
 
 

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -54,7 +54,7 @@ def get_engine(container=None, prefix="sqlalchemy.", **kwargs):
 
 
 def get_session_factory(engine):
-    return scoped_session(sessionmaker(bind=engine))
+    return sessionmaker(bind=engine)
 
 
 def get_tm_session(session_factory, transaction_manager):

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from sqlalchemy.orm import scoped_session
+
 from magpie.constants import get_constant
 from magpie.definitions.alembic_definitions import alembic
 from magpie.definitions.sqlalchemy_definitions import (
@@ -46,16 +48,13 @@ def get_engine(container=None, prefix="sqlalchemy.", **kwargs):
     settings = get_settings(container or {})
     settings[prefix + "url"] = get_db_url()
     settings[prefix + "pool_pre_ping"] = settings.get(prefix + "pool_pre_ping", True)
-    settings[prefix + "pool_threadlocal"] = True
     kwargs = kwargs or {}
     kwargs["convert_unicode"] = True
     return engine_from_config(settings, prefix, **kwargs)
 
 
 def get_session_factory(engine):
-    factory = sessionmaker()
-    factory.configure(bind=engine)
-    return factory
+    return scoped_session(sessionmaker(bind=engine))
 
 
 def get_tm_session(session_factory, transaction_manager):

--- a/magpie/ui/utils.py
+++ b/magpie/ui/utils.py
@@ -59,7 +59,7 @@ def request_api(request,            # type: Request
         extra_kwargs["cookies"] = cookies
 
     subreq = Request.blank(path, base_url=request.application_url, headers=headers, POST=data, **extra_kwargs)
-    return request.invoke_subrequest(subreq)
+    return request.invoke_subrequest(subreq, use_tweens=True)
 
 
 def error_badrequest(func):


### PR DESCRIPTION
I could reproduce the connection pool issues we were having, and this should fix it. I think multiple threads were getting the same session from the factory, and the sessions were then probably not closed properly.

Also, remove pool_threadlocal which is equivalent to use_threadlocal, which is deprecated.

Explanation here: https://docs.sqlalchemy.org/en/13/orm/contextual.html#thread-local-scope