### PR TITLE
Use pyramid-beaker to cache acl permissions for a specific service and user name

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Features / Changes
 * add an utility script ``create_users`` for quickly creating multiple users from a list of email addresses (#219).
 * add PEP8 auto-fix make target ``lint-fix`` that will correct any PEP8 and docstring problem to expected format.
 * add auto-doc of make target ``help`` message
+* add ACL caching option and documentation (#218)
 
 Unreleased
 ---------------------

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -28,6 +28,12 @@ magpie.max_restart = 5
 magpie.secret = seekrit
 magpie.push_phoenix = true
 
+# caching settings for specific sections/functions
+cache.regions = adapter
+# cache.type = memory
+# cache.adapter.expire = 5
+cache.adapter.enabled = false
+
 # ziggurat
 ziggurat_foundations.model_locations.User = magpie.models:User
 ziggurat_foundations.sign_in.username_key = user_name

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -28,7 +28,7 @@ magpie.max_restart = 5
 magpie.secret = seekrit
 magpie.push_phoenix = true
 
-# caching settings for specific sections/functions
+# caching settings refer to the Performance section in the documentation
 cache.regions = adapter
 # cache.type = memory
 # cache.adapter.expire = 5

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Package information
 
    usage
    installation
+   performance
    contributing
    authors
    history

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,0 +1,25 @@
+===========
+Performance
+===========
+
+Requesting permissions for a specific user and service can be demanding if a lot of
+requests are done rapidly. PostgreSQL and sqlalchemy are usually fast enough, but
+when more than a couple requests per second are needed, some solutions are possible to
+improve the performance of these requests.
+
+We can take advantage of the fact that permission are not susceptible to change often
+and cache the results of these permission queries.
+
+While not activated by default, it's possible to cache the access control lists (ACLs)
+for all services, and give it an expiration timeout::
+
+  # example Paste Deploy configuration
+  cache.regions = adapter
+  cache.type = memory
+  cache.adapter.expire = 5  # seconds
+
+For a particular request that queries a user's ACL
+for a specific service, the response will be cached for 5 seconds. The consequence of this
+caching is that any permission change will take 5 seconds to be effective. Depending on the
+use case, this can be perfectly acceptable and the performance improvement is not negligible.
+You should test and profile for your particular environment.

--- a/magpie/__init__.py
+++ b/magpie/__init__.py
@@ -30,6 +30,7 @@ def includeme(config):
     config.include("cornice")
     config.include("cornice_swagger")
     config.include("pyramid_chameleon")
+    config.include("pyramid_beaker")
     config.include("pyramid_mako")
     config.include("magpie.definitions")
     config.include("magpie.api")

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -150,6 +150,7 @@ class MagpieAdapter(AdapterInterface, Singleton):
 
         LOGGER.info("Loading MagpieAdapter config")
         config = get_auth_config(container)
+        config.include("pyramid_beaker")
 
         # use pyramid_tm to hook the transaction lifecycle to the request
         # make request.db available for use in Pyramid

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -9,6 +9,7 @@ from magpie.security import get_auth_config
 from magpie.db import get_session_factory, get_tm_session, get_engine
 from magpie.utils import get_logger, get_settings, get_magpie_url, CONTENT_TYPE_JSON
 from magpie import __meta__
+from pyramid_beaker import set_cache_regions_from_settings
 import time
 import logging
 import requests
@@ -142,6 +143,7 @@ class MagpieAdapter(AdapterInterface, Singleton):
 
     def configurator_factory(self, container):
         settings = get_settings(container)
+        set_cache_regions_from_settings(settings)
 
         # disable rpcinterface which is conflicting with postgres db
         settings["twitcher.rpcinterface"] = False

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -15,6 +15,7 @@ from magpie.register import (
 from magpie.security import get_auth_config
 from magpie.utils import patch_magpie_url, print_log, get_logger
 from magpie import db
+from pyramid_beaker import set_cache_regions_from_settings
 import os
 # noinspection PyUnresolvedReferences
 import logging
@@ -75,6 +76,7 @@ def main(global_config=None, **settings):
     settings["handle_exceptions"] = False
 
     config = get_auth_config(settings)
+    set_cache_regions_from_settings(settings)
 
     # Don't use scan otherwise modules like 'magpie.adapter' are
     # automatically found and cause import errors on missing packages

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -86,7 +86,8 @@ class UserResourcePermission(UserResourcePermissionMixin, Base):
 
 
 class User(UserMixin, Base):
-    pass
+    def __str__(self):
+        return "<User: %s, %s>" % (self.id, self.user_name)
 
 
 class ExternalIdentity(ExternalIdentityMixin, Base):

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -82,6 +82,8 @@ class ServiceInterface(with_metaclass(ServiceMeta)):
             cache_regions['acl'] = {'enabled': False}
         return self._get_acl_cached(self.service.resource_id, self.request.user)
 
+    # noinspection PyUnusedLocal
+    # parameters required to preserve caching of corresponding resource-id/user called
     @cache_region('acl')
     def _get_acl_cached(self, service_id, user):
         """Beaker will cache this method based on the service id and the user.

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -78,11 +78,11 @@ class ServiceInterface(with_metaclass(ServiceMeta)):
         """
         List of access control rules defining (outcome, user/group, permission) combinations.
         """
-        if 'adapter' not in cache_regions:
-            cache_regions['adapter'] = {'enabled': False}
+        if 'acl' not in cache_regions:
+            cache_regions['acl'] = {'enabled': False}
         return self._get_acl_cached(self.service.resource_id, self.request.user)
 
-    @cache_region('adapter')
+    @cache_region('acl')
     def _get_acl_cached(self, service_id, user):
         """Beaker will cache this method based on the service id and the user.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==0.9.6
 bcrypt==3.1.6
+beaker
 colander
 cornice
 cornice_swagger>=0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pastedeploy
 pluggy
 psycopg2-binary>=2.7.1
 pyramid==1.10.2
+pyramid_beaker==0.8
 pyramid_chameleon==0.3
 pyramid_mako>=1.0.2
 pyramid_tm==2.2.1


### PR DESCRIPTION
I only tested this with the `ServiceAPI` service type. 

Basically, the permissions are cached for a specific service and user. When there are a lot of concurrent requests, adding a cache with a small expiration time of 5 seconds can make a big difference (2-3 times more requests handled per second).

@fmigneault I don't think so, but look if I didn't miss anything regarding permissions that caching could interfere with...