### PR TITLE
config improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,17 @@ History
 Unreleased
 ---------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Remove ``MAGPIE_ALEMBIC_INI_FILE_PATH`` configuration parameter in favor of ``MAGPIE_INI_FILE_PATH``.
+* Forward ``.ini`` file provided as argument to ``MAGPIE_INI_FILE_PATH`` (e.g.: when using ``gunicorn --paste <ini>``).
+* Load configuration file (previously only ``.cfg``) also using ``.yml``, ``.yaml`` and ``.json`` extensions.
+* Add argument parameter for ``run_db_migration`` helper to specify the configuration ``ini`` file to employ.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Use forwarded input argument to ``MAGPIE_INI_FILE_PATH`` to execute database migration.
+
 1.9.1 (2020-02-20)
 ---------------------
 

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -18,7 +18,11 @@ pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
-pyramid.includes = pyramid_tm ziggurat_foundations.ext.pyramid.sign_in ziggurat_foundations.ext.pyramid.get_user
+pyramid.includes =
+    pyramid_beaker
+    pyramid_tm
+    ziggurat_foundations.ext.pyramid.sign_in
+    ziggurat_foundations.ext.pyramid.get_user
 
 # magpie
 magpie.port = 2001
@@ -29,10 +33,11 @@ magpie.secret = seekrit
 magpie.push_phoenix = true
 
 # caching settings refer to the Performance section in the documentation
-cache.regions = adapter
+cache.regions = adapter, acl
 # cache.type = memory
 # cache.adapter.expire = 5
 cache.adapter.enabled = false
+cache.acl.enabled = false
 
 # ziggurat
 ziggurat_foundations.model_locations.User = magpie.models:User
@@ -68,7 +73,7 @@ threads=4
 # %(here)s corresponds to this directory
 [alembic]
 script_location = %(here)s/../magpie/alembic
-#sqlalchemy.url = postgresql://${MAGPIE_POSTGRES_USERNAME}:${MAGPIE_POSTGRES_PASSWORD}@${MAGPIE_POSTGRES_HOST}/${MAGPIE_POSTGRES_DB}
+#sqlalchemy.url = postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/${POSTGRES_DB}
 
 ###
 # logging configuration

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -64,10 +64,11 @@ timeout=10
 workers=3
 threads=4
 
-# used by magpie/alembic with symlink, %(here)s corresponds to this directory
+# used by magpie/alembic for database migration
+# %(here)s corresponds to this directory
 [alembic]
 script_location = %(here)s/../magpie/alembic
-#sqlalchemy.url = postgresql://postgres:postgres@localhost/magpie
+#sqlalchemy.url = postgresql://${MAGPIE_POSTGRES_USERNAME}:${MAGPIE_POSTGRES_PASSWORD}@${MAGPIE_POSTGRES_HOST}/${MAGPIE_POSTGRES_DB}
 
 ###
 # logging configuration

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -126,11 +126,6 @@ These settings can be used to specify where to find other settings through custo
   | This variable ignores the setting/env-var resolution order since settings cannot be defined without
     firstly loading the file referenced by its value.
 
-- | ``MAGPIE_ALEMBIC_INI_FILE_PATH``
-  | Path to ``.ini`` file which defines an ``[alembic]`` section specifying details on how to execute database
-    migration operations.
-  | (Default: ``${MAGPIE_INI_FILE_PATH}``) [section defined within `magpie.ini`_]
-
 - | ``MAGPIE_ENV_DIR``
   | Directory path where to look for ``.env`` files. This variable can be useful to load specific test environment
     configurations or to specify a local path while the actual `Magpie` code is located in a Python `site-packages`

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -24,7 +24,7 @@ def main(global_config=None, **settings):  # noqa: F811
     """
     # override magpie ini if provided with --paste to gunicorn, otherwise use environment variable
     config_env = get_constant("MAGPIE_INI_FILE_PATH", raise_missing=True)
-    config_ini = (global_config or {}).get("__file__")
+    config_ini = (global_config or {}).get("__file__", config_env)
     if config_ini != config_env:
         import magpie.constants
         magpie.constants.MAGPIE_INI_FILE_PATH = config_ini

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -22,7 +22,13 @@ def main(global_config=None, **settings):  # noqa: F811
     """
     This function returns a Pyramid WSGI application.
     """
-    config_ini = get_constant("MAGPIE_INI_FILE_PATH", raise_missing=True)
+    # override magpie ini if provided with --paste to gunicorn, otherwise use environment variable
+    config_env = get_constant("MAGPIE_INI_FILE_PATH", raise_missing=True)
+    config_ini = (global_config or {}).get("__file__")
+    if config_ini != config_env:
+        import magpie.constants
+        magpie.constants.MAGPIE_INI_FILE_PATH = config_ini
+        settings["magpie.ini_file_path"] = config_ini
 
     print_log("Setting up loggers...", LOGGER)
     log_lvl = get_constant("MAGPIE_LOG_LEVEL", settings, "magpie.log_level", default_value="INFO",

--- a/magpie/constants.py
+++ b/magpie/constants.py
@@ -37,8 +37,6 @@ MAGPIE_PERMISSIONS_CONFIG_PATH = os.getenv(
     "MAGPIE_PERMISSIONS_CONFIG_PATH", "{}/permissions.cfg".format(MAGPIE_CONFIG_DIR))
 MAGPIE_INI_FILE_PATH = os.getenv(
     "MAGPIE_INI_FILE_PATH", "{}/magpie.ini".format(MAGPIE_CONFIG_DIR))
-MAGPIE_ALEMBIC_INI_FILE_PATH = os.getenv(
-    "MAGPIE_ALEMBIC_INI_FILE_PATH", MAGPIE_INI_FILE_PATH)
 # allow custom location of env files directory to avoid
 # loading from installed magpie in python site-packages
 MAGPIE_ENV_DIR = os.getenv("MAGPIE_ENV_DIR", os.path.join(MAGPIE_ROOT, "env"))

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -132,12 +132,12 @@ def get_db_session_from_config_ini(config_ini_path, ini_main_section_name="app:m
     return get_db_session_from_settings(settings)
 
 
-def run_database_migration(db_session=None):
-    # type: (Optional[Session]) -> None
+def run_database_migration(settings=None, db_session=None):
+    # type: (Optional[SettingsType], Optional[Session]) -> None
     """
     Runs db migration operations with alembic, using db session or a new engine connection.
     """
-    ini_file = get_constant("MAGPIE_ALEMBIC_INI_FILE_PATH")
+    ini_file = get_constant("MAGPIE_INI_FILE_PATH", settings)
     LOGGER.info("Using file '%s' for migration.", ini_file)
     alembic_args = ["-c", ini_file, "upgrade", "heads"]
     if not isinstance(db_session, Session):
@@ -192,7 +192,7 @@ def run_database_migration_when_ready(settings, db_session=None):
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", category=sa_exc.SAWarning)
-                    run_database_migration(db_session)
+                    run_database_migration(db_session=db_session, settings=settings)
             except ImportError as exc:
                 print_log("Database migration produced [{!r}] (ignored).".format(exc), level=logging.WARNING)
             except Exception as exc:

--- a/magpie/helpers/run_db_migration.py
+++ b/magpie/helpers/run_db_migration.py
@@ -10,4 +10,4 @@ if __name__ == "__main__":
                         help="configuration file to employ for database connection settings "
                              "(default: MAGPIE_INI_FILE_PATH='%(default)s)'")
     args = parser.parse_args()
-    run_database_migration(settings={"magpie.alembic_ini_file_path": args.config_file})
+    run_database_migration(settings={"magpie.ini_file_path": args.config_file})

--- a/magpie/helpers/run_db_migration.py
+++ b/magpie/helpers/run_db_migration.py
@@ -1,4 +1,13 @@
+import argparse
+
+from magpie.constants import MAGPIE_INI_FILE_PATH
 from magpie.db import run_database_migration
 
 if __name__ == "__main__":
-    run_database_migration()
+    parser = argparse.ArgumentParser(description="Run Magpie database migration")
+    parser.add_argument("-c", "--config-file", metavar="config_file", dest="config_file", type=str,
+                        default=MAGPIE_INI_FILE_PATH,
+                        help="configuration file to employ for database connection settings "
+                             "(default: MAGPIE_INI_FILE_PATH='%(default)s)'")
+    args = parser.parse_args()
+    run_database_migration(settings={"magpie.alembic_ini_file_path": args.config_file})

--- a/magpie/helpers/run_db_migration.py
+++ b/magpie/helpers/run_db_migration.py
@@ -3,7 +3,8 @@ import argparse
 from magpie.constants import MAGPIE_INI_FILE_PATH
 from magpie.db import run_database_migration
 
-if __name__ == "__main__":
+
+def run_database_migration_cli():
     parser = argparse.ArgumentParser(description="Run Magpie database migration")
     parser.add_argument("-c", "--config-file", metavar="config_file", dest="config_file", type=str,
                         default=MAGPIE_INI_FILE_PATH,
@@ -11,3 +12,7 @@ if __name__ == "__main__":
                              "(default: MAGPIE_INI_FILE_PATH='%(default)s)'")
     args = parser.parse_args()
     run_database_migration(settings={"magpie.ini_file_path": args.config_file})
+
+
+if __name__ == "__main__":
+    run_database_migration_cli()

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -532,7 +532,9 @@ def _get_all_configs(path_or_dict, section):
     if isinstance(path_or_dict, six.string_types):
         if os.path.isdir(path_or_dict):
             dir_path = os.path.abspath(path_or_dict)
-            cfg_names = list(sorted({fn for fn in os.listdir(dir_path) if fn.endswith(".cfg")}))
+            known_extensions = [".cfg", ".yml", ".yaml", ".json"]
+            cfg_names = list(sorted({fn for fn in os.listdir(dir_path)
+                                     if any([fn.endswith(ext) for ext in known_extensions])}))
             return [_load_config(os.path.join(dir_path, fn), section) for fn in cfg_names]
         if os.path.isfile(path_or_dict):
             return [_load_config(path_or_dict, section)]


### PR DESCRIPTION
Before this fix, the pasted ini file would define most settings, but ini file employed by db migration would use the default `./config/magpie.ini` path.

We allow also json/yaml file extensions as these formats where already supported for permissions.cfg or providers.cfg, but not explicitly looked for when specifying a directory path to load many files.

# commits 
- employ gunicorn paste ini file for db migration
- yml/json configs extensions support
