### PR TITLE
pin setuptools version breaking build/install 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apk update \
     py-pip \
     musl-dev \
     postgresql-dev \
-    && pip install --no-cache-dir --upgrade pip setuptools \
+    && pip install --no-cache-dir --upgrade -r requirements-sys.txt \
     && pip install --no-cache-dir -e $MAGPIE_DIR \
     && apk --purge del .build-deps
 

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ install-all: install-sys install-pkg install-dev
 .PHONY: install-sys
 install-sys: clean conda-env	## install system dependencies and required installers/runners
 	@echo "Installing system dependencies..."
-	@bash -c '$(CONDA_CMD) pip install --upgrade pip setuptools'
+	@bash -c '$(CONDA_CMD) pip install --upgrade -r "$(APP_ROOT)/requirements-sys.txt"'
 	@bash -c '$(CONDA_CMD) pip install gunicorn'
 
 .PHONY: install-pkg

--- a/requirements-sys.txt
+++ b/requirements-sys.txt
@@ -1,2 +1,2 @@
 pip
-setuptools<46
+setuptools

--- a/requirements-sys.txt
+++ b/requirements-sys.txt
@@ -1,0 +1,2 @@
+pip
+setuptools<46

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ typing
 wheel==0.33.0
 webob
 ziggurat-foundations==0.8.3
-zope.interface>=4.7.0,<5
+zope.interface>=4.7.2,<5
 zope.sqlalchemy==1.1
 # TODO: remove when merged
 #   until fix merged and deployed (https://github.com/authomatic/authomatic/pull/195)

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ typing
 wheel==0.33.0
 webob
 ziggurat-foundations==0.8.3
+zope.interface>=4.7.0,<5
 zope.sqlalchemy==1.1
 # TODO: remove when merged
 #   until fix merged and deployed (https://github.com/authomatic/authomatic/pull/195)


### PR DESCRIPTION
pin 'zope.interface>=4.7.0' minimal version (via zopefoundation/zope.interface#30) to fix missing 'Features' feature officially removed (via pypa/setuptools#65) and pin setuptools<46.0.0

references https://github.com/zopefoundation/zope.interface/issues/184