### PR TITLE
Fix #165 (database version)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ History
 Unreleased
 ---------------------
 
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* fix the alembic database version number in the /version route
+
 1.6.2 (2019-10-04)
 ---------------------
 

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -114,7 +114,7 @@ def run_database_migration(db_session=None):
 
 def get_database_revision(db_session):
     # type: (Session) -> Str
-    s = select(["version_num"], from_obj="alembic_version")
+    s = "SELECT version_num FROM alembic_version"
     result = db_session.execute(s).fetchone()
     return result["version_num"]
 


### PR DESCRIPTION
Fix for warning: "Textual SQL expression 'alembic_version' should be explicitly
declared as text('alembic_version')"