### PR TITLE
Magpie adapter singleton

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ Unreleased
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
+* use singleton interface for ``MagpieAdapter`` and ``MagpieServiceStore`` to avoid class recreation and reduce request
+  time by `Twitcher` when checking for a service by name.
+
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * fix issue of form submission not behaving as expected when pressing ``<ENTER>`` key (#209)


### PR DESCRIPTION
MagpieAdapter can be a singleton, since it doesn't share any state between calls except for the global settings, which aren't modified unless the app is restarted (same for MagpieServiceStore and MagpieOWSSecurity).

The adapter is a class, but behaves more like a module, so to use a singleton is a correct use case here.

Also, when calling `MagpieServiceStore.fetch_by_name`, we don't have to list all services.