### PR TITLE
don't use get_resource_root_service in migrations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Unreleased
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * fix the alembic database version number in the /version route (#165)
+* fix failing migration step due to missing ``root_service_id`` column in database at that time and version.
 
 1.6.2 (2019-10-04)
 ---------------------

--- a/magpie/alembic/versions/73b872478d87_add_resource_label.py
+++ b/magpie/alembic/versions/73b872478d87_add_resource_label.py
@@ -1,5 +1,5 @@
 """
-empty message.
+add resource_display_name column
 
 Revision ID: 73b872478d87
 Revises: d01af1f2e445


### PR DESCRIPTION
Fix for https://github.com/Ouranosinc/PAVICS/pull/149

The `get_resource_root_service` function is outside of the migration folder. Adding a column to the resource table at a later time means that the migration will try to use this non existing column during the migration when running `get_resource_root_service`.