### PR TITLE
Fix 500 error when deleting a service resource from the ui

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ Features / Changes
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * fix issue of form submission not behaving as expected when pressing ``<ENTER>`` key (#209)
+* fix 500 error when deleting a service resource from UI (#195)
 
 1.4.0 (2019-08-28)
 ---------------------

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -887,7 +887,7 @@ class ManagementViews(object):
 
         if "delete_child" in self.request.POST:
             resource_id = self.request.POST.get("resource_id")
-            path = schemas.ResourceAPI.format(resource_id=resource_id)
+            path = schemas.ResourceAPI.path.format(resource_id=resource_id)
             resp = request_api(self.request, path, "DELETE")
             check_response(resp)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16667564/64032355-46439a80-cb18-11e9-9175-93038d4ab5e4.png)
