### PR TITLE
config updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 Dockerfile
+Dockerfile.adapter
 .dockerignore
 
 **/custom.ini
@@ -34,6 +35,7 @@ magpie.egg-info
 src
 share
 downloads
+gunicorn.app.wsgiapp
 
 # Unit test / Coverage reports
 **/.cache

--- a/CONFIGURATION.rst
+++ b/CONFIGURATION.rst
@@ -1,0 +1,170 @@
+Configuration
+=============
+
+At startup, ``Magpie`` application will load multiple configuration files to define various behaviours or setup
+operations. These are defined though the following configuration settings presented below.
+
+All generic ``Magpie`` configuration settings can be defined through either the `<config/magpie.ini>`_ file or
+environment variables. Values defined in `<config/magpie.ini>`_ are expected to follow the ``magpie.[variable_name]``
+format, and corresponding ``MAGPIE_[VARIABLE_NAME]`` format is used for environment variables. Both of these
+alternatives match the constants defined in `<magpie/constants.py>`_ and can be used interchangeably. Order of
+resolution will prioritize setting values over environment variables in case of matching duplicates values.
+
+Configuration Files
+-------------------
+
+magpie.ini
+~~~~~~~~~~~~~~~~~~~
+
+This is the base configuration file that defines most of ``Magpie``'s lower level configuration. A basic example is
+provided in `<config/magpie.ini>`_ which should allow any user to run the application locally. Furthermore, this file
+is used by default in each tagged Docker image. If you want to provide different configuration, the file should be
+overridden in the Docker image using a volume mount parameter, or by specifying an alternative path through the
+environment variable ``MAGPIE_INI_FILE_PATH``.
+
+providers.cfg
+~~~~~~~~~~~~~~~~~~~
+
+
+permissions.cfg
+~~~~~~~~~~~~~~~~~~~
+
+
+
+magpie.env
+~~~~~~~~~~~~~~~~~~~
+
+By default, ``Magpie`` will try to load a ``magpie.env`` file which can define further environment variable definitions
+used to setup the application (see ``MAGPIE_ENV_FILE`` setting further below). An example of expected format and common
+variables for this file is presented in `<env/magpie.env.example>`_.
+
+**Important Notes:**
+
+If ``magpie.env`` cannot be found (using setting ``MAGPIE_ENV_FILE``) but ``magpie.env.example`` is available
+(after resolving any previously set ``MAGPIE_ENV_DIR`` variable), this example file will be used to make a copy
+saved as ``magpie.env`` and will be used as the base ``.env`` file to load its contained environment variables.
+This behaviour is intended to reduce initial configuration and preparation of  ``Magpie`` for a new user.
+
+When loading variables from the ``.env`` file, any conflicting environment variable will **NOT** be overridden.
+Therefore, only *missing but required* values will be added to the environment to ensure proper setup of ``Magpie``.
+
+postgres.env
+~~~~~~~~~~~~~~~~~~~
+
+This file behaves exactly in the same manner as for ``magpie.env`` above, but for specific variables definition
+employed to setup the `postgres` database connection (see ``MAGPIE_POSTGRES_ENV_FILE`` setting below).
+File `<env/postgres.env.example>`_ and auto-resolution of missing ``postgres.env`` is identical to ``magpie.env`` case.
+
+Settings and Constants
+----------------------
+
+Environment variables can be used to define all following settings (unless mentioned otherwise with 'constant').
+These values will be used by ``Magpie`` on startup unless prior definition is found within `<config/magpie.ini>`_.
+
+Base Settings
+~~~~~~~~~~~~~
+
+These settings can be used to specify where to find other settings through custom configuration files.
+
+- | ``MAGPIE_MODULE_DIR`` (constant)
+  | Path to the top level ``Magpie`` module (ie: source code).
+
+- | ``MAGPIE_ROOT`` (constant)
+  | Path to the containing directory of ``Magpie``. This corresponds to the directory where the repository was cloned
+    or where the package was installed.
+
+- | ``MAGPIE_CONFIG_DIR``
+  | Configuration directory where to look for ``providers.cfg`` and ``permissions.cfg`` files.
+  | (Default: ``${MAGPIE_ROOT}/config``)
+
+- | ``MAGPIE_PROVIDERS_CONFIG_PATH``
+  | Path where to find ``providers.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
+    be considered as `providers` files and will be loaded sequentially. \
+    Please refer to `<config/providers.cfg>`_ for specific format details.
+  | (Default: ``${MAGPIE_CONFIG_DIR}/providers.cfg``)
+
+- | ``MAGPIE_PERMISSIONS_CONFIG_PATH``
+  | Path where to find ``permissions.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
+    be considered as `permissions` files and will be loaded sequentially. \
+    Please refer to `<config/permissions.cfg>`_ for specific format details.
+  | (default: ``${MAGPIE_CONFIG_DIR}/permissions.cfg``)
+
+- | ``MAGPIE_INI_FILE_PATH``
+  | Specifies where to find the initialization file to run ``Magpie`` application.
+  | **Note**: this variable ignores the setting/env-var resolution order since settings cannot be defined without
+              firstly loading the file referenced by its value.
+
+- | ``MAGPIE_ALEMBIC_INI_FILE_PATH``
+  | Path to ``.ini`` file which defines an ``[alembic]`` section specifying details on how to execute database
+    migration operations.
+  | (Default: ``${MAGPIE_INI_FILE_PATH}``) [section defined within `<config/magpie.ini>`_]
+
+- | ``MAGPIE_ENV_DIR``
+  | Directory path where to look for ``.env`` files. This variable can be useful to load specific test environment
+    configurations or to specify a local path while the actual ``Magpie`` code is located in a Python `site-packages`
+    directory (``.env`` files are not installed to avoid hard-to-resolve settings loaded from an install location).
+  | (Default: ``${MAGPIE_ROOT}/env``)
+
+- | ``MAGPIE_ENV_FILE``
+  | File path to ``magpie.env`` file with additional environment variables to configure the application.
+  | (Default: ``${MAGPIE_ENV_DIR}/magpie.env``)
+
+- | ``MAGPIE_POSTGRES_ENV_FILE``
+  | File path to ``postgres.env`` file with additional environment variables to configure the `postgres` connection.
+  | (Default: ``${MAGPIE_ENV_DIR}/postgres.env``)
+
+Application Settings
+~~~~~~~~~~~~~~~~~~~~~
+
+Following settings are used to define values that are employed by ``Magpie`` after loading the `Base Settings`_.
+
+- | ``
+MAGPIE_URL = os.getenv("MAGPIE_URL", None)
+MAGPIE_SECRET = os.getenv("MAGPIE_SECRET", "seekrit")
+MAGPIE_COOKIE_NAME = os.getenv("MAGPIE_COOKIE_NAME", "auth_tkt")
+MAGPIE_COOKIE_EXPIRE = os.getenv("MAGPIE_COOKIE_EXPIRE", None)
+MAGPIE_ADMIN_USER = os.getenv("MAGPIE_ADMIN_USER", "admin")
+MAGPIE_ADMIN_PASSWORD = os.getenv("MAGPIE_ADMIN_PASSWORD", "qwerty")
+MAGPIE_ADMIN_EMAIL = "{}@mail.com".format(MAGPIE_ADMIN_USER)
+MAGPIE_ADMIN_GROUP = os.getenv("MAGPIE_ADMIN_GROUP", "administrators")
+MAGPIE_ANONYMOUS_USER = os.getenv("MAGPIE_ANONYMOUS_USER", "anonymous")
+MAGPIE_ANONYMOUS_PASSWORD = MAGPIE_ANONYMOUS_USER
+MAGPIE_ANONYMOUS_EMAIL = "{}@mail.com".format(MAGPIE_ANONYMOUS_USER)
+MAGPIE_ANONYMOUS_GROUP = MAGPIE_ANONYMOUS_USER  # left for backward compatibility of migration scripts
+MAGPIE_EDITOR_GROUP = os.getenv("MAGPIE_EDITOR_GROUP", "editors")
+MAGPIE_USERS_GROUP = os.getenv("MAGPIE_USERS_GROUP", "users")
+MAGPIE_CRON_LOG = os.getenv("MAGPIE_CRON_LOG", "~/magpie-cron.log")
+MAGPIE_DB_MIGRATION = asbool(os.getenv("MAGPIE_DB_MIGRATION", True))            # run db migration on startup
+MAGPIE_DB_MIGRATION_ATTEMPTS = int(os.getenv("MAGPIE_DB_MIGRATION_ATTEMPTS", 5))
+MAGPIE_LOG_LEVEL = os.getenv("MAGPIE_LOG_LEVEL", _get_default_log_level())      # log level to apply to the loggers
+MAGPIE_LOG_PRINT = asbool(os.getenv("MAGPIE_LOG_PRINT", False))                 # log also forces print to the console
+MAGPIE_LOG_REQUEST = asbool(os.getenv("MAGPIE_LOG_REQUEST", True))              # log detail of every incoming request
+MAGPIE_LOG_EXCEPTION = asbool(os.getenv("MAGPIE_LOG_EXCEPTION", True))          # log detail of generated exceptions
+MAGPIE_UI_ENABLED = asbool(os.getenv("MAGPIE_UI_ENABLED", True))
+PHOENIX_USER = os.getenv("PHOENIX_USER", "phoenix")
+PHOENIX_PASSWORD = os.getenv("PHOENIX_PASSWORD", "qwerty")
+PHOENIX_PORT = int(os.getenv("PHOENIX_PORT", 8443))
+PHOENIX_PUSH = asbool(os.getenv("PHOENIX_PUSH", True))
+TWITCHER_PROTECTED_PATH = os.getenv("TWITCHER_PROTECTED_PATH", "/ows/proxy")
+TWITCHER_PROTECTED_URL = os.getenv("TWITCHER_PROTECTED_URL", None)
+
+Postgres Settings
+~~~~~~~~~~~~~~~~~~~~~
+
+MAGPIE_POSTGRES_USER = os.getenv("MAGPIE_POSTGRES_USER", "magpie")
+MAGPIE_POSTGRES_PASSWORD = os.getenv("MAGPIE_POSTGRES_PASSWORD", "qwerty")
+MAGPIE_POSTGRES_HOST = os.getenv("MAGPIE_POSTGRES_HOST", "postgres")
+MAGPIE_POSTGRES_PORT = int(os.getenv("MAGPIE_POSTGRES_PORT", 5432))
+MAGPIE_POSTGRES_DB = os.getenv("MAGPIE_POSTGRES_DB", "magpie")
+
+# ===========================
+# other constants
+# ===========================
+MAGPIE_ADMIN_PERMISSION = "admin"
+# MAGPIE_ADMIN_PERMISSION = NO_PERMISSION_REQUIRED
+MAGPIE_LOGGED_USER = "current"
+MAGPIE_DEFAULT_PROVIDER = "ziggurat"
+
+# above this length is considered a token,
+# refuse longer username creation
+MAGPIE_USER_NAME_MAX_LENGTH = 64

--- a/CONFIGURATION.rst
+++ b/CONFIGURATION.rst
@@ -168,3 +168,68 @@ MAGPIE_DEFAULT_PROVIDER = "ziggurat"
 # above this length is considered a token,
 # refuse longer username creation
 MAGPIE_USER_NAME_MAX_LENGTH = 64
+
+External Providers
+----------------------
+
+In order to perform authentication in ``Magpie``, multiple external providers are supported. By default, the 'local'
+provider is ``ziggurat`` which corresponds to the package used to manage users, groups, permissions, etc. internally.
+Supported external providers are presented in the table below, although more could be added later on. 
+
+Each as different configuration parameters as defined in `<magpie/security.py>`_ and use various protocols amongst
+``OpenID``, ``ESGF``-flavored ``OpenID`` and ``OAuth2``. Further external providers can be defined using this module's
+dictionary configuration style following parameter specification of `Authomatic`_ package used for managing this
+authentication procedure.
+
++----------------------------------------------------+-----------------------------------------------------------------------+
+| Category                                           | Provider                                                              |
++====================================================+=======================================================================+
+| Open Identity (``OpenID``)                         | `OpenID`_                                                             |
++----------------------------------------------------+-----------------------------------------------------------------------+
+| Earth System Grid Federation (`ESGF`_) :sup:`(1)`  | German Climate Computing Centre (`DKRZ`_)                             |
+|                                                    +-----------------------------------------------------------------------+
+|                                                    | French Research Institute for Environment Science (`IPSL`_)           |
+|                                                    +-----------------------------------------------------------------------+
+|                                                    | British Centre for Environmental Data Analysis (`CEDA`_) :sup:`(2)`   |
+|                                                    +-----------------------------------------------------------------------+
+|                                                    | US Lawrence Livermore National Laboratory (`LLNL`_) :sup:`(3)`        |
+|                                                    +-----------------------------------------------------------------------+
+|                                                    | Swedish Meteorological and Hydrological Institute (`SMHI`_)           |
++----------------------------------------------------+-----------------------------------------------------------------------+
+| ``OAuth2``                                         | `GitHub`_ Authentication                                              |
+|                                                    +-----------------------------------------------------------------------+
+|                                                    | `WSO2`_ Open Source Identity Server                                   |
++----------------------------------------------------+-----------------------------------------------------------------------+
+
+| :sup:`(1)` extended variant of ``OpenID``
+| :sup:`(2)` formerly identified as British Atmospheric Data Centre (`BADC`_)
+| :sup:`(3)` formerly identified as Program for Climate Model Diagnosis & Intercomparison (`PCMDI`_)
+
+| **Note:**
+| Please note that due to the constantly changing nature of multiple of these external providers (APIs and moved 
+  Websites), rarely used authentication bridges by the developers could break without prior notice. If this is the
+  case and you use one of the broken connectors, summit a new `issue <MagpieIssue>`_.
+
+.. _Authomatic: https://authomatic.github.io/authomatic/
+.. _OpenID: https://openid.net/
+.. _ESGF: https://esgf.llnl.gov/
+.. _DKRZ: https://esgf-data.dkrz.de
+.. _IPSL: https://www.ipsl.fr/
+.. _BADC: http://data.ceda.ac.uk/badc
+.. _CEDA: https://esgf-index1.ceda.ac.uk
+.. _LLNL: https://www.llnl.gov/
+.. _PCMDI: https://pcmdi.llnl.gov/?esgcet/home
+.. _SMHI: https://www.smhi.se
+.. _GitHub: https://developer.github.com/v3/#authentication
+.. _WSO2: https://wso2.com/
+.. _MagpieIssues: https://github.com/Ouranosinc/Magpie/issues/new
+
+GitHub Settings
+~~~~~~~~~~~~~~~~~
+
+
+
+WSO2 Settings
+~~~~~~~~~~~~~~~~~
+
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at francis.charette-migneault@crim.ca.
+Report bugs at https://github.com/Ouranosinc/Magpie/issues/new.
 
 If you are reporting a bug, please include:
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ History
 Unreleased
 ---------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+- add ``CONFIGURATION.rst`` file that details all configuration settings that are employed by ``Magpie``.
+- add specific exception classes for `register` sub-package operations.
+
 1.6.3 (2019-10-31)
 ---------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,8 +8,11 @@ Unreleased
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-- add ``CONFIGURATION.rst`` file that details all configuration settings that are employed by ``Magpie``.
-- add specific exception classes for `register` sub-package operations.
+- add ``docs/configuration.rst`` file that details all configuration settings that are employed by ``Magpie`` (#180).
+- add more details about basic usage of `Magpie` in ``docs/usage.rst``.
+- add details about external provider setup in ``docs/configuration`` (#173).
+- add specific exception classes for ``register`` sub-package operations.
+- add ``PHOENIX_HOST`` variable to override default ``HOSTNAME``as needed.
 
 1.6.3 (2019-10-31)
 ---------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ Features / Changes
 - add ``PHOENIX_HOST`` variable to override default ``HOSTNAME`` as needed.
 - add support of ``MAGPIE_PROVIDERS_CONFIG_PATH`` and ``MAGPIE_PERMISSIONS_CONFIG_PATH`` pointing to a directory to
   load multiple similar configuration files contained in it.
+- add environment variable expansion support for all fields within ``providers.cfg`` and ``permissions.cfg`` files.
 
 1.6.3 (2019-10-31)
 ---------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,9 @@ Features / Changes
 - add more details about basic usage of `Magpie` in ``docs/usage.rst``.
 - add details about external provider setup in ``docs/configuration`` (#173).
 - add specific exception classes for ``register`` sub-package operations.
-- add ``PHOENIX_HOST`` variable to override default ``HOSTNAME``as needed.
+- add ``PHOENIX_HOST`` variable to override default ``HOSTNAME`` as needed.
+- add support of ``MAGPIE_PROVIDERS_CONFIG_PATH`` and ``MAGPIE_PERMISSIONS_CONFIG_PATH`` pointing to a directory to
+  load multiple similar configuration files contained in it.
 
 1.6.3 (2019-10-31)
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -71,23 +71,32 @@ Documentation
 
 The REST API documentation is auto-generated and served under ``{HOSTNAME}/api/`` using Swagger-UI with tag ``latest``.
 
-More ample details about installation, configuration and usage are provided in `<docs>`_.
+More ample details about installation, configuration and usage are provided in `docs`_.
+
+.. _docs: ./docs
 
 Configuration
 =============
 
 | Multiple configuration options exist for ``Magpie`` application.
-| Please refer to `configuration <docs/configuration.rst>`_ for details.
+| Please refer to `configuration`_ for details.
+
+.. _configuration: ./docs/configuration.rst
+
 
 Usage
 =====
 
-See `usage <docs/usage.rst>`_ for details.
+See `usage`_ for details.
+
+.. _usage: ./docs/usage.rst
 
 Change History
 ==============
 
-Addressed features, changes and bug fixes per version tag are available in `<HISTORY.rst>`_.
+Addressed features, changes and bug fixes per version tag are available in `HISTORY`_.
+
+.. _HISTORY: ./HISTORY.rst
 
 Docker Images
 =============

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,25 @@ At the command line::
     pip install magpie
 
 
+Configuration
+=============
+
+| Multiple configuration options exist for ``Magpie`` application.
+| Please refer to `<CONFIGURATION.rst>`_ for details.
+
+Change History
+==============
+
+Addressed features, changes and bug fixes per version tag are available in `<HISTORY.rst>`_.
+
+Helpers
+==============
+
+Multiple CLI *helpers* are provided in `<magpie/helpers>`_. These consist mostly of setup operation scripts that are
+automatically executed during ``Magpie`` startup. Additional common functions are also provided such as registering
+service providers from a configuration file or creating basic user accounts. Please refer to their corresponding usage
+by calling them with ``--help`` argument for more details.
+
 Docker Images
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -66,48 +66,28 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
 .. end-badges
 
 
-REST API Documentation
-======================
-
-The documentation is auto-generated and served under ``{HOSTNAME}/api/`` using Swagger-UI with tag ``latest``.
-
-
-Build package
+Documentation
 =============
 
-At the command line::
+The REST API documentation is auto-generated and served under ``{HOSTNAME}/api/`` using Swagger-UI with tag ``latest``.
 
-    conda create -n magpie
-    source activate magpie
-    make install
-
-
-Installation
-============
-
-At the command line::
-
-    pip install magpie
-
+More ample details about installation, configuration and usage are provided in `<docs>`_.
 
 Configuration
 =============
 
 | Multiple configuration options exist for ``Magpie`` application.
-| Please refer to `<CONFIGURATION.rst>`_ for details.
+| Please refer to `configuration <docs/configuration.rst>`_ for details.
+
+Usage
+=====
+
+See `usage <docs/usage.rst>`_ for details.
 
 Change History
 ==============
 
 Addressed features, changes and bug fixes per version tag are available in `<HISTORY.rst>`_.
-
-Helpers
-==============
-
-Multiple CLI *helpers* are provided in `<magpie/helpers>`_. These consist mostly of setup operation scripts that are
-automatically executed during ``Magpie`` startup. Additional common functions are also provided such as registering
-service providers from a configuration file or creating basic user accounts. Please refer to their corresponding usage
-by calling them with ``--help`` argument for more details.
 
 Docker Images
 =============

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
 Documentation
 =============
 
-The REST API documentation is auto-generated and served under ``{HOSTNAME}/api/`` using Swagger-UI with tag ``latest``.
+The REST API documentation is auto-generated and served under ``{MAGPIE_URL}/api/`` using Swagger-UI with tag ``latest``.
 
 More ample details about installation, configuration and usage are provided in `docs`_.
 

--- a/config/permissions.cfg
+++ b/config/permissions.cfg
@@ -22,6 +22,7 @@
 #   - unknown actions are ignored and corresponding permission are not updated, unspecified action resolves to 'create'.
 #   - already satisfied permission configurations are left as is
 #     (ie: existing permission to create or non-existing permission to remove are passed)
+#   - environment variables (formatted as `$name` or `${name}`) are expanded if they are matched in the environment.
 #
 permissions:
   - service: api

--- a/config/permissions.cfg
+++ b/config/permissions.cfg
@@ -1,8 +1,17 @@
+# Creates Magpie services/resource permissions with specified configuration values on application startup.
+#
+#   This configuration is parsed after 'providers.cfg' (if found) to allow referencing existing service definitions.
+#
+#   - Default location is 'magpie/config/permissions.cfg'.
+#   - Directory location can be overridden with 'MAGPIE_CONFIG_DIR' (using filename 'permissions.cfg')
+#     or can be explicitly overridden with 'MAGPIE_PERMISSIONS_CONFIG_PATH' pointing to a valid file.
+#   - If 'MAGPIE_PERMISSIONS_CONFIG_PATH' points to an existing directory, the application will attempt
+#     to process all '.cfg' files found under it one-by-one as separate 'permissions' configurations.
 #
 # Parameters:
 #   service:              service name to receive the permission (directly on it if no 'resource' mentioned, must exist)
 #   resource (optional):  tree path of the service's resource (ex: /res1/sub-res2/sub-sub-res3)
-#   user and/or group:    user/group for which to apply the permission(create if missing, see below)
+#   user and/or group:    user/group for which to apply the permission (create if missing, see below)
 #   permission:           name of the permission to be applied (see 'magpie/permissions.py' for supported values)
 #   action:               one of [create, remove] (default: create)
 #
@@ -11,9 +20,9 @@
 #   - create missing user/group if required (default user created: (group: anonymous, password: 12345).
 #   - applicable service, user or group is missing, corresponding permissions are ignored and not updated.
 #   - unknown actions are ignored and corresponding permission are not updated, unspecified action resolves to 'create'.
-#   - already satisfied permission configurations are left as is.
+#   - already satisfied permission configurations are left as is
+#     (ie: existing permission to create or non-existing permission to remove are passed)
 #
-
 permissions:
   - service: api
     resource: /api

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -18,10 +18,9 @@
 #   - create missing service with specified parameters.
 #   - skip already existing services matched by name and 'url'.
 #   - services matched by name but with different 'url' value are updated with the new value.
-#   -
 #   - update of other parameters not supported.
 #   - removal of service not supported (must be done manually).
-#   - variables specified in 'url' are expanded if they are specified in the environment.
+#   - environment variables (formatted as `$name` or `${name}`) are expanded if they are matched in the environment.
 #
 providers:
   catalog:

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -12,7 +12,9 @@
 #   public:     parameter passed down to Phoenix for service registration
 #   c4i:        parameter passed down to Phoenix for service registration
 #   type:       service type to use for creation, must be one of the known Magpie service types
+#               (see: magpie.services.SERVICE_TYPE_DICT)
 #   sync_type:  service synchronization type, must be one of the known Magpie service sync-types (often equals to 'type')
+#               (see: magpie.helpers.SYNC_SERVICES_TYPES)
 #
 # Default behaviour:
 #   - create missing service with specified parameters.

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -1,3 +1,28 @@
+# Creates Magpie services with specified configuration values on application startup.
+#
+#   - Default location is 'magpie/config/providers.cfg'.
+#   - Directory location can be overridden with 'MAGPIE_CONFIG_DIR' (using filename 'providers.cfg')
+#     or can be explicitly overridden with 'MAGPIE_PROVIDERS_CONFIG_PATH' pointing to a valid file.
+#   - If 'MAGPIE_PROVIDERS_CONFIG_PATH' points to an existing directory, the application will attempt
+#     to process all '.cfg' files found under it one-by-one as separate 'providers' configurations.
+#
+# Parameters
+#   url:        private URL of the service to be created
+#   title:      pretty name of the service (real name is the section key)
+#   public:     parameter passed down to Phoenix for service registration
+#   c4i:        parameter passed down to Phoenix for service registration
+#   type:       service type to use for creation, must be one of the known Magpie service types
+#   sync_type:  service synchronization type, must be one of the known Magpie service sync-types (often equals to 'type')
+#
+# Default behaviour:
+#   - create missing service with specified parameters.
+#   - skip already existing services matched by name and 'url'.
+#   - services matched by name but with different 'url' value are updated with the new value.
+#   -
+#   - update of other parameters not supported.
+#   - removal of service not supported (must be done manually).
+#   - variables specified in 'url' are expanded if they are specified in the environment.
+#
 providers:
   catalog:
     url: http://${HOSTNAME}:8086/pywps

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'nature'
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,7 +142,8 @@ html_theme = 'nature'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/logo_crim_FR.png'
+## html_logo = '_static/logo_crim_FR.png'
+html_logo = '../magpie/ui/home/static/magpie-logo.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ extensions = [
     'autoapi.extension',
 ]
 
-autoapi_dirs = [os.path.join(PROJECT_ROOT, 'magpie')]
+autoapi_dirs = [os.path.join(PROJECT_ROOT, __meta__.__package__)]
 autoapi_ignore = [os.path.join(PROJECT_ROOT, 'magpie/alembic/*')]
 autoapi_python_class_content = 'both'
 
@@ -67,7 +67,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Magpie'
+project = __meta__.__title__
 copyright = u'2017, {}'.format(__meta__.__author__)
 
 # The version info for the project you're documenting, acts as replacement
@@ -142,7 +142,7 @@ html_theme = 'nature'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-## html_logo = '_static/logo_crim_FR.png'
+# html_logo = '_static/logo_crim_FR.png'
 html_logo = '../magpie/ui/home/static/magpie-logo.png'
 
 # The name of an image file (within the static path) to use as favicon of the
@@ -218,13 +218,13 @@ latex_elements = {
     # 'preamble': '',
 }
 
+doc_title = "{} Documentation".format(__meta__.__title__)
+
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ('index', 'magpie.tex',
-     u'Magpie Documentation',
-     __meta__.__author__, 'manual'),
+    ('index', '{}.tex'.format(__meta__.__package__), doc_title, __meta__.__author__, 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at
@@ -253,9 +253,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'magpie',
-     u'Magpie Documentation',
-     [u'Francois-Xavier'], 1)
+    ('index', __meta__.__package__, doc_title, [__meta__.__author__], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -268,11 +266,11 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    ('index', 'magpie',
-     u'Magpie Documentation',
-     u'Francois-Xavier',
-     'magpie',
-     'One line description of project.',
+    ('index', __meta__.__package__,
+     doc_title,
+     __meta__.__author__,
+     __meta__.__package__,
+     __meta__.__description__,
      'Miscellaneous'),
 ]
 
@@ -290,8 +288,11 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     'celery': ('http://docs.celeryproject.org/en/latest/', None),
-    'refcom_gateway': ('http://www.crim.ca/perso/frederic.osterrath/refcom/gateway/latest/',
-          ('../../refcom_gateway/docs/_build/html/objects.inv', None)),
-    'sg': ('http://www.crim.ca/perso/frederic.osterrath/refcom/SG/latest/',
-          ('../../SG/docs/_build/html/objects.inv', None))
-    }
+    'refcom_gateway': (
+        'http://www.crim.ca/perso/frederic.osterrath/refcom/gateway/latest/',
+        ('../../refcom_gateway/docs/_build/html/objects.inv', None)
+    ),
+    'sg': (
+        'http://www.crim.ca/perso/frederic.osterrath/refcom/SG/latest/',
+        ('../../SG/docs/_build/html/objects.inv', None))
+}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,7 +16,7 @@ duplicates values.
 Configuration Files
 -------------------
 
-magpie.ini
+File: magpie.ini
 ~~~~~~~~~~~~~~~~~~~
 
 This is the base configuration file that defines most of `Magpie`'s lower level configuration. A basic example is
@@ -25,16 +25,27 @@ is used by default in each tagged Docker image. If you want to provide different
 overridden in the Docker image using a volume mount parameter, or by specifying an alternative path through the
 environment variable ``MAGPIE_INI_FILE_PATH``.
 
-providers.cfg
+File: providers.cfg
 ~~~~~~~~~~~~~~~~~~~
 
+This configuration file allows automatically registering service definitions in `Magpie` at startup. When the
+application starts, it will look for corresponding services and add them to the database as required. It will also
+look for mismatches between the service name and URL with the corresponding entry in the database to update it to
+the desired URL. See ``MAGPIE_PROVIDERS_CONFIG_PATH`` below to setup alternate references to this configuration file.
+Please refer to the heading of sample file `providers.cfg`_ for specific format and parameter details.
 
-permissions.cfg
-~~~~~~~~~~~~~~~~~~~
+File: permissions.cfg
+~~~~~~~~~~~~~~~~~~~~~~
 
+This configuration file allows automatically registering or cleaning permission definitions in `Magpie` at startup.
+Each specified permission update operation is applied for the corresponding user or group onto the specific service
+or resource. This file is processed after `providers.cfg`_ in order to allow permissions to be applied on freshly
+registered services. Furthermore, sub-resources are automatically created if they can be resolved with provided
+parameters of the corresponding permission entry. See ``MAGPIE_PERMISSIONS_CONFIG_PATH`` below to setup alternate
+references to this configuration file. Please refer to the heading of sample file `permissions.cfg`_ for specific
+format details as well as specific behaviour of each parameter according to encountered use cases.
 
-
-magpie.env
+File: magpie.env
 ~~~~~~~~~~~~~~~~~~~
 
 By default, `Magpie` will try to load a ``magpie.env`` file which can define further environment variable definitions
@@ -53,7 +64,7 @@ Therefore, only *missing but required* values will be added to the environment t
 
 .. _magpie.env.example: ../env/magpie.env.example
 
-postgres.env
+File: postgres.env
 ~~~~~~~~~~~~~~~~~~~
 
 This file behaves exactly in the same manner as for ``magpie.env`` above, but for specific variables definition

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -63,8 +63,8 @@ Settings and Constants
 Environment variables can be used to define all following settings (unless mentioned otherwise with 'constant').
 These values will be used by `Magpie` on startup unless prior definition is found within `magpie.ini <MagpieCfgINI>`_.
 
-Base Settings
-~~~~~~~~~~~~~
+Loading Settings
+~~~~~~~~~~~~~~~~~
 
 These settings can be used to specify where to find other settings through custom configuration files.
 
@@ -124,45 +124,165 @@ These settings can be used to specify where to find other settings through custo
 Application Settings
 ~~~~~~~~~~~~~~~~~~~~~
 
-Following settings are used to define values that are employed by `Magpie` after loading the `Base Settings`_.
+Following settings are used to define values that are employed by `Magpie` after loading the `Loading Settings`_.
 
-- | ``
-MAGPIE_URL = os.getenv("MAGPIE_URL", None)
-MAGPIE_SECRET = os.getenv("MAGPIE_SECRET", "seekrit")
-MAGPIE_COOKIE_NAME = os.getenv("MAGPIE_COOKIE_NAME", "auth_tkt")
-MAGPIE_COOKIE_EXPIRE = os.getenv("MAGPIE_COOKIE_EXPIRE", None)
-MAGPIE_ADMIN_USER = os.getenv("MAGPIE_ADMIN_USER", "admin")
-MAGPIE_ADMIN_PASSWORD = os.getenv("MAGPIE_ADMIN_PASSWORD", "qwerty")
-MAGPIE_ADMIN_EMAIL = "{}@mail.com".format(MAGPIE_ADMIN_USER)
-MAGPIE_ADMIN_GROUP = os.getenv("MAGPIE_ADMIN_GROUP", "administrators")
-MAGPIE_ANONYMOUS_USER = os.getenv("MAGPIE_ANONYMOUS_USER", "anonymous")
-MAGPIE_ANONYMOUS_PASSWORD = MAGPIE_ANONYMOUS_USER
-MAGPIE_ANONYMOUS_EMAIL = "{}@mail.com".format(MAGPIE_ANONYMOUS_USER)
-MAGPIE_ANONYMOUS_GROUP = MAGPIE_ANONYMOUS_USER  # left for backward compatibility of migration scripts
-MAGPIE_EDITOR_GROUP = os.getenv("MAGPIE_EDITOR_GROUP", "editors")
-MAGPIE_USERS_GROUP = os.getenv("MAGPIE_USERS_GROUP", "users")
-MAGPIE_CRON_LOG = os.getenv("MAGPIE_CRON_LOG", "~/magpie-cron.log")
-MAGPIE_DB_MIGRATION = asbool(os.getenv("MAGPIE_DB_MIGRATION", True))            # run db migration on startup
-MAGPIE_DB_MIGRATION_ATTEMPTS = int(os.getenv("MAGPIE_DB_MIGRATION_ATTEMPTS", 5))
-MAGPIE_LOG_LEVEL = os.getenv("MAGPIE_LOG_LEVEL", _get_default_log_level())      # log level to apply to the loggers
-MAGPIE_LOG_PRINT = asbool(os.getenv("MAGPIE_LOG_PRINT", False))                 # log also forces print to the console
-MAGPIE_LOG_REQUEST = asbool(os.getenv("MAGPIE_LOG_REQUEST", True))              # log detail of every incoming request
-MAGPIE_LOG_EXCEPTION = asbool(os.getenv("MAGPIE_LOG_EXCEPTION", True))          # log detail of generated exceptions
-MAGPIE_UI_ENABLED = asbool(os.getenv("MAGPIE_UI_ENABLED", True))
+- | ``MAGPIE_URL``
+  | Full hostname URL to use so that `Magpie` can resolve his own running instance location.
+  | **Note:**
+  | If the value is not set, `Magpie` will attempt to retrieve this critical information through other variables such
+    as ``MAGPIE_HOST``, ``MAGPIE_PORT``, ``MAGPIE_SCHEME`` and ``HOSTNAME``. Modifying any of these variables
+    partially is permitted but will force `Magpie` to attempt building the full URL as best as possible from the
+    individual parts. The result of these parts (potential using corresponding defaults) will have the following format:
+    ``"${MAGPIE_SCHEME}//:${MAGPIE_HOST}:${MAGPIE_PORT}"``.
+  | (Default: ``"http://localhost:2001"``)
+
+- | ``MAGPIE_SCHEME``
+  | Protocol scheme URL part of `Magpie` application to rebuild the full ``MAGPIE_URL``.
+  | (Default: ``"http"``)
+
+- | ``MAGPIE_HOST``
+  | Domain host URL part of `Magpie` application to rebuild the full ``MAGPIE_URL``.
+  | (Default: ``"localhost"``)
+
+- | ``MAGPIE_PORT``
+  | Port URL part of `Magpie` application to rebuild the full ``MAGPIE_URL``.
+  | (Default: ``2001``)
+
+- | ``MAGPIE_SECRET``
+  | Port URL part of `Magpie` application to rebuild the full ``MAGPIE_URL``.
+  | (Default: ``2001``)
+
+- | ``MAGPIE_CRON_LOG``
+  | Path that the ``cron`` operation should use for logging.
+  | (Default: ``"~/magpie-cron.log"``)
+
+- | ``MAGPIE_DB_MIGRATION``
+  | Run database migration on startup in order to bring it up to date using ``alembic``.
+  | (Default: ``True``)
+
+- | ``MAGPIE_DB_MIGRATION_ATTEMPTS``
+  | Number of attempts to re-run database migration on startup in cased it failed (eg: due to connection error).
+  | (Default: ``5``)
+
+- | ``MAGPIE_LOG_LEVEL``
+  | Logging level of operations. `Magpie` will first use the complete logging configuration found in
+    `magpie.ini <MagpieCfgINI>`_ in order to define logging formatters and handler referencing to the ``logger_magpie``
+    section. If this configuration fails, this variable is used instead to prepare a basic logger.
+  | (Default: ``INFO``)
+
+- | ``MAGPIE_LOG_LEVEL``
+  | Specifies whether `Magpie` logging should also enforce printing the details to the console when using *helpers*.
+    Otherwise, the configured logging methodology in `magpie.ini <MagpieCfgINI>`_ is used (which can also define a
+    console handler).
+  | (Default: ``False``)
+
+- | ``MAGPIE_LOG_REQUEST``
+  | Specifies whether `Magpie` should log incoming request details.
+  | **Note:**
+  | This can make `Magpie` quite verbose if large quantity of requests are accomplished.
+  | (Default: ``True``)
+
+- | ``MAGPIE_LOG_EXCEPTION``
+  | Specifies whether `Magpie` should log a raised exception during a process execution.
+  | (Default: ``True``)
+
+- | ``MAGPIE_UI_ENABLED``
+  | Specifies whether `Magpie` graphical user interface should be available with the started instance. If disabled,
+    all routes that normally refer to the UI will return ``404``, except the frontpage that will return a simple JSON
+    description as it is normally the default entrypoint of the application.
+  | (Default: ``True``)
 
 
+Security Settings
+~~~~~~~~~~~~~~~~~~~~~
+
+- | ``MAGPIE_SECRET``
+  | Secret value employed to encrypt user authentication tokens.
+  | **Important Note:**
+  | Changing this value at a later time will cause previously created user tokens to be invalidated.
+    It is **strongly** recommended to change this value before proceeding to user accounts and permissions creation
+    in your `Magpie` instance.
+  | (Default: ``"seekrit"``)
+
+- | ``MAGPIE_COOKIE_NAME``
+  | Identifier of the cookie that will be used for reading and writing in the requests from login and for
+    user authentication operations.
+  | (Default: ``"auth_tkt"``)
+
+- | ``MAGPIE_COOKIE_EXPIRE``
+  | Lifetime duration of the cookies. Tokens become invalid after this duration is elapsed.
+  | (Default: ``None`` [infinite])
+
+- | ``MAGPIE_ADMIN_USER``
+  | Name of the default 'administrator' generated by the application.
+  | **Note:**
+  | This user is required for initial launch of the application to avoid being 'looked out' as routes for creating new
+    users require administrative permissions and access rights. It should be used as a first login method to setup other
+    accounts. It will also be used by other `Magpie` internal operations such as service synchronization and setup
+    during the application startup. If this user is missing, it is automatically re-created on following start.
+  | (Default: ``"admin"``)
+
+- | ``MAGPIE_ADMIN_PASSWORD``
+  | Password of the default 'administrator' generated by the application.
+  | (Default: ``"qwerty"``)
+
+- | ``MAGPIE_ADMIN_EMAIL``
+  | Email of the default 'administrator' generated by the application.
+  | (Default: ``"${MAGPIE_ADMIN_USER}@mail.com"``)
+
+- | ``MAGPIE_ADMIN_GROUP``
+  | Group name of the default 'administrator' generated by the application.
+  | **Note:**
+  | To simplify configuration of future administrators of the application, all their inherited permissions are shared
+    through this group instead of setting individual permissions on each user. It is recommended to keep defining such
+    higher level permissions on this group to ease the management process of granted access to all their members.
+  | (Default: ``"administrators"``)
+
+- | ``MAGPIE_ADMIN_PERMISSION``
+  | Name of the permission used to represent highest administration privilege in the application.
+  | Except for some public routes, most API and UI paths will require the user to have this permission (either with
+    direct permission or by inherited group permission) to be granted access to view and edit content.
+    The group defined by ``MAGPIE_ADMIN_GROUP`` automatically gets granted this permission.
+  | (Default: ``"admin"``)
+
+- | ``MAGPIE_ANONYMOUS_USER``
+  | Name of the default user that represents a non logged-in user (ie: invalid or no authentication token provided).
+  | This user is used to manage "public" access to service and resources.
+  | (Default: ``"anonymous"``)
+
+- | ``MAGPIE_ANONYMOUS_PASSWORD`` (constant)
+  | Password of the default unauthenticated user.
+  | This value is not modifiable directly and is available only for preparation of the default user on startup.
+  | (Default: ``${MAGPIE_ANONYMOUS_USER}``)
+
+- | ``MAGPIE_ANONYMOUS_EMAIL``
+  | Email of the default unauthenticated user.
+  | (Default: ``"${MAGPIE_ANONYMOUS_USER}@mail.com"``)
+
+- | ``MAGPIE_ANONYMOUS_GROUP`` (constant)
+  | This parameter is preserved for backward compatibility of migration scripts and external libraries.
+  | All users are automatically member of this group to inherit "public" permissions to services and resources.
+  | **Important Note:**
+  | To set "public" permissions, one should always set them on this group instead of directly on
+    ``MAGPIE_ANONYMOUS_USER`` as setting them directly on this user will cause only him to be granted access to the
+    targeted resource. In this situation, all *other* users would "lose" public permissions after they authenticate
+    themselves in `Magpie` as they would not be recognized as ``MAGPIE_ANONYMOUS_USER`` anymore.
+  | (Default: ``${MAGPIE_ANONYMOUS_USER}``)
+
+- | ``MAGPIE_EDITOR_GROUP``
+  | *Unused for the moment.*
+  | (Default: ``"editors"``)
+
+- | ``MAGPIE_USERS_GROUP``
+  | Name of the default group created to associate all users registered in the application.
+  | New users are created with this group.
+  | (Default: ``"users"``)
 
 - | ``MAGPIE_USER_NAME_MAX_LENGTH``
   | Maximum length to consider as a valid user name. User name specified during creation will be forbidden if longer.
   | **Note:**
   | This value should not be greater then the token length used to identify a user to preserve some utility behaviour.
   | (Default: ``64``)
-
-- | ``MAGPIE_ADMIN_PERMISSION``
-  | Name of the permission used to represent highest administration privilege in the application.
-  | Except for some public routes, most API and UI paths will require the user to have this permission (either with
-    direct permission or by inherited group permission) to be granted access to view and edit content.
-  | (Default: ``"admin"``)
 
 - | ``MAGPIE_LOGGED_USER``
   | Keyword used to define route resolution using the currently logged in user. This value allows, for example,
@@ -196,16 +316,16 @@ Following settings provide some integration support for `Phoenix`_ in order to s
   | Password of the user to use for authentication in `Phoenix`_.
   | (Default: ``"qwerty"``)
 
+- | ``PHOENIX_HOST``
+  | Hostname to use for `Phoenix`_ connection for authentication and service synchronization.
+  | (Default: ``${HOSTNAME}"``)
+
 - | ``PHOENIX_PORT``
-  | Password of the user to use for authentication in `Phoenix`_.
-  | (Default: ``"qwerty"``)
-
-- | ``PHOENIX_PASSWORD``
-  | Password of the user to use for authentication in `Phoenix`_.
-  | (Default: ``"qwerty"``)
+  | Port to use for `Phoenix`_ connection for authentication and service synchronization.
+  | (Default: ``8443``)
 
 
-PHOENIX_PORT = int(os.getenv("PHOENIX_PORT", 8443))
+
 PHOENIX_PUSH = asbool(os.getenv("PHOENIX_PUSH", True))
 TWITCHER_PROTECTED_PATH = os.getenv("TWITCHER_PROTECTED_PATH", "/ows/proxy")
 TWITCHER_PROTECTED_URL = os.getenv("TWITCHER_PROTECTED_URL", None)
@@ -282,6 +402,9 @@ GitHub Settings
 To use `GitHub`_ authentication provider, variables ``GITHUB_CLIENT_ID`` and ``GITHUB_CLIENT_SECRET`` must be
 configured. These settings correspond to the values retrieved from following steps described in
 `Creating an OAuth App <GithubOAuthApp>`_.
+
+Furthermore, the callback URL used for configuring the OAuth application on Github must match the running `Magpie`
+instance URL. For this reason, the values of ``MAGPIE_URL``, ``MAGPIE_HOST`` and ``HOSTNAME`` must be considered.
 
 .. _GithubOAuthApp: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,14 +1,15 @@
 Configuration
 =============
 
-At startup, ``Magpie`` application will load multiple configuration files to define various behaviours or setup
+At startup, `Magpie` application will load multiple configuration files to define various behaviours or setup
 operations. These are defined though the following configuration settings presented below.
 
-All generic ``Magpie`` configuration settings can be defined through either the `<config/magpie.ini>`_ file or
-environment variables. Values defined in `<config/magpie.ini>`_ are expected to follow the ``magpie.[variable_name]``
-format, and corresponding ``MAGPIE_[VARIABLE_NAME]`` format is used for environment variables. Both of these
-alternatives match the constants defined in `<magpie/constants.py>`_ and can be used interchangeably. Order of
-resolution will prioritize setting values over environment variables in case of matching duplicates values.
+All generic `Magpie` configuration settings can be defined through either the `magpie.ini <MagpieCfgINI>`_ file
+or environment variables. Values defined in `magpie.ini <MagpieCfgINI>`_ are expected to follow the 
+``magpie.[variable_name]`` format, and corresponding ``MAGPIE_[VARIABLE_NAME]`` format is used for environment 
+variables. Both of these alternatives match the constants defined in `<../magpie/constants.py>`_ and can be used 
+interchangeably. Order of resolution will prioritize setting values over environment variables in case of matching
+duplicates values.
 
 Configuration Files
 -------------------
@@ -16,8 +17,8 @@ Configuration Files
 magpie.ini
 ~~~~~~~~~~~~~~~~~~~
 
-This is the base configuration file that defines most of ``Magpie``'s lower level configuration. A basic example is
-provided in `<config/magpie.ini>`_ which should allow any user to run the application locally. Furthermore, this file
+This is the base configuration file that defines most of `Magpie`'s lower level configuration. A basic example is
+provided in `magpie.ini <MagpieCfgINI>`_ which should allow any user to run the application locally. Furthermore, this file
 is used by default in each tagged Docker image. If you want to provide different configuration, the file should be
 overridden in the Docker image using a volume mount parameter, or by specifying an alternative path through the
 environment variable ``MAGPIE_INI_FILE_PATH``.
@@ -34,32 +35,33 @@ permissions.cfg
 magpie.env
 ~~~~~~~~~~~~~~~~~~~
 
-By default, ``Magpie`` will try to load a ``magpie.env`` file which can define further environment variable definitions
+By default, `Magpie` will try to load a ``magpie.env`` file which can define further environment variable definitions
 used to setup the application (see ``MAGPIE_ENV_FILE`` setting further below). An example of expected format and common
-variables for this file is presented in `<env/magpie.env.example>`_.
+variables for this file is presented in `<../env/magpie.env.example>`_.
 
 **Important Notes:**
 
 If ``magpie.env`` cannot be found (using setting ``MAGPIE_ENV_FILE``) but ``magpie.env.example`` is available
 (after resolving any previously set ``MAGPIE_ENV_DIR`` variable), this example file will be used to make a copy
 saved as ``magpie.env`` and will be used as the base ``.env`` file to load its contained environment variables.
-This behaviour is intended to reduce initial configuration and preparation of  ``Magpie`` for a new user.
+This behaviour is intended to reduce initial configuration and preparation of  `Magpie` for a new user.
 
 When loading variables from the ``.env`` file, any conflicting environment variable will **NOT** be overridden.
-Therefore, only *missing but required* values will be added to the environment to ensure proper setup of ``Magpie``.
+Therefore, only *missing but required* values will be added to the environment to ensure proper setup of `Magpie`.
 
 postgres.env
 ~~~~~~~~~~~~~~~~~~~
 
 This file behaves exactly in the same manner as for ``magpie.env`` above, but for specific variables definition
 employed to setup the `postgres` database connection (see ``MAGPIE_POSTGRES_ENV_FILE`` setting below).
-File `<env/postgres.env.example>`_ and auto-resolution of missing ``postgres.env`` is identical to ``magpie.env`` case.
+File `<../env/postgres.env.example>`_ and auto-resolution of missing ``postgres.env`` is identical to ``magpie.env``
+case.
 
 Settings and Constants
 ----------------------
 
 Environment variables can be used to define all following settings (unless mentioned otherwise with 'constant').
-These values will be used by ``Magpie`` on startup unless prior definition is found within `<config/magpie.ini>`_.
+These values will be used by `Magpie` on startup unless prior definition is found within `magpie.ini <MagpieCfgINI>`_.
 
 Base Settings
 ~~~~~~~~~~~~~
@@ -67,10 +69,10 @@ Base Settings
 These settings can be used to specify where to find other settings through custom configuration files.
 
 - | ``MAGPIE_MODULE_DIR`` (constant)
-  | Path to the top level ``Magpie`` module (ie: source code).
+  | Path to the top level `Magpie` module (ie: source code).
 
 - | ``MAGPIE_ROOT`` (constant)
-  | Path to the containing directory of ``Magpie``. This corresponds to the directory where the repository was cloned
+  | Path to the containing directory of `Magpie`. This corresponds to the directory where the repository was cloned
     or where the package was installed.
 
 - | ``MAGPIE_CONFIG_DIR``
@@ -80,28 +82,29 @@ These settings can be used to specify where to find other settings through custo
 - | ``MAGPIE_PROVIDERS_CONFIG_PATH``
   | Path where to find ``providers.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
     be considered as `providers` files and will be loaded sequentially. \
-    Please refer to `<config/providers.cfg>`_ for specific format details.
+    Please refer to `providers.cfg <MagpieCfgProvs>`_ for specific format details.
   | (Default: ``${MAGPIE_CONFIG_DIR}/providers.cfg``)
 
 - | ``MAGPIE_PERMISSIONS_CONFIG_PATH``
   | Path where to find ``permissions.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
     be considered as `permissions` files and will be loaded sequentially. \
-    Please refer to `<config/permissions.cfg>`_ for specific format details.
+    Please refer to `permissions.cfg <MagpieCfgPerms>`_ for specific format details.
   | (default: ``${MAGPIE_CONFIG_DIR}/permissions.cfg``)
 
 - | ``MAGPIE_INI_FILE_PATH``
-  | Specifies where to find the initialization file to run ``Magpie`` application.
-  | **Note**: this variable ignores the setting/env-var resolution order since settings cannot be defined without
-              firstly loading the file referenced by its value.
+  | Specifies where to find the initialization file to run `Magpie` application.
+  | **Note**:
+  | This variable ignores the setting/env-var resolution order since settings cannot be defined without
+    firstly loading the file referenced by its value.
 
 - | ``MAGPIE_ALEMBIC_INI_FILE_PATH``
   | Path to ``.ini`` file which defines an ``[alembic]`` section specifying details on how to execute database
     migration operations.
-  | (Default: ``${MAGPIE_INI_FILE_PATH}``) [section defined within `<config/magpie.ini>`_]
+  | (Default: ``${MAGPIE_INI_FILE_PATH}``) [section defined within `magpie.ini <MagpieCfgINI>`_]
 
 - | ``MAGPIE_ENV_DIR``
   | Directory path where to look for ``.env`` files. This variable can be useful to load specific test environment
-    configurations or to specify a local path while the actual ``Magpie`` code is located in a Python `site-packages`
+    configurations or to specify a local path while the actual `Magpie` code is located in a Python `site-packages`
     directory (``.env`` files are not installed to avoid hard-to-resolve settings loaded from an install location).
   | (Default: ``${MAGPIE_ROOT}/env``)
 
@@ -113,10 +116,15 @@ These settings can be used to specify where to find other settings through custo
   | File path to ``postgres.env`` file with additional environment variables to configure the `postgres` connection.
   | (Default: ``${MAGPIE_ENV_DIR}/postgres.env``)
 
+
+.. _MagpieCfgINI: ../config/magpie.ini
+.. _MagpieCfgPerms: ../config/permissions.cfg
+.. _MagpieCfgProvs: ../config/permissions.cfg
+
 Application Settings
 ~~~~~~~~~~~~~~~~~~~~~
 
-Following settings are used to define values that are employed by ``Magpie`` after loading the `Base Settings`_.
+Following settings are used to define values that are employed by `Magpie` after loading the `Base Settings`_.
 
 - | ``
 MAGPIE_URL = os.getenv("MAGPIE_URL", None)
@@ -141,12 +149,68 @@ MAGPIE_LOG_PRINT = asbool(os.getenv("MAGPIE_LOG_PRINT", False))                 
 MAGPIE_LOG_REQUEST = asbool(os.getenv("MAGPIE_LOG_REQUEST", True))              # log detail of every incoming request
 MAGPIE_LOG_EXCEPTION = asbool(os.getenv("MAGPIE_LOG_EXCEPTION", True))          # log detail of generated exceptions
 MAGPIE_UI_ENABLED = asbool(os.getenv("MAGPIE_UI_ENABLED", True))
-PHOENIX_USER = os.getenv("PHOENIX_USER", "phoenix")
-PHOENIX_PASSWORD = os.getenv("PHOENIX_PASSWORD", "qwerty")
+
+
+
+- | ``MAGPIE_USER_NAME_MAX_LENGTH``
+  | Maximum length to consider as a valid user name. User name specified during creation will be forbidden if longer.
+  | **Note:**
+  | This value should not be greater then the token length used to identify a user to preserve some utility behaviour.
+  | (Default: ``64``)
+
+- | ``MAGPIE_ADMIN_PERMISSION``
+  | Name of the permission used to represent highest administration privilege in the application.
+  | Except for some public routes, most API and UI paths will require the user to have this permission (either with
+    direct permission or by inherited group permission) to be granted access to view and edit content.
+  | (Default: ``"admin"``)
+
+- | ``MAGPIE_LOGGED_USER``
+  | Keyword used to define route resolution using the currently logged in user. This value allows, for example,
+    retrieving the user details of the logged user with ``GET /users/${MAGPIE_LOGGED_USER}`` instead of having to
+    find explicitly the ``GET /users/<my-user-id>`` variant. User resolution is done using the authentication cookie
+    found in the request. If no cookie can be found, it defaults to the ``MAGPIE_ANONYMOUS_USER`` value.
+  | **Note:**
+  | Because the user executing the request with this keyword is effectively the authenticated user, the behaviour of
+    some specific paths can be slightly different than their literal user-id counterpart. For example, user details
+    will be accessible to the logged user (he can view his own information) but this same user will receive an
+    unauthorized response if using is ID in the path if he doesn't have administrator privilege.
+  | (Default: ``"current"``)
+
+- | ``MAGPIE_DEFAULT_PROVIDER``
+  | Name of the provider used for local login. This represents the identifier that will be set to define who to
+    differentiate between a local sign-in procedure and a dispatched one to one of the known `External Providers`_.
+  | *The default is the value of the internal package used to manage user permissions.*
+  | (Default: ``"ziggurat"``)
+
+Phoenix Settings
+~~~~~~~~~~~~~~~~~~~~~
+
+Following settings provide some integration support for `Phoenix`_ in order to synchronize its service definitions with
+`Magpie` services.
+
+- | ``PHOENIX_USER``
+  | Name of the user to use for authentication in `Phoenix`_.
+  | (Default: ``"phoenix"``)
+
+- | ``PHOENIX_PASSWORD``
+  | Password of the user to use for authentication in `Phoenix`_.
+  | (Default: ``"qwerty"``)
+
+- | ``PHOENIX_PORT``
+  | Password of the user to use for authentication in `Phoenix`_.
+  | (Default: ``"qwerty"``)
+
+- | ``PHOENIX_PASSWORD``
+  | Password of the user to use for authentication in `Phoenix`_.
+  | (Default: ``"qwerty"``)
+
+
 PHOENIX_PORT = int(os.getenv("PHOENIX_PORT", 8443))
 PHOENIX_PUSH = asbool(os.getenv("PHOENIX_PUSH", True))
 TWITCHER_PROTECTED_PATH = os.getenv("TWITCHER_PROTECTED_PATH", "/ows/proxy")
 TWITCHER_PROTECTED_URL = os.getenv("TWITCHER_PROTECTED_URL", None)
+
+.. _Phoenix: https://github.com/bird-house/pyramid-phoenix
 
 Postgres Settings
 ~~~~~~~~~~~~~~~~~~~~~
@@ -157,26 +221,14 @@ MAGPIE_POSTGRES_HOST = os.getenv("MAGPIE_POSTGRES_HOST", "postgres")
 MAGPIE_POSTGRES_PORT = int(os.getenv("MAGPIE_POSTGRES_PORT", 5432))
 MAGPIE_POSTGRES_DB = os.getenv("MAGPIE_POSTGRES_DB", "magpie")
 
-# ===========================
-# other constants
-# ===========================
-MAGPIE_ADMIN_PERMISSION = "admin"
-# MAGPIE_ADMIN_PERMISSION = NO_PERMISSION_REQUIRED
-MAGPIE_LOGGED_USER = "current"
-MAGPIE_DEFAULT_PROVIDER = "ziggurat"
-
-# above this length is considered a token,
-# refuse longer username creation
-MAGPIE_USER_NAME_MAX_LENGTH = 64
-
 External Providers
 ----------------------
 
-In order to perform authentication in ``Magpie``, multiple external providers are supported. By default, the 'local'
+In order to perform authentication in `Magpie`, multiple external providers are supported. By default, the 'local'
 provider is ``ziggurat`` which corresponds to the package used to manage users, groups, permissions, etc. internally.
 Supported external providers are presented in the table below, although more could be added later on. 
 
-Each as different configuration parameters as defined in `<magpie/security.py>`_ and use various protocols amongst
+Each as different configuration parameters as defined in `<../magpie/security.py>`_ and use various protocols amongst
 ``OpenID``, ``ESGF``-flavored ``OpenID`` and ``OAuth2``. Further external providers can be defined using this module's
 dictionary configuration style following parameter specification of `Authomatic`_ package used for managing this
 authentication procedure.
@@ -227,9 +279,25 @@ authentication procedure.
 GitHub Settings
 ~~~~~~~~~~~~~~~~~
 
+To use `GitHub`_ authentication provider, variables ``GITHUB_CLIENT_ID`` and ``GITHUB_CLIENT_SECRET`` must be
+configured. These settings correspond to the values retrieved from following steps described in
+`Creating an OAuth App <GithubOAuthApp>`_.
 
+.. _GithubOAuthApp: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
 
 WSO2 Settings
 ~~~~~~~~~~~~~~~~~
 
+To use `WSO2`_ authentication provider, following variables must be set:
 
+- ``WSO2_HOSTNAME``
+- ``WSO2_CLIENT_ID``
+- ``WSO2_CLIENT_SECRET``
+- ``WSO2_CERTIFICATE_FILE``
+- ``WSO2_SSL_VERIFY``
+
+To configure your `Magpie` instance as a trusted application for ``WSO2`` (and therefore retrieve values of above
+parameters), please refer to `WSO2 Identity Server Documentation <WSO2IdentityServerDoc>`_.
+
+
+.. _WSO2IdentityServerDoc: https://docs.wso2.com/display/IS550/WSO2+Identity+Server+Documentation

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,12 +4,14 @@ Configuration
 At startup, `Magpie` application will load multiple configuration files to define various behaviours or setup
 operations. These are defined though the following configuration settings presented below.
 
-All generic `Magpie` configuration settings can be defined through either the `magpie.ini <MagpieCfgINI>`_ file
-or environment variables. Values defined in `magpie.ini <MagpieCfgINI>`_ are expected to follow the 
+All generic `Magpie` configuration settings can be defined through either the `magpie.ini`_ file
+or environment variables. Values defined in `magpie.ini`_ are expected to follow the 
 ``magpie.[variable_name]`` format, and corresponding ``MAGPIE_[VARIABLE_NAME]`` format is used for environment 
-variables. Both of these alternatives match the constants defined in `<../magpie/constants.py>`_ and can be used 
+variables. Both of these alternatives match the constants defined in `constants.py`_ and can be used
 interchangeably. Order of resolution will prioritize setting values over environment variables in case of matching
 duplicates values.
+
+.. _constants.py: ../magpie/constants.py
 
 Configuration Files
 -------------------
@@ -18,7 +20,7 @@ magpie.ini
 ~~~~~~~~~~~~~~~~~~~
 
 This is the base configuration file that defines most of `Magpie`'s lower level configuration. A basic example is
-provided in `magpie.ini <MagpieCfgINI>`_ which should allow any user to run the application locally. Furthermore, this file
+provided in `magpie.ini`_ which should allow any user to run the application locally. Furthermore, this file
 is used by default in each tagged Docker image. If you want to provide different configuration, the file should be
 overridden in the Docker image using a volume mount parameter, or by specifying an alternative path through the
 environment variable ``MAGPIE_INI_FILE_PATH``.
@@ -37,7 +39,7 @@ magpie.env
 
 By default, `Magpie` will try to load a ``magpie.env`` file which can define further environment variable definitions
 used to setup the application (see ``MAGPIE_ENV_FILE`` setting further below). An example of expected format and common
-variables for this file is presented in `<../env/magpie.env.example>`_.
+variables for this file is presented in `magpie.env.example`_.
 
 **Important Notes:**
 
@@ -49,19 +51,23 @@ This behaviour is intended to reduce initial configuration and preparation of  `
 When loading variables from the ``.env`` file, any conflicting environment variable will **NOT** be overridden.
 Therefore, only *missing but required* values will be added to the environment to ensure proper setup of `Magpie`.
 
+.. _magpie.env.example: ../env/magpie.env.example
+
 postgres.env
 ~~~~~~~~~~~~~~~~~~~
 
 This file behaves exactly in the same manner as for ``magpie.env`` above, but for specific variables definition
 employed to setup the `postgres` database connection (see ``MAGPIE_POSTGRES_ENV_FILE`` setting below).
-File `<../env/postgres.env.example>`_ and auto-resolution of missing ``postgres.env`` is identical to ``magpie.env``
+File `postgres.env.example`_ and auto-resolution of missing ``postgres.env`` is identical to ``magpie.env``
 case.
+
+.. _postgres.env.example: ../env/postgres.env.example
 
 Settings and Constants
 ----------------------
 
 Environment variables can be used to define all following settings (unless mentioned otherwise with 'constant').
-These values will be used by `Magpie` on startup unless prior definition is found within `magpie.ini <MagpieCfgINI>`_.
+These values will be used by `Magpie` on startup unless prior definition is found within `magpie.ini`_.
 
 Loading Settings
 ~~~~~~~~~~~~~~~~~
@@ -82,13 +88,13 @@ These settings can be used to specify where to find other settings through custo
 - | ``MAGPIE_PROVIDERS_CONFIG_PATH``
   | Path where to find ``providers.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
     be considered as `providers` files and will be loaded sequentially. \
-    Please refer to `providers.cfg <MagpieCfgProvs>`_ for specific format details.
+    Please refer to `providers.cfg`_ for specific format details.
   | (Default: ``${MAGPIE_CONFIG_DIR}/providers.cfg``)
 
 - | ``MAGPIE_PERMISSIONS_CONFIG_PATH``
   | Path where to find ``permissions.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
     be considered as `permissions` files and will be loaded sequentially. \
-    Please refer to `permissions.cfg <MagpieCfgPerms>`_ for specific format details.
+    Please refer to `permissions.cfg`_ for specific format details.
   | (default: ``${MAGPIE_CONFIG_DIR}/permissions.cfg``)
 
 - | ``MAGPIE_INI_FILE_PATH``
@@ -100,7 +106,7 @@ These settings can be used to specify where to find other settings through custo
 - | ``MAGPIE_ALEMBIC_INI_FILE_PATH``
   | Path to ``.ini`` file which defines an ``[alembic]`` section specifying details on how to execute database
     migration operations.
-  | (Default: ``${MAGPIE_INI_FILE_PATH}``) [section defined within `magpie.ini <MagpieCfgINI>`_]
+  | (Default: ``${MAGPIE_INI_FILE_PATH}``) [section defined within `magpie.ini`_]
 
 - | ``MAGPIE_ENV_DIR``
   | Directory path where to look for ``.env`` files. This variable can be useful to load specific test environment
@@ -117,9 +123,9 @@ These settings can be used to specify where to find other settings through custo
   | (Default: ``${MAGPIE_ENV_DIR}/postgres.env``)
 
 
-.. _MagpieCfgINI: ../config/magpie.ini
-.. _MagpieCfgPerms: ../config/permissions.cfg
-.. _MagpieCfgProvs: ../config/permissions.cfg
+.. _magpie.ini: ../config/magpie.ini
+.. _permissions.cfg: ../config/permissions.cfg
+.. _providers.cfg: ../config/permissions.cfg
 
 Application Settings
 ~~~~~~~~~~~~~~~~~~~~~
@@ -166,13 +172,13 @@ Following settings are used to define values that are employed by `Magpie` after
 
 - | ``MAGPIE_LOG_LEVEL``
   | Logging level of operations. `Magpie` will first use the complete logging configuration found in
-    `magpie.ini <MagpieCfgINI>`_ in order to define logging formatters and handler referencing to the ``logger_magpie``
+    `magpie.ini`_ in order to define logging formatters and handler referencing to the ``logger_magpie``
     section. If this configuration fails, this variable is used instead to prepare a basic logger.
   | (Default: ``INFO``)
 
 - | ``MAGPIE_LOG_LEVEL``
   | Specifies whether `Magpie` logging should also enforce printing the details to the console when using *helpers*.
-    Otherwise, the configured logging methodology in `magpie.ini <MagpieCfgINI>`_ is used (which can also define a
+    Otherwise, the configured logging methodology in `magpie.ini`_ is used (which can also define a
     console handler).
   | (Default: ``False``)
 
@@ -348,7 +354,7 @@ In order to perform authentication in `Magpie`, multiple external providers are 
 provider is ``ziggurat`` which corresponds to the package used to manage users, groups, permissions, etc. internally.
 Supported external providers are presented in the table below, although more could be added later on. 
 
-Each as different configuration parameters as defined in `<../magpie/security.py>`_ and use various protocols amongst
+Each as different configuration parameters as defined in `MagpieSecurity`_ and use various protocols amongst
 ``OpenID``, ``ESGF``-flavored ``OpenID`` and ``OAuth2``. Further external providers can be defined using this module's
 dictionary configuration style following parameter specification of `Authomatic`_ package used for managing this
 authentication procedure.
@@ -380,7 +386,8 @@ authentication procedure.
 | **Note:**
 | Please note that due to the constantly changing nature of multiple of these external providers (APIs and moved 
   Websites), rarely used authentication bridges by the developers could break without prior notice. If this is the
-  case and you use one of the broken connectors, summit a new `issue <MagpieIssue>`_.
+  case and you use one of the broken connectors, summit a new
+  `issue <https://github.com/Ouranosinc/Magpie/issues/new>`_.
 
 .. _Authomatic: https://authomatic.github.io/authomatic/
 .. _OpenID: https://openid.net/
@@ -394,19 +401,19 @@ authentication procedure.
 .. _SMHI: https://www.smhi.se
 .. _GitHub: https://developer.github.com/v3/#authentication
 .. _WSO2: https://wso2.com/
-.. _MagpieIssues: https://github.com/Ouranosinc/Magpie/issues/new
+.. _MagpieSecurity: ../magpie/security.py
 
 GitHub Settings
 ~~~~~~~~~~~~~~~~~
 
 To use `GitHub`_ authentication provider, variables ``GITHUB_CLIENT_ID`` and ``GITHUB_CLIENT_SECRET`` must be
 configured. These settings correspond to the values retrieved from following steps described in
-`Creating an OAuth App <GithubOAuthApp>`_.
+`Creating an OAuth App`_.
 
 Furthermore, the callback URL used for configuring the OAuth application on Github must match the running `Magpie`
 instance URL. For this reason, the values of ``MAGPIE_URL``, ``MAGPIE_HOST`` and ``HOSTNAME`` must be considered.
 
-.. _GithubOAuthApp: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
+.. _Creating an OAuth App: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
 
 WSO2 Settings
 ~~~~~~~~~~~~~~~~~
@@ -420,7 +427,7 @@ To use `WSO2`_ authentication provider, following variables must be set:
 - ``WSO2_SSL_VERIFY``
 
 To configure your `Magpie` instance as a trusted application for ``WSO2`` (and therefore retrieve values of above
-parameters), please refer to `WSO2 Identity Server Documentation <WSO2IdentityServerDoc>`_.
+parameters), please refer to `WSO2 Identity Server Documentation`_.
 
 
-.. _WSO2IdentityServerDoc: https://docs.wso2.com/display/IS550/WSO2+Identity+Server+Documentation
+.. _WSO2 Identity Server Documentation: https://docs.wso2.com/display/IS550/WSO2+Identity+Server+Documentation

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -31,7 +31,7 @@ File: providers.cfg
 This configuration file allows automatically registering service definitions in `Magpie` at startup. When the
 application starts, it will look for corresponding services and add them to the database as required. It will also
 look for mismatches between the service name and URL with the corresponding entry in the database to update it to
-the desired URL. See ``MAGPIE_PROVIDERS_CONFIG_PATH`` below to setup alternate references to this configuration file.
+the desired URL. See ``MAGPIE_PROVIDERS_CONFIG_PATH`` below to setup alternate references to this type of configuration.
 Please refer to the heading of sample file `providers.cfg`_ for specific format and parameter details.
 
 File: permissions.cfg
@@ -42,7 +42,7 @@ Each specified permission update operation is applied for the corresponding user
 or resource. This file is processed after `providers.cfg`_ in order to allow permissions to be applied on freshly
 registered services. Furthermore, sub-resources are automatically created if they can be resolved with provided
 parameters of the corresponding permission entry. See ``MAGPIE_PERMISSIONS_CONFIG_PATH`` below to setup alternate
-references to this configuration file. Please refer to the heading of sample file `permissions.cfg`_ for specific
+references to this type of configuration. Please refer to the heading of sample file `permissions.cfg`_ for specific
 format details as well as specific behaviour of each parameter according to encountered use cases.
 
 File: magpie.env

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
-Magpie documentation
+Magpie Documentation
 ======================================
 
 .. include:: ../README.rst
 
 
-Package information
+Package Information
 ===================
 
 .. toctree::
@@ -12,20 +12,21 @@ Package information
 
    usage
    installation
+   configuration
    performance
    contributing
    authors
    history
 
 
-Source code
+Source Code
 ===================
 
 .. toctree::
    :maxdepth: 2
 
 
-Indices and tables
+Indices and Tables
 ==================
 
 * :ref:`genindex`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ All above is done automatically with::
     make install
 
 
-If you want the full setup for development, use::
+If you want the full setup for development (including dependencies for test execution), use::
 
     make install-dev
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,7 +2,37 @@
 Usage
 ========
 
-To use Magpie in a project::
+Package
+~~~~~~~
+
+To use Magpie in a project, fist you need to install it. To do so, you can do a basic ``pip install``.
+For more details or other installation variants and preparation, see `installation <installation.rst>`_ and
+`configuration <configuration.rst>`_ procedures.
+
+Then simply import the Python package::
 
     import magpie
 
+
+API
+~~~~~~~
+
+When the application is started, the Swagger API should be available under ``/api`` path. Please refer to this
+documentation to discover all provided API paths and operations supported by ``Magpie``. The API allows an administrator
+with sufficient access rights to modify services, resources, users and groups references via HTTP requests.
+
+GUI
+~~~~~~~
+
+When the application is started, ``Magpie``'s UI should be directly accessible on the top endpoint path. This interface
+allows quicker editing of elements accessible through the API by providing common operations such as modifying service
+fields or adjusting specific user-resource permissions. To have access to this interface, the user must have
+administrator permissions.
+
+Helpers
+~~~~~~~
+
+Multiple CLI *helpers* are provided in `<../magpie/helpers>`_. These consist mostly of setup operation scripts that are
+automatically executed during ``Magpie`` startup. Additional common functions are also provided such as registering
+service providers from a configuration file or creating basic user accounts. Please refer to their corresponding usage
+by calling them with ``--help`` argument for more details.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,8 +6,8 @@ Package
 ~~~~~~~
 
 To use Magpie in a project, fist you need to install it. To do so, you can do a basic ``pip install``.
-For more details or other installation variants and preparation, see `installation <installation.rst>`_ and
-`configuration <configuration.rst>`_ procedures.
+For more details or other installation variants and preparation, see `installation`_ and
+`configuration`_ procedures.
 
 Then simply import the Python package::
 
@@ -18,13 +18,13 @@ API
 ~~~~~~~
 
 When the application is started, the Swagger API should be available under ``/api`` path. Please refer to this
-documentation to discover all provided API paths and operations supported by ``Magpie``. The API allows an administrator
+documentation to discover all provided API paths and operations supported by `Magpie`. The API allows an administrator
 with sufficient access rights to modify services, resources, users and groups references via HTTP requests.
 
 GUI
 ~~~~~~~
 
-When the application is started, ``Magpie``'s UI should be directly accessible on the top endpoint path. This interface
+When the application is started, `Magpie`'s UI should be directly accessible on the top endpoint path. This interface
 allows quicker editing of elements accessible through the API by providing common operations such as modifying service
 fields or adjusting specific user-resource permissions. To have access to this interface, the user must have
 administrator permissions.
@@ -32,7 +32,11 @@ administrator permissions.
 Helpers
 ~~~~~~~
 
-Multiple CLI *helpers* are provided in `<../magpie/helpers>`_. These consist mostly of setup operation scripts that are
-automatically executed during ``Magpie`` startup. Additional common functions are also provided such as registering
+Multiple CLI `helpers`_ are provided. These consist mostly of setup operation scripts that are
+automatically executed during `Magpie` startup. Additional common functions are also provided such as registering
 service providers from a configuration file or creating basic user accounts. Please refer to their corresponding usage
 by calling them with ``--help`` argument for more details.
+
+.. _helpers: ../magpie/helpers
+.. _configuration: ./configuration.rst
+.. _installation: ./installation.rst

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -25,8 +25,8 @@ def debug_cookie_identify(request):
 
         This function is intended for debugging purposes only. It reveals sensible configuration information.
 
-    Re-implements basic functionality of :function:`pyramid.AuthTktAuthenticationPolicy.cookie.identify` called via
-    :function:`request.unauthenticated_userid` within :function:`get_user` to provide additional logging.
+    Re-implements basic functionality of :func:`pyramid.AuthTktAuthenticationPolicy.cookie.identify` called via
+    :func:`request.unauthenticated_userid` within :func:`get_user` to provide additional logging.
 
     .. seealso::
         - :class:`pyramid.authentication.AuthTktCookieHelper`

--- a/magpie/api/login/esgfopenid.py
+++ b/magpie/api/login/esgfopenid.py
@@ -1,10 +1,16 @@
 """
-|openid| Providers
+ESGF OpenID Providers
 ----------------------------------
+
 Providers which implement the |openid|_ protocol based on the
 `python-openid`_ library.
+
 .. warning::
     This providers are dependent on the |python-openid|_ package.
+
+.. _openid: https://openid.net/
+.. _python-openid: https://github.com/openid/python-openid
+
 """
 
 from magpie.utils import get_logger

--- a/magpie/constants.py
+++ b/magpie/constants.py
@@ -106,6 +106,7 @@ MAGPIE_LOG_EXCEPTION = asbool(os.getenv("MAGPIE_LOG_EXCEPTION", True))          
 MAGPIE_UI_ENABLED = asbool(os.getenv("MAGPIE_UI_ENABLED", True))
 PHOENIX_USER = os.getenv("PHOENIX_USER", "phoenix")
 PHOENIX_PASSWORD = os.getenv("PHOENIX_PASSWORD", "qwerty")
+PHOENIX_HOST = os.getenv("PHOENIX_HOST")  # default None to use HOSTNAME
 PHOENIX_PORT = int(os.getenv("PHOENIX_PORT", 8443))
 PHOENIX_PUSH = asbool(os.getenv("PHOENIX_PUSH", True))
 TWITCHER_PROTECTED_PATH = os.getenv("TWITCHER_PROTECTED_PATH", "/ows/proxy")

--- a/magpie/helpers/sync_services.py
+++ b/magpie/helpers/sync_services.py
@@ -6,20 +6,24 @@ import abc
 import requests
 import threddsclient
 if TYPE_CHECKING:
-    from magpie.definitions.typedefs import Dict, Str, Type  # noqa: F401
+    from magpie.definitions.typedefs import Dict, JSON, Str, Type  # noqa: F401
 
 
 def is_valid_resource_schema(resources):
+    # type: (JSON) -> bool
     """
-    Returns True if the structure of the input dictionary is a tree of the form:
+    Returns ``True`` if the structure of the input dictionary is a tree of the form::
 
-    {'resource_name_1': {'children': {'resource_name_3': {'children': {}},
-                                      'resource_name_4': {'children': {}}
-                                      },
-                         },
-     'resource_name_2': {'children': {}}
-     }
-    :return: bool
+        {
+            "resource_name_1": {
+                "children": {
+                    "resource_name_3": {"children": {}},
+                    "resource_name_4": {"children": {}}
+                }
+            }
+            "resource_name_2": {"children": {}}
+        }
+
     """
     for resource_name, values in resources.items():
         if "children" not in values:
@@ -37,12 +41,12 @@ class SyncServiceInterface(with_metaclass(abc.ABCMeta)):
         self.service_name = service_name
         self.url = url
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def max_depth(self):
+        # type: () -> int
         """
         The max depth at which remote resources are fetched.
-
-        :return: (int)
         """
 
     @abc.abstractmethod

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -129,7 +129,7 @@ def phoenix_update_services(services_dict):
         print_log("Could not remove services, aborting register sync services to Phoenix", logger=LOGGER)
         return False
     if not phoenix_register_services(services_dict):
-        print_log("Failed services registration from Magpie to Phoenix\n" +
+        print_log("Failed services registration from Magpie to Phoenix\n"
                   "[warning: services could have been removed but could not be re-added]", logger=LOGGER)
         return False
     return True

--- a/magpie/security.py
+++ b/magpie/security.py
@@ -89,19 +89,21 @@ def authomatic_config(request=None):
         },
         'ipsl': {
             'class_': esgfopenid.ESGFOpenID,
-            'hostname': 'providers-node.ipsl.fr',
+            'hostname': 'esgf-node.ipsl.upmc.fr',
             'display_name': 'IPSL',
         },
-        'badc': {
+        # former 'badc'
+        'ceda': {
             'class_': esgfopenid.ESGFOpenID,
-            'hostname': 'ceda.ac.uk',
+            'hostname': 'esgf-index1.ceda.ac.uk',
             'provider_url': 'https://{hostname}/openid/{username}',
-            'display_name': 'BADC',
+            'display_name': 'CEDA',
         },
-        'pcmdi': {
+        # former 'pcmdi'
+        'llnl': {
             'class_': esgfopenid.ESGFOpenID,
-            'hostname': 'providers-node.llnl.gov',
-            'display_name': 'PCMDI',
+            'hostname': 'esgf-node.llnl.gov',
+            'display_name': 'LLNL',
         },
         'smhi': {
             'class_': esgfopenid.ESGFOpenID,

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -269,8 +269,10 @@ def get_magpie_url(container=None):
         raise ConfigurationError("MAGPIE_URL or magpie.url config cannot be found")
 
 
-def get_phoenix_url():
-    hostname = get_constant("HOSTNAME")
+def get_phoenix_url(container=None):
+    # type: (Optional[AnySettingsContainer]) -> Str
+    hostname = get_constant("PHOENIX_HOST", container, raise_missing=False, raise_not_set=False) or \
+               get_constant("HOSTNAME")
     phoenix_port = get_constant("PHOENIX_PORT", raise_not_set=False)
     return "https://{0}{1}".format(hostname, ":{}".format(phoenix_port) if phoenix_port else "")
 

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -272,7 +272,9 @@ def get_magpie_url(container=None):
 def get_phoenix_url(container=None):
     # type: (Optional[AnySettingsContainer]) -> Str
     hostname = get_constant("PHOENIX_HOST", container, raise_missing=False, raise_not_set=False) or \
-               get_constant("HOSTNAME")
+               get_constant("HOSTNAME", raise_missing=False, raise_not_set=False)
+    if not hostname:
+        raise ConfigurationError("Missing or unset PHOENIX_HOST or HOSTNAME value.")
     phoenix_port = get_constant("PHOENIX_PORT", raise_not_set=False)
     return "https://{0}{1}".format(hostname, ":{}".format(phoenix_port) if phoenix_port else "")
 


### PR DESCRIPTION
Adding multiple reviewers to spread the news about added info.

- Adds multiple documentation details about magpie's long list of setup configurations variables.
- Adds support of *multi*-cfg file loading for providers and permissions (in order to support docker-compose configs loaded from many places, such as `config` and `private-config`.
- Improve the generation and rendering of docs.

Fix #173, #180 