### PR TITLE
fix docker-build-hook for latest twitcher with master/latest magpie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
   postgresql: "9.6"
 services:
   - postgresql
-test:
+postgres:
   adapter: postgresql
   database: magpie
   username: postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ stages:
   - check       # run linting checks and don't bother with the rest if invalid
   - test        # use default stage to run job matrix variations
   - smoke-test  # try running the built/packaged docker image
-  - coverage    # only run once after everything else, will report analysis after if everything worked
 jobs:
   include:
     # use stages to quick fail faster tests
@@ -84,7 +83,7 @@ jobs:
       python: "3.6"
       os: linux
       script: make docs
-    - stage: coverage
+    - stage: test
       name: "Coverage"
       python: "3.6"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
+version: ~> 1.0
 # === setup ===
 language: python
+os:
+  - linux
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
+  - "3.5"
+  - "2.7"
 cache:
   - pip
   - directories:
@@ -22,7 +25,9 @@ env:
     - TEST_TARGET=coverage      START_TARGET=
 addons:
   postgresql: "9.6"
-postgres:
+services:
+  - postgresql
+test:
   adapter: postgresql
   database: magpie
   username: postgres
@@ -59,21 +64,41 @@ before_script:
   - export PATH=${CONDA_HOME}/bin:${PATH}
   - hash -r
   - env
+stages:
+  - check       # run linting checks and don't bother with the rest if invalid
+  - test        # use default stage to run job matrix variations
+  - smoke-test  # try running the built/packaged docker image
+  - coverage    # only run once after everything else, will report analysis after if everything worked
+jobs:
+  include:
+    # use stages to quick fail faster tests
+    # these are extra to default 'test' stage with auto-matrix/env extension
+    - stage: check
+      name: "Linter Checks"
+      python: "3.6"
+      os: linux
+      script: make check
+    - stage: check
+      name: "Documentation Check"   # verify that build works
+      python: "3.6"
+      os: linux
+      script: make docs
+    - stage: coverage
+      name: "Coverage"
+      python: "3.6"
+      os: linux
+      script: make coverage
+    - stage: smoke-test
+      name: "Smoke Test"
+      python: "3.6"
+      os: linux
+      script: make test-docker
 script:
-  # linting tests
-  - |
-    if [ "${TRAVIS_PYTHON_VERSION}" == "3.6" ]; then
-      make check
-    fi
-  # unit/functional tests
+  # unit/functional tests (start as needed)
   - make stop ${START_TARGET}
   - make ${TEST_TARGET}
   - make stop
-  # smoke test the docker image
-  - |
-    if [ "${TRAVIS_PYTHON_VERSION}" == "3.6" ]; then
-      make test-docker
-    fi
 after_success:
+  # coverage report
   - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
   - source ${CONDA_PREFIX}/bin/activate ${CONDA_ENV} && python-codacy-coverage -r reports/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 version: ~> 1.0
 # === setup ===
 language: python
+dist: xenial
 os:
   - linux
 python:
@@ -19,7 +20,7 @@ env:
     - CONDA_HOME=$HOME/conda
     - DOWNLOAD_CACHE=$HOME/downloads
     - secure: lzPPXuRTlqLHl2MCAUuy7ROrewSwPFGGKqbADo7npQ4jqVMAb/TQ5PTzIi4IAIvsv817dNj5WSAd39hsp1zSlE1R2jLtbxGEVqwcjTqSv9VStGascRQnCW1hcoSKYqESweEhtdIcH+uXpV8qnDsUWB6YIIP2VjgWPMfSPZPynFKC0IqZm2sFsqDEJJHr3QM5iN3i3Z9GrEIrBEEpoaf0yak5u8LjqoGSaY8ISPGWipBJYn7i/r/+sZpirFXbZRJmI4ljsaHi0tysNWdANOIf7S2+Dy/oGNn/3Br0OMJ5snFe/n6Uf4GcmPGDc1c86oN0FpGcoNSA+lCUPMASghOGwVqBhMjX+qAZZfzEbCGtr2j/MhcpETMO3S9oqelw4CcbZRXxP2Y20L+KGNOCSt3SC4/HdKj5MWRQGUnIZbT9C2Tpn2wTffpVRoKvhik/6UU8/KT12LSwDhjjrfqLgCEFLqH1nBL2Mopkj/eOwQbZ66nZmthrAF7/c+vaB38LWoqBIZi/fOwo6+kt947d1bW6UX6Z1KnCNLN2KO064Hjn+SHb1gAes0JIXIZE7af1Gti2dKmUL4a5eoYyU5vCLlp2nq5yxEtTUdJKZ1UVnkDqRtSaT0F3FgLypbFqi+qZ6AtygxKqplMjeAGhvVSqZTPqRupP1ac/KBBCvMzG8pkfXWs=
-  matrix:
+  jobs:
     - TEST_TARGET=test-local    START_TARGET=
     - TEST_TARGET=test-remote   START_TARGET=start
     - TEST_TARGET=coverage      START_TARGET=

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -252,7 +252,7 @@ Bug Fixes
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix migration script errors due to incorrect object fetching from db
-  (`#149 <https://github.com/Ouranosinc/PAVICS/issues/149>`_).
+  (`#149 <https://github.com/Ouranosinc/PAVICS/pull/149>`_).
 
 `1.3.3 <https://github.com/Ouranosinc/Magpie/tree/1.3.3>`_ (2019-07-11)
 ------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,8 @@ dist: clean conda-env	## package for distribution
 .PHONY: install
 install: install-all	## alias for 'install-all' target
 
-.PHONY: install-all		## install every dependency and package definition
-install-all: install-sys install-pkg install-dev install-docs
+.PHONY: install-all
+install-all: install-sys install-pkg install-dev install-docs	## install every dependency and package definition
 
 .PHONY: install-sys
 install-sys: clean conda-env	## install system dependencies and required installers/runners
@@ -460,7 +460,7 @@ test-remote: install-dev install	## run only remote tests with the default Pytho
 .PHONY: test-docker
 test-docker: docker-test			## alias for 'docker-test' target - WARNING: could build image if missing
 
-# covereage file location cannot be changed
+# coverage file location cannot be changed
 COVERAGE_FILE     := $(APP_ROOT)/.coverage
 COVERAGE_HTML_DIR := $(REPORTS_DIR)/coverage
 COVERAGE_HTML_IDX := $(COVERAGE_HTML_DIR)/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,9 @@ autoapi_python_class_content = "both"
 linkcheck_ignore = [
     # might not exist yet (we are generating it!)
     "https://pavics-magpie.readthedocs.io/en/latest/api.html",
+    # FIXME: tmp disable due to Retry-After header for rate-limiting by Github not respected
+    #        (see: https://github.com/sphinx-doc/sphinx/issues/7388)
+    "https://github.com/Ouranosinc/Magpie/*",    # limit only Magpie so others are still checked
 ]
 
 linkcheck_timeout = 20

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,8 +113,8 @@ linkcheck_ignore = [
     "https://pavics-magpie.readthedocs.io/en/latest/api.html",
 ]
 
-linkcheck_timeout = 10
-linkcheck_retries = 3
+linkcheck_timeout = 20
+linkcheck_retries = 5
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,6 +114,8 @@ linkcheck_ignore = [
     # FIXME: tmp disable due to Retry-After header for rate-limiting by Github not respected
     #        (see: https://github.com/sphinx-doc/sphinx/issues/7388)
     "https://github.com/Ouranosinc/Magpie/*",    # limit only Magpie so others are still checked
+    # ignore private links
+    "https://github.com/Ouranosinc/PAVICS/*",
 ]
 
 linkcheck_timeout = 20

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 echo "=> Information of Magpie Adapter image for Twitcher (docker tag: $DOCKER_TAG)"
-make MAGPIE_VERSION=${DOCKER_TAG} docker-info
+make APP_VERSION=${DOCKER_TAG} docker-info
 
 echo "=> Building Magpie Adapter image for Twitcher (docker tag: $DOCKER_TAG)"
-make MAGPIE_VERSION=${DOCKER_TAG} docker-build-adapter
+make APP_VERSION=${DOCKER_TAG} docker-build-adapter
 
 echo "=> Pushing Magpie Adapter image for Twitcher (docker tag: $DOCKER_TAG)"
-make MAGPIE_VERSION=${DOCKER_TAG} docker-push-adapter
+make APP_VERSION=${DOCKER_TAG} docker-push-adapter


### PR DESCRIPTION
Since https://github.com/Ouranosinc/Magpie/commit/1c0a1566f94a92e2781a19f5a41d8fedb49e4568, (ie magpie `1.7.4`), any master branch build of the docker image did not create the corresponding sync twitcher image because `MAGPIE_VERSION` -> `APP_VERSION` was not reflected in build hook.

last build of `pavics/twitcher:magpie-latest` ~6 months ago: 
https://hub.docker.com/layers/pavics/twitcher/magpie-latest/images/sha256-9061cff0a712da5570a048a5dbf7429c413a1c61f26026b70a2d52da2a698a44?context=explore

Explicitly tagged versions are not affected as they used the real value of the makefile.