### PR TITLE
Fix migration: don't use the orm

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ History
 Unreleased
 ---------------------
 
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* fix migration script for project-api service type
+
 1.6.0 (2019-09-20)
 ---------------------
 


### PR DESCRIPTION
We can't query using models.Resource.resource_type because it's a declared_attr in sqlalchemy. 

In general, migrations that don't depend on the sqlalchemy models will be more stable as the models get modified.