### PR TITLE
handle final slash for lookup of ACL from HTTP path

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ History
 Unreleased
 ---------------------
 
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Handle trailing ``/`` of HTTP path that would fail an ACL lookup of the corresponding service or resource.
+
 1.9.1 (2020-02-20)
 ---------------------
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -350,7 +350,7 @@ class ServiceAPI(ServiceInterface):
         self.expand_acl(self.service, self.request.user)
 
         match_index = 0
-        route_parts = self.request.path.split("/")
+        route_parts = self.request.path.rstrip("/").split("/")
         route_api_base = self.service.resource_name
 
         if self.service.resource_name in route_parts and route_api_base in route_parts:


### PR DESCRIPTION
Without this fix calling a route like `/twitcher/ows/proxy/finch/` would fail to lookup permissions of the user/group for service `finch` as a final empty string resource would be looked for.