### PR TITLE
Permission extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Features / Changes
   specified configuration of the specific service (resolves `#361 <https://github.com/Ouranosinc/Magpie/issues/361>`_).
 * Add documentation details about parsing methodologies, specific custom configurations and respective usage of the
   various ``Service`` types provided by `Magpie`.
+* Adjust ``MagpieAdapter`` such that ``OWSAccessForbidden`` is raised by default if the ``Service`` implementation fails
+  to provide a valid ``Permission`` enum from ``permission_requested`` method. Incorrectly defined ``Service`` will
+  therefore not unexpectedly grant access to protected resources. Behaviour also aligns with default ``DENY`` access
+  obtained when resolving effective permissions through `Magpie` API routes.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+* Nothing yet.
+
+`3.1.0 <https://github.com/Ouranosinc/Magpie/tree/3.1.0>`_ (2020-10-23)
+------------------------------------------------------------------------------------
+
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Add ``BROWSE`` permission for ``ServiceTHREDDS`` to parse request against *metadata* or *data* contents according to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,15 @@ Features / Changes
   therefore not unexpectedly grant access to protected resources. Behaviour also aligns with default ``DENY`` access
   obtained when resolving effective permissions through `Magpie` API routes.
 
+* | Upgrade migration script is added to duplicate ``BROWSE`` permissions from existing ``READ`` permissions on every
+    ``ServiceTHREDDS`` and all their children resource to preserve previous functionality where both *metadata* and
+    *data* access where both managed by the same ``READ`` permission.
+  |
+  | **WARNING**:
+  | Downgrade migration drops every ``BROWSE`` permission that could exist in later versions. This is done like so
+    to avoid granting additional access to some ``THREDDS`` directories or file if only ``BROWSE`` was specified.
+    When doing downgrade migration, ensure to have ``READ`` where both *metadata* and *data* should be granted access.
+
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix parsing of ``ServiceAPI`` routes during retrieval of the deepest *available* ``Resource`` to ensure that even when

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Bug Fixes
   the targeted ``Resource`` is actually missing, the *closest* parent permissions with ``Scope.RECURSIVE`` will still
   take effect. Same fix applied for ``ServiceTHREDDS`` for corresponding directory and file typed ``Resource``.
 * Propagate SSL verify option of generated service definition if provided to `Twitcher` obtained from ``MagpieAdapter``.
+* Adjust and validate parsing of ``ServiceWPS`` request using ``POST`` XML body
+  (fixes `157 <https://github.com/Ouranosinc/Magpie/issues/157>`_).
 
 `3.0.0 <https://github.com/Ouranosinc/Magpie/tree/3.0.0>`_ (2020-10-19)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add ``BROWSE`` permission for ``ServiceTHREDDS`` to parse request against *metadata* or *data* contents according to
+  specified configuration of the specific service (resolves `#361 <https://github.com/Ouranosinc/Magpie/issues/361>`_).
 
 `3.0.0 <https://github.com/Ouranosinc/Magpie/tree/3.0.0>`_ (2020-10-19)
 ------------------------------------------------------------------------------------
@@ -513,7 +516,7 @@ Bug Fixes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* Prioritize settings (ie: `magpie.ini` values) before environment variables and ``magpie.constants`` globals.
+* Prioritize settings (ie: ``magpie.ini`` values) before environment variables and ``magpie.constants`` globals.
 * Allow specifying ``magpie.scheme`` setting to generate the ``magpie.url`` with it if the later was omitted.
 * Look in settings for required parameters for function ``get_admin_cookies``.
 * Use API definitions instead of literal strings for routes employed in ``MagpieAdapter``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,14 @@ Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Add ``BROWSE`` permission for ``ServiceTHREDDS`` to parse request against *metadata* or *data* contents according to
   specified configuration of the specific service (resolves `#361 <https://github.com/Ouranosinc/Magpie/issues/361>`_).
+* Add documentation details about parsing methodologies, specific custom configurations and respective usage of the
+  various ``Service`` types provided by `Magpie`.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix parsing of ``ServiceAPI`` routes during retrieval of the deepest *available* ``Resource`` to ensure that even when
+  the targeted ``Resource`` is actually missing, the *closest* parent permissions with ``Scope.RECURSIVE`` will still
+  take effect.
 
 `3.0.0 <https://github.com/Ouranosinc/Magpie/tree/3.0.0>`_ (2020-10-19)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,8 @@ Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix parsing of ``ServiceAPI`` routes during retrieval of the deepest *available* ``Resource`` to ensure that even when
   the targeted ``Resource`` is actually missing, the *closest* parent permissions with ``Scope.RECURSIVE`` will still
-  take effect.
+  take effect. Same fix applied for ``ServiceTHREDDS`` for corresponding directory and file typed ``Resource``.
+* Propagate SSL verify option of generated service definition if provided to `Twitcher` obtained from ``MagpieAdapter``.
 
 `3.0.0 <https://github.com/Ouranosinc/Magpie/tree/3.0.0>`_ (2020-10-19)
 ------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ MAKEFILE_NAME := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 # Application
 APP_ROOT    := $(abspath $(lastword $(MAKEFILE_NAME))/..)
 APP_NAME    := magpie
-APP_VERSION ?= 3.0.0
+APP_VERSION ?= 3.1.0
 APP_INI     ?= $(APP_ROOT)/config/$(APP_NAME).ini
 
 # guess OS (Linux, Darwin,...)

--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,13 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
     :alt: Requires Python 2.7, 3.5+
     :target: https://www.python.org/getit
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/Ouranosinc/Magpie/3.0.0.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/Ouranosinc/Magpie/3.1.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/Ouranosinc/Magpie/compare/3.0.0...master
+    :target: https://github.com/Ouranosinc/Magpie/compare/3.1.0...master
 
-.. |version| image:: https://img.shields.io/badge/tag-3.0.0-blue.svg?style=flat
+.. |version| image:: https://img.shields.io/badge/tag-3.1.0-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/Ouranosinc/Magpie/tree/3.0.0
+    :target: https://github.com/Ouranosinc/Magpie/tree/3.1.0
 
 .. |dependencies| image:: https://pyup.io/repos/github/Ouranosinc/Magpie/shield.svg
     :alt: Dependencies Status
@@ -45,9 +45,9 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
     :alt: Travis-CI Build Status (master branch)
     :target: https://travis-ci.com/Ouranosinc/Magpie
 
-.. |travis_tagged| image:: https://img.shields.io/travis/com/Ouranosinc/Magpie/3.0.0.svg?label=3.0.0
+.. |travis_tagged| image:: https://img.shields.io/travis/com/Ouranosinc/Magpie/3.1.0.svg?label=3.1.0
     :alt: Travis-CI Build Status (latest tag)
-    :target: https://github.com/Ouranosinc/Magpie/tree/3.0.0
+    :target: https://github.com/Ouranosinc/Magpie/tree/3.1.0
 
 .. |readthedocs| image:: https://img.shields.io/readthedocs/pavics-magpie
     :alt: Readthedocs Build Status (master branch)
@@ -118,8 +118,8 @@ Following most recent variants are available:
     * - Magpie
       - Twitcher |br|
         (with integrated ``MagpieAdapter``)
-    * - pavics/magpie:3.0.0
-      - pavics/twitcher:magpie-3.0.0
+    * - pavics/magpie:3.1.0
+      - pavics/twitcher:magpie-3.1.0
     * - pavics/magpie:latest
       - pavics/twitcher:magpie-latest
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -363,5 +363,4 @@ texinfo_documents = [
 # texinfo_no_detailmenu = False
 
 intersphinx_mapping = {
-    "celery": ("http://docs.celeryproject.org/en/latest/", None),
 }

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -92,6 +92,20 @@ See ``MAGPIE_PERMISSIONS_CONFIG_PATH`` setting below to setup alternate referenc
 Please refer to the comment header of sample file `permissions.cfg`_ for specific format details as well as specific
 behaviour of each parameter according to encountered use cases.
 
+Configuration File Formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionchanged:: 1.9.2
+
+Any file represented in the :ref:`Configuration` chapter using any of the extension ``.cfg``, ``.json``, ``.yaml`` or
+``.yml`` will be accepted interchangeably if provided. Both parsing as JSON and YAML will be attempted for backward
+compatibility of each resolved file path.
+
+It is not mandatory for the the name of each file to also match the employed name in the documentation, provided
+the paths can be resolved to valid files, though there is special handling of default ``.example`` extensions with
+matching file names when no other alternative configurations can be found. Again, this is mostly for backward
+compatibility.
+
 Combined Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -182,18 +196,18 @@ These settings can be used to specify where to find other settings through custo
 - | ``MAGPIE_PROVIDERS_CONFIG_PATH``
   | (Default: ``${MAGPIE_CONFIG_DIR}/providers.cfg``)
 
-  Path where to find ``providers.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
+  Path where to find a `providers.cfg`_ file. Can also be a directory path, where all contained ``.cfg`` files will
   be considered as `providers` files and will be loaded sequentially.
 
   .. note::
     If a directory path is specified, the order of loaded configuration files is not guaranteed
-    (depending on OS implementation).
+    (depending on OS implementation). Duplicate entries could therefore be loaded in inconsistent order.
     Please refer to `providers.cfg`_ for specific format details and loading methodology according to arguments.
 
 - | ``MAGPIE_PERMISSIONS_CONFIG_PATH``
   | (default: ``${MAGPIE_CONFIG_DIR}/permissions.cfg``)
 
-  Path where to find ``permissions.cfg`` file. Can also be a directory path, where all contained ``.cfg`` files will
+  Path where to find `permissions.cfg`_ file. Can also be a directory path, where all contained ``.cfg`` files will
   be considered as `permissions` files and will be loaded sequentially.
 
   .. note::

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -340,9 +340,6 @@ at the start of the `Configuration`_ section.
   within the `themes`_ subdirectory.
 
 
-.. _themes: https://github.com/Ouranosinc/Magpie/tree/master/magpie/ui/home/static/themes
-
-
 Security Settings
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -768,18 +765,6 @@ this :term:`Authentication` procedure.
     Websites), rarely used authentication bridges by the developers could break without prior notice. If this is the
     case and you use one of the broken connectors, summit a new `issue`_.
 
-.. _OpenID: https://openid.net/
-.. _ESGF: https://esgf.llnl.gov/
-.. _DKRZ: https://esgf-data.dkrz.de
-.. _IPSL: https://www.ipsl.fr/
-.. _BADC: http://data.ceda.ac.uk/badc
-.. _CEDA: https://esgf-index1.ceda.ac.uk
-.. _LLNL: https://www.llnl.gov/
-.. _PCMDI: http://pcmdi.llnl.gov
-.. _SMHI: https://www.smhi.se
-.. _GitHub: https://developer.github.com/v3/#authentication
-.. _WSO2: https://wso2.com/
-.. _MagpieSecurity: https://github.com/Ouranosinc/Magpie/tree/master/magpie/security.py
 
 GitHub Settings
 ~~~~~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -5,14 +5,22 @@ Configuration
 =============
 
 At startup, `Magpie` application will load multiple configuration files to define various behaviours or setup
-operations. These are defined though the configuration settings presented below.
+operations. These are defined though the configuration settings presented in below sections.
 
-All generic `Magpie` configuration settings can be defined through either the `magpie.ini`_ file
-or environment variables. Values defined in `magpie.ini`_ are expected to follow the
-``magpie.[variable_name]`` format, and corresponding ``MAGPIE_[VARIABLE_NAME]`` format is used for environment
-variables. Both of these alternatives match the constants defined in `constants.py`_ and can be used
-interchangeably. Order of resolution will prioritize setting values over environment variables in case of duplicate
-configurations resulting into different values.
+All generic `Magpie` configuration settings can be defined through either the `magpie.ini`_ file or environment
+variables. Values defined in `magpie.ini`_ are expected to follow the ``magpie.[variable_name]`` format, and
+corresponding ``MAGPIE_[VARIABLE_NAME]`` format is used for environment variables. Both of these alternatives match
+the constants defined in `constants.py`_ and can be used interchangeably.
+
+.. versionchanged:: 1.1
+    Order of resolution will prioritize *setting configurations* over *environment variables* in case of duplicates
+    resulting into different values. Environment variables will not override already specified setting values.
+
+    Previous versions of `Magpie` would instead prioritize environment variables, but this behaviour was deemed as
+    counter intuitive. This is attributed to the global scope nature of environment variables that often made it hard
+    to understand why some custom INI file would not behave as intended since those variable would inconsistently take
+    precedence whether or not they were defined. Using a common configuration file makes it easier to maintain and
+    understand the applied settings, and is therefore preferable.
 
 .. _constants.py: https://github.com/Ouranosinc/Magpie/tree/master/magpie/constants.py
 
@@ -35,15 +43,14 @@ By default, `Magpie` will try to load a ``magpie.env`` file which can define fur
 used to setup the application (see ``MAGPIE_ENV_FILE`` setting further below). An example of expected format and common
 variables for this file is presented in `magpie.env.example`_.
 
-**Important Notes:**
+.. warning::
+    If ``magpie.env`` cannot be found (e.g.: using setting ``MAGPIE_ENV_FILE``) but `magpie.env.example`_ is available
+    after resolving any previously set ``MAGPIE_ENV_DIR`` variable, this example file will be used to make a copy saved
+    as ``magpie.env`` and will be used as the base ``.env`` file to load its contained environment variables.
+    This behaviour is intended to reduce initial configuration and preparation of  `Magpie` for a new user.
 
-If ``magpie.env`` cannot be found (using setting ``MAGPIE_ENV_FILE``) but ``magpie.env.example`` is available
-(after resolving any previously set ``MAGPIE_ENV_DIR`` variable), this example file will be used to make a copy
-saved as ``magpie.env`` and will be used as the base ``.env`` file to load its contained environment variables.
-This behaviour is intended to reduce initial configuration and preparation of  `Magpie` for a new user.
-
-When loading variables from the ``.env`` file, any conflicting environment variable will **NOT** be overridden.
-Therefore, only *missing but required* values will be added to the environment to ensure proper setup of `Magpie`.
+    When loading variables from the ``.env`` file, any conflicting environment variable will **NOT** be overridden.
+    Therefore, only *missing but required* values will be added to the environment to ensure proper setup of `Magpie`.
 
 .. _magpie.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/magpie.env.example
 
@@ -67,6 +74,10 @@ to the desired URL. See ``MAGPIE_PROVIDERS_CONFIG_PATH`` setting below to setup 
 configuration. Please refer to the comment header of sample file `providers.cfg`_ for specific format and parameter
 details.
 
+.. versionchanged:: 3.1
+    Some services, such as :ref:`ServiceTHREDDS` for instance, can take additional parameters to customize some of
+    their behaviour. Please refer to :ref:`Services` chapter for specific configuration supported.
+
 File: permissions.cfg
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -84,9 +95,11 @@ behaviour of each parameter according to encountered use cases.
 Combined Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. versionadded:: 2.0
+
 Since contents of all different configurations files (`providers.cfg`_, `permissions.cfg`_) reside under distinct
-top-level objects (of same name), it is actually possible to use an unique file to define everything. For example,
-one could define a combined configuration as follows.
+top-level objects, it is actually possible to use an unique file to define everything. For example, one could define
+a combined configuration as follows.
 
 .. code-block:: YAML
 
@@ -141,7 +154,7 @@ Settings and Constants
 
 Environment variables can be used to define all following configurations (unless mentioned otherwise with
 ``[constant]`` keyword next to the parameter name). Most values are parsed as plain strings, unless they refer to an
-activable setting (e.g.: ``True`` or ``False``), or when specified with more specific ``[<type>]`` notation.
+activatable setting (e.g.: ``True`` or ``False``), or when specified with more specific ``[<type>]`` notation.
 
 Configuration variables will be used by `Magpie` on startup unless prior definition is found within `magpie.ini`_.
 All variables (i.e.: non-``[constant]`` parameters) can also be specified by their ``magpie.[variable_name]`` setting

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -22,8 +22,6 @@ the constants defined in `constants.py`_ and can be used interchangeably.
     precedence whether or not they were defined. Using a common configuration file makes it easier to maintain and
     understand the applied settings, and is therefore preferable.
 
-.. _constants.py: https://github.com/Ouranosinc/Magpie/tree/master/magpie/constants.py
-
 Configuration Files
 -------------------
 
@@ -52,8 +50,6 @@ variables for this file is presented in `magpie.env.example`_.
     When loading variables from the ``.env`` file, any conflicting environment variable will **NOT** be overridden.
     Therefore, only *missing but required* values will be added to the environment to ensure proper setup of `Magpie`.
 
-.. _magpie.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/magpie.env.example
-
 File: postgres.env
 ~~~~~~~~~~~~~~~~~~~
 
@@ -61,8 +57,6 @@ This file behaves exactly in the same manner as for ``magpie.env`` above, but fo
 employed to setup the `postgres` database connection (see ``MAGPIE_POSTGRES_ENV_FILE`` setting below).
 File `postgres.env.example`_ and auto-resolution of missing ``postgres.env`` is identical to ``magpie.env``
 case.
-
-.. _postgres.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/postgres.env.example
 
 File: providers.cfg
 ~~~~~~~~~~~~~~~~~~~
@@ -105,6 +99,8 @@ It is not mandatory for the the name of each file to also match the employed nam
 the paths can be resolved to valid files, though there is special handling of default ``.example`` extensions with
 matching file names when no other alternative configurations can be found. Again, this is mostly for backward
 compatibility.
+
+.. _config_file:
 
 Combined Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -226,7 +222,7 @@ These settings can be used to specify where to find other settings through custo
   .. note::
     When provided, all other combinations of ``MAGPIE_CONFIG_DIR``, ``MAGPIE_PERMISSIONS_CONFIG_PATH`` and
     ``MAGPIE_PROVIDERS_CONFIG_PATH`` are effectively ignored in favour of definitions in this file.
-    See `Combined Configuration File`_ for further details and example.
+    See :ref:config_file` for further details and example.
 
 - ``MAGPIE_INI_FILE_PATH``
 
@@ -252,11 +248,6 @@ These settings can be used to specify where to find other settings through custo
   | (Default: ``"${MAGPIE_ENV_DIR}/postgres.env"``)
 
   File path to ``postgres.env`` file with additional environment variables to configure the `postgres` connection.
-
-
-.. _magpie.ini: https://github.com/Ouranosinc/Magpie/tree/master/config/magpie.ini
-.. _permissions.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg
-.. _providers.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg
 
 Application Settings
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -126,7 +126,7 @@ Glossary
         for implementation details to achieve this result.
 
     Request User
-        Active request session :term:`User` that can be retrieved by calling ``request.user`` with resolution of
+        Active HTTP request session :term:`User` that can be retrieved by calling ``request.user`` with resolution of
         :term:`Authentication` headers within the request (:term:`User` is ``None`` if unauthenticated,
         i.e.: :py:data:`magpie.constants.MAGPIE_ANONYMOUS_USER`). This is not the same as the :term:`Context User`
         extracted from ``{user_name}`` path variable, except for the special case covered by :term:`Logged User`'s

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -97,10 +97,14 @@ Glossary
         :py:data:`magpie.constants.MAGPIE_ANONYMOUS_USER`. Otherwise, it is whoever the
         :term:`Authentication` mechanism identifies with token extracted from request :term:`Cookies`.
 
+    OGC
+        Acronym for `Open Geospatial Consortium` that represent the global initiative and community to standardize
+        geospatial data and service methodologies in order to improve access to geospatial and location information.
+
     OWS
-        Acronym that regroups all `Open Geospatial Consortium` (OGC) Web Services. This includes
-        `Web Feature Service` (WFS), `Web Map Service` (WMS) and `Web Processing Service` (WPS) for which `Magpie`
-        offers some specific :term:`Service` request parser implementations.
+        Acronym that regroups all :term:`OGC` Web Services. This includes `Web Feature Service` (WFS),
+        `Web Map Service` (WMS) and `Web Processing Service` (WPS) for which `Magpie` offers some specific
+        :term:`Service` request parser implementations.
 
     Permission
         Element that defines which rules are applicable for a given combination of :term:`User` and/or :term:`Group`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -28,8 +28,6 @@ If you want the full setup for development (including dependencies for test exec
 
 You can run the Magpie container with a ``docker-compose.yml`` for a local setup (see `docker-compose.yml.example`_)
 
-.. _`docker-compose.yml.example`: https://github.com/Ouranosinc/Magpie/tree/master/docker-compose.yml.example
-
 
 Backward Compatibility
 --------------------------

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -358,6 +358,7 @@ This query can be extremely useful to quickly answer *"does the user have any pe
 without needing to manually execute multiple successive lookup requests with all combinations of :term:`Resource`
 identifiers in the hierarchy.
 
+.. _permission_modifiers::
 
 Permissions Definition and Modifiers
 --------------------------------------
@@ -439,6 +440,8 @@ cause ambiguous resolution, the ``match`` :term:`Permission` is prioritized over
 As a general of thumb, all :term:`Permission` are resolved such that more restrictive access applied *closer* to
 the actual :term:`Resource` for the targeted :term:`User` will have priority, both in terms of inheritance by tree
 hierarchy and by :term:`Group` memberships.
+
+.. _permission_representations::
 
 Permissions Representations
 --------------------------------------

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -1,6 +1,10 @@
 .. _permissions:
 .. include:: references.rst
 
+.. default location to quickly reference items without the explicit and long prefix
+.. using the full name when introducing the element (to make the location obvious), the reuse shorthand variant
+.. py:currentmodule:: magpie.permissions
+
 ===========
 Permissions
 ===========
@@ -368,7 +372,8 @@ Permissions Definition and Modifiers
     Previous versions of `Magpie` employed literal ``[permission_name]`` and ``[permission_name]-match`` to
     respectively represent recursive and match ``scope`` over the hierarchy of :term:`Resource`.
     All ``-match`` suffixed :term:`Permission` names are now deprecated in favor of modifiers presented in this section.
-    Furthermore, the `Deny` concept is introduced via ``access`` field, which did not exist at all in previous versions.
+    Furthermore, the :attr:`Access.DENY` concept is introduced via ``access`` field, which did not exist at all in
+    previous versions.
 
 When applying a :term:`Permission` on a :term:`Service` or :term:`Resource` for a :term:`User` or :term:`Group`, there
 are 3 components considered to interpret its definition:
@@ -389,11 +394,12 @@ The ``access`` component is defined by :class:`magpie.permissions.Access` enum. 
 correspondingly grant or remove the :term:`Permission` for previously denied or allowed :term:`User` or :term:`Group`
 when resolving the :term:`Resource` tree hierarchy. This helps solving special use cases where different inheritance
 conditions must be applied at different hierarchy levels. By default, if no ``access`` indication is provided when
-creating a new :term:`Permission`, `Allow` is employed since `Magpie` resolves all ``access`` to a :term:`Resource`
-as `Deny` unless explicitly granted. In other words, `Magpie` assumes that administrators adding new :term:`Permission`
-entries indent to grant :term:`Service` or :term:`Resource` access for the targeted :term:`User` or :term:`Group`.
-Any :term:`Permission` specifically created using `Deny` should be involved only to revert a previously resolved
-`Allow`, as they are otherwise redundant to default :term:`Effective Permissions` resolution.
+creating a new :term:`Permission`, :attr:`Access.ALLOW` is employed since `Magpie` resolves all ``access`` to a
+:term:`Resource` as :attr:`Access.DENY` unless explicitly granted. In other words, `Magpie` assumes that administrators
+adding new :term:`Permission` entries indent to grant :term:`Service` or :term:`Resource` access for the targeted
+:term:`User` or :term:`Group`. Any :term:`Permission` specifically created using :attr:`Access.DENY` should be involved
+only to revert a previously resolved :attr:`Access.ALLOW`, as they are otherwise redundant to default
+:term:`Effective Permissions` resolution.
 
 The ``scope`` concept is defined by :class:`magpie.permissions.Scope` enum. This tells `Magpie` whether the
 :term:`Applied Permission` should impact only the immediate :term:`Resource` (i.e.: when ``match``) or should instead

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -442,7 +442,7 @@ As a general of thumb, all :term:`Permission` are resolved such that more restri
 the actual :term:`Resource` for the targeted :term:`User` will have priority, both in terms of inheritance by tree
 hierarchy and by :term:`Group` memberships.
 
-.. _permission_representations::
+.. _permission_representations:
 
 Permissions Representations
 --------------------------------------

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -5,6 +5,8 @@
 Permissions
 ===========
 
+.. _permission_types:
+
 Types of Permissions
 -----------------------
 
@@ -173,7 +175,6 @@ value that implicitly retrieves the :term:`Request User` as the :term:`Context U
     some additional request-specific logic (depending on its purpose and resulting actions) for special-cases that is
     not explicitly detailed in above steps. Some of these special behaviors can be observed across the various `tests`_.
 
-.. _tests: https://github.com/Ouranosinc/Magpie/tree/master/tests
 
 Finally, it is worth further detailing the small distinction between
 :py:data:`magpie.constants.MAGPIE_LOGGED_PERMISSION` and :py:data:`magpie.constants.MAGPIE_CONTEXT_PERMISSION`,
@@ -236,7 +237,7 @@ to execute `Magpie` application. Effectively, when the active session correspond
 Example to distinguish Applied, Inherited and Effective Permissions
 --------------------------------------------------------------------------------------
 
-This section intends to provide more insight on the different :ref:`Types of Permissions` using a simplified
+This section intends to provide more insight on the different :ref:`permission_types` using a simplified
 demonstration of interaction between defined :term:`Service`, :term:`Resource`, :term:`Group`, :term:`User` and
 :term:`Permission` elements.
 
@@ -312,7 +313,7 @@ On the other hand, using ``effective`` would result in the following:
     /users/example-user/resources/resource-B1/permissions?effective=true    => [read]           (2)
     /users/example-user/resources/resource-B2/permissions?effective=true    => [read, write]    (4)
 
-In this case, :term:`Resource`s that had :term:`Permission` directly set on them :sup:`(2)`, whether through
+In this case, all :term:`Resource` entries that had :term:`Permission` directly set on them :sup:`(2)`, whether through
 :term:`User` or :term:`Group` combination, all return the exact same set of :term:`Permission`. This is because
 `Effective Permissions`_ always imply `Inherited Permissions`_ (i.e.: using both query simultaneously is redundant).
 The reason why we obtain these sets for cases :sup:`(2)` is also because there is no other :term:`Permission` applied
@@ -358,7 +359,7 @@ This query can be extremely useful to quickly answer *"does the user have any pe
 without needing to manually execute multiple successive lookup requests with all combinations of :term:`Resource`
 identifiers in the hierarchy.
 
-.. _permission_modifiers::
+.. _permission_modifiers:
 
 Permissions Definition and Modifiers
 --------------------------------------
@@ -483,4 +484,4 @@ Therefore, it can be noted that all API responses that contain details about per
 
 It can be noted that the JSON representation also provides a fourth ``type`` parameter which serves as indicative
 detail about the kind of :term:`Permission` being displayed, in attempt to reduce the ambiguity described in
-:ref:`Types of Permissions`.
+:ref:`permission_types`.

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -449,7 +449,7 @@ Permissions Representations
 
 .. versionadded:: 3.0
     Prior to this version, only plain *permission-names* where employed. These are represented by the *implicit* string
-    representation in following versions of `M̀agpie`.
+    representation in following versions of `Magpie`.
 
 As presented in the previous section, every :term:`Permission` in `Magpie` is represented by three (3) elements, namely
 the ``name``, the ``access`` and the ``scope``. These are represented in API responses by both *explicit* and *implicit*

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -18,10 +18,29 @@
 .. _Waitress: https://github.com/Pylons/waitress
 .. _Ziggurat-Foundations: https://github.com/ergo/ziggurat_foundations
 
+.. external providers
+.. _OpenID: https://openid.net/
+.. _ESGF: https://esgf.llnl.gov/
+.. _DKRZ: https://esgf-data.dkrz.de
+.. _IPSL: https://www.ipsl.fr/
+.. _BADC: http://data.ceda.ac.uk/badc
+.. _CEDA: https://esgf-index1.ceda.ac.uk
+.. _LLNL: https://www.llnl.gov/
+.. _PCMDI: http://pcmdi.llnl.gov
+.. _SMHI: https://www.smhi.se
+.. _GitHub: https://developer.github.com/v3/#authentication
+.. _WSO2: https://wso2.com/
+
 .. file/source references
+.. _configuration: configuration.rst
 .. _constants.py: https://github.com/Ouranosinc/Magpie/tree/master/magpie/constants.py
+.. _`docker-compose.yml.example`: https://github.com/Ouranosinc/Magpie/tree/master/docker-compose.yml.example
+.. _magpie-con: https://github.com/Ouranosinc/Magpie/tree/master/magpie-cron
 .. _magpie.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/magpie.env.example
 .. _magpie.ini: https://github.com/Ouranosinc/Magpie/tree/master/config/magpie.ini
+.. _MagpieSecurity: https://github.com/Ouranosinc/Magpie/tree/master/magpie/security.py
 .. _permissions.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg
 .. _postgres.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/postgres.env.example
 .. _providers.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg
+.. _themes: https://github.com/Ouranosinc/Magpie/tree/master/magpie/ui/home/static/themes
+.. _tests: https://github.com/Ouranosinc/Magpie/tree/master/tests

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -17,3 +17,11 @@
 .. _Twitcher: https://github.com/bird-house/twitcher
 .. _Waitress: https://github.com/Pylons/waitress
 .. _Ziggurat-Foundations: https://github.com/ergo/ziggurat_foundations
+
+.. file/source references
+.. _constants.py: https://github.com/Ouranosinc/Magpie/tree/master/magpie/constants.py
+.. _magpie.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/magpie.env.example
+.. _magpie.ini: https://github.com/Ouranosinc/Magpie/tree/master/config/magpie.ini
+.. _permissions.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg
+.. _postgres.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/postgres.env.example
+.. _providers.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -3,10 +3,12 @@
 
 .. _Alembic: https://alembic.sqlalchemy.org/
 .. _Authomatic: https://authomatic.github.io/authomatic/
+.. _GeoServer: http://geoserver.org/
 .. _Gunicorn: https://gunicorn.org/
 .. _issue: https://github.com/Ouranosinc/Magpie/issues/new
 .. _Magpie Docker Images: https://hub.docker.com/r/pavics/magpie/tags
 .. _Magpie REST API: https://pavics-magpie.readthedocs.io/en/latest/api.html
+.. _ncWMS2: https://github.com/Reading-eScience-Centre/ncwms
 .. _Ouranosinc/requests-magpie: https://github.com/Ouranosinc/requests-magpie
 .. _Phoenix: https://github.com/bird-house/pyramid-phoenix
 .. _PostgreSQL: https://www.postgresql.org/

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -13,6 +13,7 @@
 .. _Pyramid: https://docs.pylonsproject.org/projects/pyramid/
 .. _ReadTheDocs: https://pavics-magpie.readthedocs.io/
 .. _SQLAlchemy: https://www.sqlalchemy.org/
+.. _THREDDS: https://www.unidata.ucar.edu/software/tds/
 .. _Twitcher: https://github.com/bird-house/twitcher
 .. _Waitress: https://github.com/Pylons/waitress
 .. _Ziggurat-Foundations: https://github.com/ergo/ziggurat_foundations

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -37,7 +37,7 @@
 .. _configuration: configuration.rst
 .. _constants.py: https://github.com/Ouranosinc/Magpie/tree/master/magpie/constants.py
 .. _`docker-compose.yml.example`: https://github.com/Ouranosinc/Magpie/tree/master/docker-compose.yml.example
-.. _magpie-con: https://github.com/Ouranosinc/Magpie/tree/master/magpie-cron
+.. _magpie-cron: https://github.com/Ouranosinc/Magpie/tree/master/magpie-cron
 .. _magpie.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/magpie.env.example
 .. _magpie.ini: https://github.com/Ouranosinc/Magpie/tree/master/config/magpie.ini
 .. _MagpieSecurity: https://github.com/Ouranosinc/Magpie/tree/master/magpie/security.py

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -407,6 +407,8 @@ When using the `Magpie` Docker image, the default command run the `magpie-cron`_
 cron job will periodically execute the :term:`Resource` auto-synchronization feature for a given :term:`Service` that
 supports it.
 
+The synchronization mechanism can be launched from `Magpie` UI using the ``Sync`` button located on relevant pages.
+
 .. seealso::
 
     Utility ``magpie_sync_resources`` in :ref:`utilities_helpers` is also available to manually launch a

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -1,9 +1,6 @@
 .. _services:
 .. include:: references.rst
 
-.. employ the permissions as base for this chapter to ease reading by shorter reference definitions
-.. py:currentmodule:: magpie.permissions
-
 ===========
 Services
 ===========
@@ -25,7 +22,7 @@ Therefore, they can be listed and searched for either using ``/services`` API ro
 On top of any :term:`Resource`'s metadata, a :term:`Service` provides specific information about its location, its
 remote synchronization method (if any), and its exposed endpoint. Another important detail about the :term:`Service`
 is its ``type``. This will not only dictate its purpose, but also define the whole schema of allowed :term:`Resource`
-under it (if any), as well as every one of their :ref:`Allowed Permissions`.
+under it (if any), as well as every one of their :term:`Allowed Permissions`.
 
 The final distinction between a :term:`Service` and generic :term:`Resource` is their position in the hierarchy. Only
 :term:`Service`-specialized :term:`Resource` (literally ``resource_type = "service"``) are allowed to be placed at the
@@ -89,6 +86,9 @@ On top of the above methods, the following attributes must be defined.
 Available Services
 -------------------
 
+.. employ the permissions as base for this section to ease reading by shorter reference definitions
+.. py:currentmodule:: magpie.permissions
+
 .. seealso::
     Module :py:mod:`magpie.services` contains the implementation of every :term:`Service` presented below.
 
@@ -148,7 +148,7 @@ each sub-:term:`Resource` as presented below.
 
 Every :class:`magpie.models.Route` as well as the :term:`Service` itself can have the :term:`Permission` based on the
 HTTP method of the incoming request. All :class:`Access` and :class:`Scope` modifiers are also supported for highly
-customizable :term:`ACL` combinations. See `permission_modifiers`_ for further details.
+customizable :term:`ACL` combinations. See :ref:`permission_modifiers` for further details.
 
 ServiceTHREDDS
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -113,18 +113,19 @@ by the below configuration.
         # customizable request parsing methodology (specific to `thredds` type)
         file_patterns:
           - .*.nc
+        metadata_type:
+          prefixes:
+            - null  # note: special value evaluated as `no-prefix`, use quotes to handle special keywords if needed
+            - catalog
+            - ncml
+            - uddc
+            - iso
         data_type:
           prefixes:
             - fileServer
             - dodsC
             - wcs
             - wms
-        metadata_type:
-          prefixes:
-            - catalog
-            - ncml
-            - uddc
-            - iso
 
 Assuming a proxy intended to receive incoming requests configured with :class:`magpie.adapter.MagpieAdapter` such that
 ``{PROXY_URL}`` is the base path, the following path would point toward the above registered service::
@@ -140,7 +141,9 @@ The above template demonstrates that `Magpie` will attempt to match the ``<prefi
 ``prefixes`` in the configuration. If a match is found, the corresponding *metadata* or *data* content will be assumed,
 according to where the match entry was located, to determine whether :attr:`Permission.BROWSE` or
 :attr:`Permission.READ` should be respectively assumed for this request access. If no ``<prefix>`` can be resolved, the
-permission will be immediately assumed as :attr:`Permission.BROWSE` directly on the :term:`Service`.
+permission will be immediately assumed as :attr:`Access.DENY`. To allow top-level access directly on the
+:term:`Service`'s root without ``<prefix>``, it is important to provide ``null`` within the desired ``prefixes`` list.
+Duplicates between the two lists of ``prefixes`` will favor entries in ``metadata_type`` over ``data_type``.
 
 After resolution of the content type from ``<prefix>``, the resolution of any amount of :class:`magpie.models.Directory`
 :term:`Resource` will be attempted. Any missing children directory :term:`Resource` will terminate the lookup process

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -380,9 +380,21 @@ Service Synchronization
 .. versionadded:: 0.7
 
 Some :term:`Service` implementations offer a synchronization feature which is represented by field ``sync_type`` within
-`Magpie` API responses. When this option is available, the corresponding :term:`Service` is able to query the real
-*remote service provider* to retrieve actual :term:`Resource` nested under it. This allows quick generation of the full
-:term:`Resource` tree hierarchy rather than manually creating each element.
+`Magpie` API responses. When this parameter is defined (during :term:`Service` creation, whether through API request or
+startup :ref:`Configuration`), the corresponding :term:`Service` will be able to query the real
+*remote service provider* to retrieve actual :term:`Resource` nested under it, based on the referenced implementation
+from the :mod:`magpie.cli.sync_services` module. Each of these synchronization implementations must derive from
+:class:`magpie.cli.sync_service.SyncServiceInterface` and must populate the database with appropriate :term:`Resource`
+types. This allows quick generation of the retrieved :term:`Resource` tree hierarchy rather than manually creating each
+element.
+
+.. note::
+    The depth of the :term:`Resource` tree hierarchy that will be synchronized between `Magpie` and the
+    *remote service provider* depends on the specific implementation of the ``sync_type`` referring to a derived
+    :class:`magpie.cli.sync_service.SyncServiceInterface`. These classes provide a parameter ``max_depth`` which
+    can limit how many :term:`Resource` must be generated. This is useful for entries that have very large and deeply
+    nested structure that would take too long to synchronize. By default, ``max_depth`` is not set to pull the whole
+    tree hierarchy.
 
 .. note::
     If only :attr:`Scope.RECURSIVE` :term:`Permission` are being applied on the :term:`Service` or their children

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -268,22 +268,42 @@ multiple :term:`Resource` for every *metadata*/*data* representation.
 ServiceGeoserverWMS
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. todo::
+.. todo:: details, depends on ServiceBaseWMS
 
 ServiceNCWMS2
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. todo::
+.. todo:: details, depends on ServiceBaseWMS
 
-ServiceWMS
-~~~~~~~~~~~~~~~~~~~~~
-
-.. todo::
 
 ServiceWPS
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. todo::
+The implementation of this :term:`Service` is handled by class :class:`magpie.services.ServiceWPS`. It is intended to
+control access to the operations provided by an :term:`OWS` `Web Processing Service`. This :term:`Service` allows
+one (1) type of child :term:`Resource`, namely the :class:`magpie.models.Process` which represent the execution units
+that are registered under a remote `WPS`. Every :class:`magpie.models.Process` cannot itself have a child
+:term:`Resource`, making `ServiceWPS`_ maximally a 2-tier level hierarchy.
+
+There are three (3) types of :term:`Allowed Permissions` which each represent an operation that can be requested from it
+(via ``request`` query parameter value of the HTTP request), specifically the :attr:`Permission.GET_CAPABILITIES`,
+:attr:`Permission.DESCRIBE_PROCESS`, and :attr:`Permission.EXECUTE`. The :attr:`Permission.GET_CAPABILITIES`
+corresponds to the retrieval of available list of *Processes* on the `WPS` instance, and therefore, can only be applied
+on the top-level :term:`Service`. The other two permissions can be applied on either the :term:`Service` or specifically
+on individual :class:`magpie.models.Process` :term:`Resource` definitions. When applied to the :term:`Service` with
+:attr:`Scope.RECURSIVE` modifier, the corresponding :term:`Permission` becomes effective to all underlying *Processes*.
+Otherwise, the :term:`Permission` applied on specific :class:`magpie.models.Process` entries control the specific
+:term:`ACL` only for it. When a specific :term:`Permission` is involved on a :class:`magpie.models.Process` during
+:term:`Effective Permissions` resolution, the value of the query parameter ``identifier`` is employ to attempt mapping
+it against an existing :term:`Resource`. The resolution of :term:`Effective Permissions` in even of multi-level tree
+:term:`Resource` is computed in the usual manner described in the :ref:`Permissions` chapter.
+
+
+.. warning::
+    When applying permissions on a per-:class:`magpie.models.Process` basis, :attr:`Scope.MATCH` modifier is recommended
+    if only a specific ``request`` should be granted access, although :attr:`Scope.RECURSIVE` would have the same effect
+    currently because these resources are necessarily leaf nodes by definition. This is to prevent unexpectedly granting
+    additional lower-level :term:`Resource` access in the event this definition gets modified or extended in the future.
 
 
 Adding Service Types

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -49,7 +49,99 @@ ServiceAPI
 ServiceTHREDDS
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. todo:
+The implementation of this service is handled by class :class:`magpie.services.ServiceTHREDDS`. It refers to a remote
+data server named `Thematic Real-time Environmental Distributed Data Services` (`THREDDS`_). The service employs two (2)
+types of :term:`Resources`, namely :class:`magpie.models.Directory` and :class:`magpie.models.File`. All the directory
+resources can be nested any number of times, and files can only reside as leaves of the hierarchy, similarly to a
+traditional file system. The :term:`Allowed Permissions` on both the :term:`Service` itself or any of its children
+:term:`Resource` are :attr:`Permission.BROWSE`, :attr:`Permission.READ`, and :attr:`Permission.WRITE` (see note below
+regarding this last permission).
+
+.. versionadded:: 3.1
+    The :attr:`Permission.BROWSE` permission is used to provide listing access of contents when targeting a
+    :term:`Resource` of type :class:`magpie.models.Directory`. When targeting a :class:`magpie.models.File`, it instead
+    provides *metadata* access to that file.
+
+Permission :attr:`Permission.READ` can be applied to all of the resources, but will only effectively make sense when
+attempting access of a specific :term:`Resource of type :class:`magpie.models.File`.
+
+.. versionchanged:: 3.1
+    Permission :attr:`Permission.READ` does not offer *metadata* content listing of :class:`magpie.models.Directory`
+    anymore. For this, :attr:`Permission.BROWSE` should be used instead. Setting :attr:`Permission.READ` on a
+    directory will only be logical when combined with :attr:`Scope.RECURSIVE`, in which case `Magpie` will interpret
+    the :term:`Effective Permissions` to allow read access to all :class:`magpie.models.File` under that directory, at
+    any depth level, unless denied by a lower-level specification.
+
+Finally, :attr:`Permission.WRITE` can also be applied on all of the resources, but are not explicitly employed during
+parsing of incoming requests.
+
+.. note::
+    The :attr:`Permission.WRITE` is not handled by `ServiceTHREDDS`_ itself during :term:`ACL` resolution as it is not
+    considered by :meth:`magpie.services.ServiceTHREDDS.permission_requested` that never returns this value. The method
+    only returns either :attr:`Permission.BROWSE` or :attr:`Permission.READ`. An :term:`User` or :term:`Group` can still
+    have this :term:`Applied Permission` to allow a third party service to interrogate `Magpie API` about the presence
+    of :attr:`Permission.WRITE` permission and perform the appropriate action with the result. The
+    :term:`Effective Permissions` API routes will provide the resolved ``access``. It is only `Twitcher`_ proxy that
+    will not be able to make use of it during incoming requests as it depends on
+    :class:`magpie.adapter.magpieowssecurity.MagpieOWSSecurity`, which in turn employs the result from the :term:`ACL`.
+
+    The :attr:`Permission.WRITE` is mostly preserved for backward compatibility of services that employed
+    `ServiceTHREDDS`_ to obtain information about which directory or files (which registered `Magpie` :term:`Resource`)
+    are writable or not, although using another upload methodology that is not specifically executed via the actual
+    remote `THREDDS`_ service.
+
+
+As presented above, the main two permissions are :attr:`Permission.BROWSE` and :attr:`Permission.READ` which
+correspondingly serve to retrieve *metadata* and actual *data* of a given :term:`Resource`. To distinguish requests
+between these two types of contents, `ServiceTHREDDS`_ employs two parts from the request path, the sub-path *prefix*
+and the file *extension*. A default methodology is employed categorize these two types of content, but can be modified
+using custom configurations as described in :ref:`Custom THREDDS Settings` section.
+
+
+
+
+Custom THREDDS Settings
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+    See section :ref:`ServiceTHREDDS` about the base implementation components of this service type for further details.
+
+
+With either the `providers.cfg`_ or the `Combined Configuration File`_ presented in previous sections, a service of
+type `THREDDS`_ can be slightly customized to meet the intended needs. Specifically, two additional fields
+``metadata_type`` and ``data_type
+
+
+As presented above, the main two permissions are :attr:`Permission.BROWSE` and :attr:`Permission.READ` which
+correspondingly serve to retrieve *metadata* and actual *data* of a given :term:`Resource`. To distinguish requests
+between these two types of contents, `ServiceTHREDDS`_ employs two parts from the request path, the sub-path *prefix*
+and the file *extension*. The *default* methodology employed to categorize these two types of content is presented
+below.
+
+.. code-block:: YAML
+
+    providers:
+      thredds_service:
+        data_type:
+          - prefix: fileServer
+          - prefix: dodsC
+          - prefix: wcs
+          - prefix: wms
+        metadata_type:
+          # no extra sub-path, case when navigating contents using an UI browser
+          # (`~` is the representation method of JSON's `null`, make sure to adjust accordingly with file extension)
+          - prefix: ~
+          - prefix: catalog
+          - prefix: ncml
+          - prefix: uddc
+          - prefix: iso
+
+
+
+.. note::
+    The *default* categorization between *metadata*/*data* contents can be modified using custom configurations
+    specified within a `providers.cfg`_ or :ref:`Combined Configuration File`.
+
 
 ServiceGeoserverWMS
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -259,12 +259,22 @@ immediately, and :term:`ACL` will be resolved considering :attr:`Scope.RECURSIVE
 
 Once the last element of the path is reached, the ``file_patterns`` will be applied against ``<file>`` in order to
 attempt extracting the targeted :class:`magpie.models.File` :term:`Resource`. Patterns are applied until the first
-positive match is found. Therefore, order is important if providing multiple. If there is a match, that value will be
-used to lookup the :term:`Resource`. Otherwise, the plain ``<file>`` name is used directly. The plain name is also used
-if ``file_patterns`` is specified as empty or ``null``. Not explicitly overriding the field will result into using the
+positive match is found. Therefore, order is important if providing multiple. For example, if the path ended with
+``file.ncml`` and, that both ``.*.ncml`` and ``.*.nc`` where defined in the configuration in that specific order, the
+result will first match ``.*.ncml``, and the final :class:`magpie.models.File` :term:`Resource` value will be considered
+as ``file.ncml`` for lookup. In this case, another request using only ``file.nc`` would lookup an entirely different
+:term:`Resource`, since the second pattern would be the first valid match. On the other hand, if only ``.*.nc`` was
+defined in ``file_patterns``, the matched pattern would convert both the names ``file.ncml`` and ``file.nc`` to
+``file.nc``, which will lookup exactly the same :class:`magpie.models.File` reference.
+
+To summarize, if ``file_patterns`` produces a match, that matched portion will be used as lookup value of the
+:term:`Resource`. Otherwise, if not any match could be found amongst all the ``file_patterns``, the plain ``<file>``
+name is used directly (as is from the specified request path). The plain name is also used if ``file_patterns`` is
+explicitly specified as an empty list or ``null``. Not explicitly overriding the field will result into using the
 above *default* ``file_patterns``. The ``file_patterns`` allow for example to consider ``file.nc``, ``file.ncml`` and
 ``file.nc.html`` as the same :term:`Resource` internally, which avoids duplicating :term:`Applied Permissions` across
-multiple :term:`Resource` for every *metadata* or *data* representation.
+multiple :term:`Resource` for their corresponding *metadata* or *data* representations.
+
 
 ServiceBaseWMS
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -124,6 +124,7 @@ by the below configuration.
           prefixes:
             - fileServer
             - dodsC
+            - dap4
             - wcs
             - wms
 
@@ -139,11 +140,11 @@ An incoming request will be parsed according to configured values against the fo
 
 The above template demonstrates that `Magpie` will attempt to match the ``<prefix>`` part with any of the listed
 ``prefixes`` in the configuration. If a match is found, the corresponding *metadata* or *data* content will be assumed,
-according to where the match entry was located, to determine whether :attr:`Permission.BROWSE` or
-:attr:`Permission.READ` should be respectively assumed for this request access. If no ``<prefix>`` can be resolved, the
-permission will be immediately assumed as :attr:`Access.DENY`. To allow top-level access directly on the
-:term:`Service`'s root without ``<prefix>``, it is important to provide ``null`` within the desired ``prefixes`` list.
-Duplicates between the two lists of ``prefixes`` will favor entries in ``metadata_type`` over ``data_type``.
+according to where the match entry was located, to determine whether the requested :term:`Resource` should be validated
+respectively for :attr:`Permission.BROWSE` or :attr:`Permission.READ` access. If no ``<prefix>`` can be resolved, the
+permission will be immediately assumed as :attr:`Access.DENY` regardless of type. To allow top-level access directly on
+the :term:`Service`'s root without ``<prefix>``, it is important to provide ``null`` within the desired ``prefixes``
+list. Duplicates between the two lists of ``prefixes`` will favor entries in ``metadata_type`` over ``data_type``.
 
 After resolution of the content type from ``<prefix>``, the resolution of any amount of :class:`magpie.models.Directory`
 :term:`Resource` will be attempted. Any missing children directory :term:`Resource` will terminate the lookup process

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -37,8 +37,6 @@ Available helpers:
       - | Synchronizes local and remote resources based on `Magpie` service's ``sync-type`` methodology.
         | See also `magpie-con`_.
 
-.. _configuration: configuration.rst
-.. _magpie-con: https://github.com/Ouranosinc/Magpie/tree/master/magpie-cron
 
 For convenience, a generic CLI ``magpie_helper`` is also provided which allows calling each of the other helper
 operations as *mode*. You can therefore do as follows.

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -35,7 +35,7 @@ Available helpers:
         | This operation is the same command that is executed at `Magpie` startup to ensure data integrity.
     * - ``magpie_sync_resources``
       - | Synchronizes local and remote resources based on `Magpie` service's ``sync-type`` methodology.
-        | See also `magpie-con`_.
+        | See also `magpie-cron`_.
 
 
 For convenience, a generic CLI ``magpie_helper`` is also provided which allows calling each of the other helper

--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -2,7 +2,7 @@
 General meta information on the magpie package.
 """
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 __title__ = "Magpie"
 __package__ = "magpie"  # pylint: disable=W0622
 __author__ = "Francois-Xavier Derue, Francis Charette-Migneault"

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -64,9 +64,11 @@ class MagpieOWSSecurity(OWSSecurityInterface):
                     for attr_name in base_attr:
                         LOGGER.debug("  %s: %s", attr_name, getattr(authn_policy.cookie, attr_name))
 
-                if not has_permission:
-                    raise OWSAccessForbidden("Not authorized to access this resource. "
-                                             "User does not meet required permissions.")
+                if has_permission:
+                    return  # allowed
+
+            raise OWSAccessForbidden("Not authorized to access this resource. "
+                                     "User does not meet required permissions.")
 
     def update_request_cookies(self, request):
         """

--- a/magpie/adapter/magpieservice.py
+++ b/magpie/adapter/magpieservice.py
@@ -87,7 +87,8 @@ class MagpieServiceStore(ServiceStoreInterface):
 
             return Service(url=service.url,
                            name=service.resource_name,
-                           type=service.type)
+                           type=service.type,
+                           verify=self.twitcher_ssl_verify)
         finally:
             session.close()
 

--- a/magpie/alembic/versions/2020-10-28_9b8e5d37f684_thredds_browse_for_read_resources.py
+++ b/magpie/alembic/versions/2020-10-28_9b8e5d37f684_thredds_browse_for_read_resources.py
@@ -1,0 +1,117 @@
+"""
+Apply THREDDS BROWSE permission for resources with READ
+
+Due to the addition of metadata BROWSE permission, any pre-existing resource with READ permissions for user/group
+that previously handled both metadata and data access would become denied access for metadata-related access.
+Automatically assign the corresponding permission to make change transparent for pre-existing resources.
+
+Revision ID: 9b8e5d37f684
+Revises: 5f2648b8ff49
+Create Date: 2020-10-28 12:49:22.735259
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic.context import get_context  # noqa: F401
+from sqlalchemy.dialects.postgresql.base import PGDialect
+from sqlalchemy.orm.session import sessionmaker
+from ziggurat_foundations.models.services.group_resource_permission import GroupResourcePermissionService
+from ziggurat_foundations.models.services.user_resource_permission import UserResourcePermissionService
+
+# revision identifiers, used by Alembic.
+revision = "9b8e5d37f684"
+down_revision = "5f2648b8ff49"
+branch_labels = None
+depends_on = None
+
+Session = sessionmaker()
+
+services = sa.table(
+    "services",
+    sa.column("resource_id", sa.Integer),
+    sa.column("type", sa.UnicodeText)
+)
+resources = sa.table(
+    "resources",
+    sa.column("resource_id", sa.Integer),
+    sa.column("root_service_id", sa.Integer)
+)
+grp_res_perms = sa.table(
+    "groups_resources_permissions",
+    sa.column("group_id", sa.Integer),
+    sa.column("resource_id", sa.Integer),
+    sa.column("perm_name", sa.UnicodeText)
+)
+usr_res_perms = sa.table(
+    "users_resources_permissions",
+    sa.column("user_id", sa.Integer),
+    sa.column("resource_id", sa.Integer),
+    sa.column("perm_name", sa.UnicodeText)
+)
+
+
+def duplicate_browse(resource_id, session):
+    grp_query = sa.select([grp_res_perms]).where(grp_res_perms.c.resource_id == resource_id)
+    grp_perms = session.execute(grp_query)
+    usr_query = sa.select([usr_res_perms]).where(usr_res_perms.c.resource_id == resource_id)
+    usr_perms = session.execute(usr_query)
+
+    for perm in grp_perms:
+        if not perm.perm_name.startswith("read"):  # must consider any variant with [access]-[scope]
+            continue
+        perm_name = perm.perm_name.replace("read", "browse")
+        query = sa.insert(grp_res_perms, (perm.group_id, resource_id, perm_name))
+        session.execute(query)
+
+    for perm in usr_perms:
+        if not perm.perm_name.startswith("read"):  # must consider any variant with [access]-[scope]
+            continue
+        perm_name = perm.perm_name.replace("read", "browse")
+        query = sa.insert(usr_res_perms, (perm.user_id, resource_id, perm_name))
+        session.execute(query)
+
+
+def upgrade():
+    """
+    Duplicate THREDDS Service and sub-resources READ permissions with BROWSE.
+    """
+    session = Session(bind=op.get_bind())
+
+    query = sa.select([services]).where(services.c.type == "thredds")
+    thredds_services = session.execute(query)
+
+    for svc in thredds_services:
+        svc_id = svc.resource_id
+        duplicate_browse(svc_id, session)
+
+        query = sa.select([resources]).where(resources.c.root_service_id == svc_id)
+        child_resources = session.execute(query)
+        for res in child_resources:
+            duplicate_browse(res.resource_id, session)
+
+    session.commit()
+
+
+def downgrade():
+    """
+    Any existing 'BROWSE' permission must be dropped.
+    """
+    context = get_context()
+    session = Session(bind=op.get_bind())
+    if not isinstance(context.connection.engine.dialect, PGDialect):
+        return
+
+    # two following lines avoids double "DELETE" erroneous call (ignore duplicate)
+    # https://stackoverflow.com/questions/28824401
+    context.connection.engine.dialect.supports_sane_rowcount = False
+    context.connection.engine.dialect.supports_sane_multi_rowcount = False
+
+    grp_perms = GroupResourcePermissionService.base_query(db_session=session)
+    usr_perms = UserResourcePermissionService.base_query(db_session=session)
+    for perm in grp_perms:
+        if perm.perm_name == "browse":
+            session.delete(perm)
+    for perm in usr_perms:
+        if perm.perm_name == "browse":
+            session.delete(perm)
+    session.commit()

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -59,16 +59,16 @@ def main(global_config=None, **settings):  # noqa: F811
     print_log("Register default users...", LOGGER)
     register_defaults(db_session=db_session, settings=settings)
 
+    print_log("Register service providers...", logger=LOGGER)
     combined_config = get_constant("MAGPIE_CONFIG_PATH", settings, default_value=None,
                                    raise_missing=False, raise_not_set=False, print_missing=True)
-    print_log("Register configuration providers...", logger=LOGGER)
     push_phoenix = asbool(get_constant("PHOENIX_PUSH", settings, settings_name="phoenix.push", default_value=False,
                                        raise_missing=False, raise_not_set=False, print_missing=True))
-
     prov_cfg = combined_config or get_constant("MAGPIE_PROVIDERS_CONFIG_PATH", settings, default_value="",
                                                raise_missing=False, raise_not_set=False, print_missing=True)
-    magpie_register_services_from_config(prov_cfg, push_to_phoenix=push_phoenix,
-                                         force_update=True, disable_getcapabilities=False, db_session=db_session)
+    settings["magpie.services"] = magpie_register_services_from_config(prov_cfg, push_to_phoenix=push_phoenix,
+                                                                       force_update=True, disable_getcapabilities=False,
+                                                                       db_session=db_session)
 
     print_log("Register configuration permissions...", LOGGER)
     perm_cfg = combined_config or get_constant("MAGPIE_PERMISSIONS_CONFIG_PATH", settings, default_value="",

--- a/magpie/owsrequest.py
+++ b/magpie/owsrequest.py
@@ -115,6 +115,9 @@ class OWSPostParser(OWSParser):
             return self.document.attrib[param].lower()
         if param == "request":
             return self.document.tag.lower()
+        for section in self.document:
+            if param == section.tag.lower():
+                return section.text.strip()
         return None
 
 

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -23,6 +23,7 @@ class Permission(ExtendedEnum):
     READ = "read"
     WRITE = "write"
     ACCESS = "access"
+    BROWSE = "browse"
     # WPS permissions
     GET_CAPABILITIES = "getcapabilities"
     GET_MAP = "getmap"

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -567,7 +567,7 @@ def _expand_all(config):
             config[i] = _expand_all(cfg)
     elif isinstance(config, six.string_types):
         config = os.path.expandvars(str(config))
-    elif isinstance(config, (int, bool, float)):
+    elif isinstance(config, (int, bool, float, type(None))):
         pass
     else:
         raise NotImplementedError("unknown parsing of config of type: {}".format(type(config)))

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -456,16 +456,6 @@ class ServiceBaseWMS(ServiceOWS):
         "dataset"
     ]
 
-    resource_types_permissions = {
-        models.Workspace: [
-            Permission.GET_CAPABILITIES,
-            Permission.GET_MAP,
-            Permission.GET_FEATURE_INFO,
-            Permission.GET_LEGEND_GRAPHIC,
-            Permission.GET_METADATA,
-        ]
-    }
-
 
 class ServiceNCWMS2(ServiceBaseWMS):
     """
@@ -542,6 +532,16 @@ class ServiceGeoserverWMS(ServiceBaseWMS):
     Service that represents a ``Web Map Service`` endpoint with functionalities specific to ``GeoServer``.
     """
     service_type = "geoserverwms"
+
+    resource_types_permissions = {
+        models.Workspace: [
+            Permission.GET_CAPABILITIES,
+            Permission.GET_MAP,
+            Permission.GET_FEATURE_INFO,
+            Permission.GET_LEGEND_GRAPHIC,
+            Permission.GET_METADATA,
+        ]
+    }
 
     def resource_requested(self):
         permission = self.permission_requested()

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -658,10 +658,10 @@ class ServiceTHREDDS(ServiceInterface):
     service_type = "thredds"
 
     permissions = [
+        Permission.BROWSE,
+        # read are for
         Permission.READ,
-        # FIXME:
-        #   does WRITE permission even make sense here?
-        #   leave it for bw-compat, but not even considered since 'permission_requested' always returns READ
+        # NOTE: see special usage of WRITE in docs
         Permission.WRITE,
     ]
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -711,7 +711,7 @@ class ServiceTHREDDS(ServiceInterface):
             # when reaching the final part, test for possible file pattern, otherwise default to literal value
             #   allows combining different naming formats into a common file resource (eg: extra extensions)
             # if final part is a directory, still works because of literal value
-            #   directory name much match exactly, no format naming variants allowed
+            #   directory name must match exactly, no format naming variants allowed
             # if final part is 'catalog.html' file, lookup would fail and fall back to previous directory part
             #   since that would be the last part extracted, the parent directory will be matched as intended
             if not path_parts:

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -78,9 +78,9 @@ class ServiceInterface(object):
         The method must specifically define how to convert generic request path, query, etc. elements into permissions
         that match the service and its children resources.
 
-        If ``None`` is returned, the ACL will effectively be resolved to denied access.
+        If ``None`` is returned, the :term:`ACL` will effectively be resolved to denied access.
         Otherwise, one or more returned :class:`Permission` will indicate which permissions should be looked for to
-        resolve the ACL of the authenticated user and its groups.
+        resolve the :term:`ACL` of the authenticated user and its groups.
         """
         raise NotImplementedError("missing implementation of request permission converter")
 
@@ -689,7 +689,7 @@ class ServiceTHREDDS(ServiceInterface):
         cfg.setdefault("file_patterns", [r".*.nc"])
         cfg.setdefault("data_type", {"prefixes": []})
         if not cfg["data_type"]["prefixes"]:
-            cfg["data_type"]["prefixes"] = ["fileServer", "dodsC", "wcs", "wms"]
+            cfg["data_type"]["prefixes"] = ["fileServer", "dodsC", "dap4", "wcs", "wms"]
         cfg.setdefault("metadata_type", {"prefixes": []})
         if not cfg["metadata_type"]["prefixes"]:
             cfg["metadata_type"]["prefixes"] = [None, "catalog", "ncml", "uddc", "iso"]
@@ -719,7 +719,7 @@ class ServiceTHREDDS(ServiceInterface):
                     try:
                         part_name = re.match(pattern, part_name)[0]
                         break
-                    except (TypeError, KeyError):  # fail match or fail to extract
+                    except (TypeError, KeyError):  # fail match or fail to extract (depending on configured pattern)
                         pass
             child_res_id = child_resource.resource_id
             child_resource = models.find_children_by_name(part_name, parent_id=child_res_id, db_session=self.request.db)
@@ -727,7 +727,7 @@ class ServiceTHREDDS(ServiceInterface):
                 found_resource = child_resource
 
         # target resource reached if no more parts to process, otherwise we have some parent (minimally the service)
-        target = not len(path_parts)
+        target = not len(path_parts) and child_resource is not None
         return found_resource, target
 
     def permission_requested(self):

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -1,3 +1,4 @@
+import re
 from typing import TYPE_CHECKING
 
 import abc
@@ -15,6 +16,7 @@ from magpie.api import exception as ax
 from magpie.constants import get_constant
 from magpie.owsrequest import ows_parser_factory
 from magpie.permissions import Access, Permission, PermissionSet, PermissionType, Scope
+from magpie.utils import get_settings
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
@@ -23,7 +25,7 @@ if TYPE_CHECKING:
     from pyramid.request import Request
     from ziggurat_foundations.permissions import PermissionTuple  # noqa
 
-    from magpie.typedefs import AccessControlListType, ServiceOrResourceType, Str
+    from magpie.typedefs import AccessControlListType, ConfigDict, ServiceOrResourceType, Str
 
 
 class ServiceMeta(type):
@@ -210,7 +212,14 @@ class ServiceInterface(object):
         if svc_name not in path_parts:
             return None
         svc_idx = path_parts.index(svc_name)
-        return path_parts[svc_idx + 1::]
+        return path_parts[svc_idx + 1:]
+
+    def get_config(self):
+        # type: () -> ConfigDict
+        """
+        Obtains the configuration of the registered service during startup.
+        """
+        return get_settings(self.request).get("services", {}).get(self.service.resource_name, {})
 
     @classmethod
     def get_resource_permissions(cls, resource_type_name):
@@ -606,17 +615,19 @@ class ServiceAPI(ServiceInterface):
         route_parts = self._get_request_path_parts()
         if not route_parts:
             return self.service, True
-        route_child = self.service
+        route_found = route_child = self.service
 
         # find deepest possible resource matching sub-route name
         while route_child and route_parts:
             part_name = route_parts.pop(0)
             route_res_id = route_child.resource_id
             route_child = models.find_children_by_name(part_name, parent_id=route_res_id, db_session=self.request.db)
+            if route_child:
+                route_found = route_child
 
         # target reached if no more parts to process, otherwise we have some parent (minimally the service)
-        route_target = not len(route_parts)
-        return route_child, route_target
+        route_target = not len(route_parts) and route_child is not None
+        return route_found, route_target
 
     def permission_requested(self):
         if self.request.method.upper() in ["GET", "HEAD"]:
@@ -672,50 +683,64 @@ class ServiceTHREDDS(ServiceInterface):
         models.File: permissions,
     }
 
+    def get_config(self):
+        # type: () -> ConfigDict
+        cfg = super(ServiceTHREDDS, self).get_config()
+        cfg.setdefault("file_patterns", [r".*.nc"])
+        cfg.setdefault("data_type", {"prefixes": []})
+        if not cfg["data_type"]["prefixes"]:
+            cfg["data_type"]["prefixes"] = ["fileServer", "dodsC", "wcs", "wms"]
+        cfg.setdefault("metadata_type", {"prefixes": []})
+        if not cfg["metadata_type"]["prefixes"]:
+            cfg["metadata_type"]["prefixes"] = [None, "catalog", "ncml", "uddc", "iso"]
+        return cfg
+
     def resource_requested(self):
         path_parts = self._get_request_path_parts()
 
-        re.match(".*.nc", os.path.split(path)[-1])[0]
-
-        # handled optional prefix and missing specifiers
-        if not path_parts:
+        # handle optional prefix or remove it
+        if len(path_parts) < 2:
             return self.service, True
-        if path_parts[0] == "":
-            path_parts = path_parts[1:]
-        if path_parts and path_parts[0].lower() == "thredds":
-            path_parts = path_parts[1:]
-        if not path_parts:
-            return self.service, True
-
-        # when looking at catalog, must point to corresponding parent Directory
-        if path_parts[-1].lower() == "catalog.html":
-            path_parts = path_parts[:-1]
-        # convert file name to common value representing the same NetCDF resource accessed
-        if ".nc" in path_parts[-1].lower():
-            # same as 'catalog.html' when 'catalog' is in path, even if '.nc' file is specified
-            # (THREDDS redirects to HTML view of parent directory)
-            if path_parts[0] == "catalog":
-                path_parts = path_parts[:-1]
-            # otherwise it is the specific representation of the NetCDF
-            # remove any extra extension whenever applicable (eg: discard '.dds' from '.nc.dds')
-            else:
-                path_parts[-1] = path_parts[-1].split(".nc")[0] + ".nc"
-        # remove the 'serviceType' prefix (dodsC, catalog, etc.)
         path_parts = path_parts[1:]
+        cfg = self.get_config()
 
         # find deepest possible resource matching either Directory or File by name
-        found_resource = self.service
-        while found_resource and path_parts:
+        found_resource = child_resource = self.service
+        while child_resource and path_parts:
             part_name = path_parts.pop(0)
-            found_res_id = found_resource.resource_id
-            found_resource = models.find_children_by_name(part_name, parent_id=found_res_id, db_session=self.request.db)
+            # when reaching the final part, test for possible file pattern, otherwise default to literal value
+            #   allows combining different naming formats into a common file resource (eg: extra extensions)
+            # if final part is a directory, still works because of literal value
+            #   directory name much match exactly, no format naming variants allowed
+            # if final part is 'catalog.html' file, lookup would fail and fall back to previous directory part
+            #   since that would be the last part extracted, the parent directory will be matched as intended
+            if not path_parts:
+                for pattern in cfg["file_patterns"]:
+                    try:
+                        part_name = re.match(pattern, part_name)[0]
+                        break
+                    except (TypeError, KeyError):  # fail match or fail to extract
+                        pass
+            child_res_id = child_resource.resource_id
+            child_resource = models.find_children_by_name(part_name, parent_id=child_res_id, db_session=self.request.db)
+            if child_resource:
+                found_resource = child_resource
 
         # target resource reached if no more parts to process, otherwise we have some parent (minimally the service)
         target = not len(path_parts)
         return found_resource, target
 
     def permission_requested(self):
-        return Permission.READ
+        path_parts = self._get_request_path_parts() or [None]  # in case of no `<prefix>`, simulate as `null`
+        path_prefix = path_parts[0]
+        cfg = self.get_config()
+        for prefix in cfg["metadata_type"]["prefixes"]:
+            if prefix == path_prefix:
+                return Permission.BROWSE
+        for prefix in cfg["data_type"]["prefixes"]:
+            if prefix == path_prefix:
+                return Permission.READ
+        return None  # automatically deny
 
 
 SERVICE_TYPE_DICT = dict()

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -403,8 +403,8 @@ class ServiceWPS(ServiceOWS):
     params_expected = [
         "service",
         "request",
-        "version"
-        # "identifier" not used because not required when requesting capabilities
+        "version",
+        "identifier",
     ]
 
     resource_types_permissions = {
@@ -420,7 +420,7 @@ class ServiceWPS(ServiceOWS):
             return self.service, True
         if wps_request in [Permission.DESCRIBE_PROCESS, Permission.EXECUTE]:
             wps_id = self.service.resource_id
-            proc_id = self.request.params.get("identifier")
+            proc_id = self.parser.params["identifier"]
             if not proc_id:
                 return self.service, False
             proc = models.find_children_by_name(proc_id, parent_id=wps_id, db_session=self.request.db)

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -658,11 +658,9 @@ class ServiceTHREDDS(ServiceInterface):
     service_type = "thredds"
 
     permissions = [
-        Permission.BROWSE,
-        # read are for
-        Permission.READ,
-        # NOTE: see special usage of WRITE in docs
-        Permission.WRITE,
+        Permission.BROWSE,  # for metadata access
+        Permission.READ,    # for file data access
+        Permission.WRITE,   # NOTE: see special usage of WRITE in docs
     ]
 
     params_expected = [
@@ -676,6 +674,8 @@ class ServiceTHREDDS(ServiceInterface):
 
     def resource_requested(self):
         path_parts = self._get_request_path_parts()
+
+        re.match(".*.nc", os.path.split(path)[-1])[0]
 
         # handled optional prefix and missing specifiers
         if not path_parts:

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -219,7 +219,7 @@ class ServiceInterface(object):
         """
         Obtains the configuration of the registered service during startup.
         """
-        return get_settings(self.request).get("services", {}).get(self.service.resource_name, {})
+        return get_settings(self.request).get("magpie.services", {}).get(self.service.resource_name, {})
 
     @classmethod
     def get_resource_permissions(cls, resource_type_name):

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -73,3 +73,8 @@ if TYPE_CHECKING:
     AnyAccessPrincipalType = Union[Str, Iterable[Str]]
     AccessControlEntryType = Union[Tuple[Str, Str, Str], Str]
     AccessControlListType = List[AccessControlEntryType]
+
+    # registered configurations
+    ConfigItem = Dict[Str, JSON]
+    ConfigList = List[ConfigItem]
+    ConfigDict = Dict[Str, Union[ConfigItem, ConfigList]]

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -77,4 +77,4 @@ if TYPE_CHECKING:
     # registered configurations
     ConfigItem = Dict[Str, JSON]
     ConfigList = List[ConfigItem]
-    ConfigDict = Dict[Str, Union[ConfigItem, ConfigList]]
+    ConfigDict = Dict[Str, Union[ConfigItem, ConfigList, JSON]]

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -429,17 +429,19 @@ table.panel-line td {
     padding: 0 0.5em 0 0;
 }
 
-.alert-note-info {
+.alert-note {
     width: auto;
     display: inline-flex;
     float: left;
-    text-align: center;
-    margin-top: 0.25em;
+    margin-top: 1em;
     margin-left: 0.1em;
 }
 
 .alert-note-text {
     margin-left: 0.25em;
+    margin-bottom: -1em;
+    margin-top: -1em;
+    text-align: left;
 }
 
 .icon-error {
@@ -450,6 +452,7 @@ table.panel-line td {
 .icon-warning {
     width: 1.25em;
     height: 1.25em;
+    margin-top: 0.05em;
 }
 
 .icon-info {
@@ -479,6 +482,16 @@ table.panel-line td {
 .option-text {
 }
 
+.permission-apply-container {
+    display: inline-block;
+    width: 100%;
+}
+
+.permission-apply-container>input {
+    float: right;
+    margin-right: 1.25em;
+}
+
 .permission-effective {
     background-color: white;
     padding: 1px 2px 2px;
@@ -489,17 +502,17 @@ table.panel-line td {
     margin-right: 0.05em;
 }
 
+.permission-effective-tester {
+    float: right;
+    display: inline-flex;
+}
+
 .success {
     color: #2C8F30;
 }
 
 .failure {
     color: #880000;
-}
-
-.permission-effective-tester {
-    float: right;
-    display: inline-flex;
 }
 
 input[type="button"].permission-effective-button {

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -194,18 +194,20 @@ table thead {
 }
 
 .checkbox-align label {
-  display: block;
-  /*float: left;*/
-  padding-left: 0.2em;
-  padding-right: 0.2em;
-  padding-bottom: 1em;
-  white-space: nowrap;
+    display: block;
+    /*float: left;*/
+    padding-left: 0.2em;
+    padding-right: 0.2em;
+    padding-bottom: 1em;
+    white-space: nowrap;
 }
 .checkbox-align input {
-  vertical-align: middle;
+    vertical-align: middle;
+    margin-top: 0.05em;
 }
+
 .checkbox-align label span {
-  vertical-align: middle;
+    vertical-align: middle;
 }
 
 /*---Panel Information Box---*/
@@ -267,10 +269,8 @@ table.panel-line td {
 }
 
 .panel-line-checkbox {
-    vertical-align: middle;
-    display: inline-flex;
-    margin-top: 0;
-    margin-bottom: 0;
+    padding-top: 0.1em;
+    display: inline-block;
 }
 
 .panel-title {
@@ -467,13 +467,16 @@ table.panel-line td {
     display: none;
 }
 
+.option-container {
+    margin-bottom: 1em;
+}
+
 .option-section {
     margin-left: 0.5em;
     display: inline-block;
 }
 
 .option-text {
-
 }
 
 .permission-effective {
@@ -570,12 +573,13 @@ table.simple-list input[type="submit"] {
 }
 
 .tree-header {
-    padding: 5em 0 2em;
+    padding: 1em 0 0;
     font-weight: bold;
 }
 
 .tree .collapsible {
     /*cursor: pointer;*/  /* looks better on 'tree-key' element */
+    margin-top: -1em;  /* make each new sub-list aligned such as if continuous flat list without extra spacing */
 }
 
 .tree .collapsible > ul {
@@ -585,6 +589,23 @@ table.simple-list input[type="submit"] {
 
 .tree .collapsible.expanded > ul {
     display: block;     /* expanded */
+}
+
+/* fake marker area to receive click event handler over 'collapsible::marker' list-item (toggling arrow) */
+.collapsible-marker {
+    /* make the area offset back (starting from text) over the arrow marker of list-item */
+    position: relative;
+    left: -1.25em;
+    top: 1.25em;
+    /* make the marker area large enough to overlap completely the arrow with a little overflow  */
+    width: 1.25em;
+    height: 1.25em;
+    margin-bottom: -0.25em;  /* undo extra height added to align the marker, preserve appearance of line height */
+    background-color: transparent;  /* adjust color with alpha value to apply changes to help visualize during edits */
+}
+
+.collapsible-marker:hover {
+    cursor: pointer;
 }
 
 /* leaf nodes will have this style, as not overridden by following ones */
@@ -663,6 +684,9 @@ div.tree-button {
 
 .clear {
     clear: both;
+}
+
+.underline {
     border-bottom: 1px solid #DDDDDD;
 }
 
@@ -747,6 +771,14 @@ ul.breadcrumb li a:hover {
     vertical-align: center;
 }
 
+.header-line {
+    height: 5px;  /* offset to avoid being partially under Magpie logo */
+    border-bottom: 1px solid #DDDDDD;
+}
+
+.header-section {
+}
+
 .header>div>a {
     color: white;
     font-size: 3em;
@@ -795,6 +827,14 @@ ul.breadcrumb li a:hover {
 #image-overlay>img {
     width: inherit;
     height: inherit;
+}
+
+.language {
+    float: left;
+}
+
+.logged {
+    float: right;
 }
 
 /*---Home---*/

--- a/magpie/ui/home/templates/template.mako
+++ b/magpie/ui/home/templates/template.mako
@@ -17,11 +17,20 @@
     <meta name="source" content=${MAGPIE_SOURCE_URL}>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script type="text/javascript">
-        <%include file="magpie.ui.management:templates/tree_toggle.js"></%include>
+        <%include file="magpie.ui.management:templates/tree_scripts.js"/>
     </script>
-    <style>
-        <%block name="style"/>
-    </style>
+    <!-- needs more work, some elements should be static such as resource-names -->
+    <!--
+    <script type="text/javascript">
+        function googleTranslateElementInit() {
+          new google.translate.TranslateElement(
+              {pageLanguage: 'en', layout: google.translate.TranslateElement.InlineLayout.SIMPLE},
+              "google_translate_element" // div element id
+          );
+        }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    -->
 </head>
 <body>
 
@@ -65,15 +74,18 @@
             %endif
         </div>
     </div>
-    <div class="clear"></div>
-    <div>
+    <div class="clear header-line"></div>
+    <div class="header-section">
         <ul class="breadcrumb">
             <%block name="breadcrumb"/>
         </ul>
         %if MAGPIE_LOGGED_USER:
-        <div style="float: right;">Logged in: <a href="${request.route_url('edit_current_user')}">${MAGPIE_LOGGED_USER}</a></div>
+        <div class="logged">
+            Logged in: <a href="${request.route_url('edit_current_user')}">${MAGPIE_LOGGED_USER}</a>
+        </div>
         %endif
     </div>
+    <div class="language" id="google_translate_element"></div>
 </div>
 
 <div class="content">

--- a/magpie/ui/management/templates/add_resource.mako
+++ b/magpie/ui/management/templates/add_resource.mako
@@ -1,14 +1,18 @@
 <%inherit file="magpie.ui.home:templates/template.mako"/>
 
 <%block name="breadcrumb">
-<li><a href="${request.route_url('home')}">
-    Home</a></li>
-<li><a href="${request.route_url('view_services', cur_svc_type=cur_svc_type)}">
-    Services</a></li>
-<li><a href="${request.route_url('edit_service', service_name=service_name, cur_svc_type=cur_svc_type)}">
-    Service [${service_name}]</a></li>
-<li><a href="${request.route_url('add_resource', service_name=service_name, cur_svc_type=cur_svc_type, resource_id=resource_id)}">
-    Add Resource</a></li>
+<li><a href="${request.route_url('home')}">Home</a></li>
+<li><a href="${request.route_url('view_services', cur_svc_type=cur_svc_type)}">Services</a></li>
+<li>
+    <a href="${request.route_url('edit_service', service_name=service_name, cur_svc_type=cur_svc_type)}">
+    Service [${service_name}]
+    </a>
+</li>
+<li>
+    <a href="${request.route_url('add_resource', service_name=service_name, cur_svc_type=cur_svc_type, resource_id=resource_id)}">
+    Add Resource
+    </a>
+</li>
 </%block>
 
 <h1>New Resource</h1>

--- a/magpie/ui/management/templates/edit_group.mako
+++ b/magpie/ui/management/templates/edit_group.mako
@@ -2,12 +2,13 @@
 <%namespace name="tree" file="magpie.ui.management:templates/tree_scripts.mako"/>
 
 <%block name="breadcrumb">
-<li><a href="${request.route_url('home')}">
-    Home</a></li>
-<li><a href="${request.route_url('view_groups')}">
-    Groups</a></li>
-<li><a href="${request.route_url('edit_group', group_name=group_name, cur_svc_type=cur_svc_type)}">
-    Group [${group_name}]</a></li>
+<li><a href="${request.route_url('home')}">Home</a></li>
+<li><a href="${request.route_url('view_groups')}">Groups</a></li>
+<li>
+    <a href="${request.route_url('edit_group', group_name=group_name, cur_svc_type=cur_svc_type)}">
+    Group [${group_name}]
+    </a>
+</li>
 </%block>
 
 <h1>Edit Group: [${group_name}]</h1>
@@ -88,9 +89,9 @@
                     </p>
                 </form>
                 <form id="edit_discoverable" action="${request.path}" method="post">
-                    <p class="panel-line panel-line-checkbox">
+                    <p class="panel-line">
                         <span class="panel-entry">Discoverable: </span>
-                        <label>
+                        <label class="checkbox-align panel-line-checkbox">
                         <!-- when unchecked but checkbox pressed checkbox 'value' not actually sent -->
                         <input type="hidden" value="${discoverable}" name="is_discoverable"/>
                         <input type="checkbox" name="new_discoverable"
@@ -118,7 +119,7 @@
 %for user in users:
 <tr>
     <td>
-        <label>
+        <label class="checkbox-align">
         <input type="checkbox" value="${user}" name="member"
             %if user in members:
                checked
@@ -153,7 +154,7 @@
     %endfor
 
     <div class="current-tab-panel">
-        <div class="clear"></div>
+        <div class="clear underline"></div>
         %if error_message:
             <div class="alert alert-danger alert-visible">${error_message}</div>
         %endif

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -2,12 +2,13 @@
 <%namespace name="tree" file="magpie.ui.management:templates/tree_scripts.mako"/>
 
 <%block name="breadcrumb">
-<li><a href="${request.route_url('home')}">
-    Home</a></li>
-<li><a href="${request.route_url('view_services', cur_svc_type=cur_svc_type)}">
-    Services</a></li>
-<li><a href="${request.route_url('edit_service', service_name=service_name, service_url=service_url, cur_svc_type=cur_svc_type)}">
-    Service [${service_name}]</a></li>
+<li><a href="${request.route_url('home')}">Home</a></li>
+<li><a href="${request.route_url('view_services', cur_svc_type=cur_svc_type)}">Services</a></li>
+<li>
+    <a href="${request.route_url('edit_service', service_name=service_name, service_url=service_url, cur_svc_type=cur_svc_type)}">
+    Service [${service_name}]
+    </a>
+</li>
 </%block>
 
 <div class="alert alert-danger" id="EditService_DeleteAlert">

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -3,12 +3,13 @@
 <%namespace name="tree" file="magpie.ui.management:templates/tree_scripts.mako"/>
 
 <%block name="breadcrumb">
-<li><a href="${request.route_url('home')}">
-    Home</a></li>
-<li><a href="${request.route_url('view_users')}">
-    Users</a></li>
-<li><a href="${request.route_url('edit_user', user_name=user_name, cur_svc_type=cur_svc_type)}">
-    User [${user_name}]</a></li>
+<li><a href="${request.route_url('home')}">Home</a></li>
+<li><a href="${request.route_url('view_users')}">Users</a></li>
+<li>
+    <a href="${request.route_url('edit_user', user_name=user_name, cur_svc_type=cur_svc_type)}">
+    User [${user_name}]
+    </a>
+</li>
 </%block>
 
 <h1>Edit User: [${user_name}]</h1>
@@ -100,7 +101,7 @@
     %for group in groups:
     <tr>
         <td>
-            <label>
+            <label class="checkbox-align">
             <input type="checkbox" value="${group}" name="member"
                 %if group in own_groups:
                    checked
@@ -121,39 +122,41 @@
 
 <h3>Permissions</h3>
 
-<form id="toggle_visible_perms" action="${request.path}" method="post">
-    <div class="option-section">
-        <label>
-        <input type="checkbox" value="${inherit_groups_permissions}" name="toggle_inherit_groups_permissions"
-               onchange="document.getElementById('toggle_visible_perms').submit()"
-        %if inherit_groups_permissions:
-            checked>
-            <input type="hidden" value="False" name="inherit_groups_permissions"/>
-        %else:
-            >
-            <input type="hidden" value="True" name="inherit_groups_permissions"/>
-        %endif
-        <span class="option-text">
-        View inherited group permissions
-        </span>
-        </label>
-    </div>
-</form>
+<div class="option-container">
+    <form id="toggle_visible_perms" action="${request.path}" method="post">
+        <div class="option-section">
+            <label class="checkbox-align">
+            <input type="checkbox" value="${inherit_groups_permissions}" name="toggle_inherit_groups_permissions"
+                   onchange="document.getElementById('toggle_visible_perms').submit()"
+            %if inherit_groups_permissions:
+                checked>
+                <input type="hidden" value="False" name="inherit_groups_permissions"/>
+            %else:
+                >
+                <input type="hidden" value="True" name="inherit_groups_permissions"/>
+            %endif
+            <span class="option-text">
+            View inherited group permissions
+            </span>
+            </label>
+        </div>
+    </form>
 
-%if inherit_groups_permissions:
-<div class="option-section">
-    <div class="alert-note-info alert-visible">
-        <img src="${request.static_url('magpie.ui.home:static/info.png')}"
-             alt="INFO" class="icon-info alert-info" />
-        <meta name="source" content="https://commons.wikimedia.org/wiki/File:Infobox_info_icon.svg">
-        <div class="alert-note-text">
-            Individual resources can be tested for effective access using the
-            <input type="button" value="?" class="permission-effective-button button-no-click">
-            <span>button next to the corresponding permission.</span>
+    %if inherit_groups_permissions:
+    <div class="option-section">
+        <div class="alert-note-info alert-visible">
+            <img src="${request.static_url('magpie.ui.home:static/info.png')}"
+                 alt="INFO" class="icon-info alert-info" />
+            <meta name="source" content="https://commons.wikimedia.org/wiki/File:Infobox_info_icon.svg">
+            <div class="alert-note-text">
+                Individual resources can be tested for effective access using the
+                <input type="button" value="?" class="permission-effective-button button-no-click">
+                <span>button next to the corresponding permission.</span>
+            </div>
         </div>
     </div>
+    %endif
 </div>
-%endif
 
 <div class="tabs-panel">
 
@@ -168,7 +171,7 @@
     %endfor
 
     <div class="current-tab-panel">
-        <div class="clear"></div>
+        <div class="clear underline"></div>
         %if error_message:
             <div class="alert alert-danger alert-visible">${error_message}</div>
         %endif

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -136,7 +136,7 @@
                 <input type="hidden" value="True" name="inherit_groups_permissions"/>
             %endif
             <span class="option-text">
-            View inherited group permissions
+            View inherited group permissions and effective user permissions.
             </span>
             </label>
         </div>
@@ -144,14 +144,26 @@
 
     %if inherit_groups_permissions:
     <div class="option-section">
-        <div class="alert-note-info alert-visible">
+        <div class="alert-note alert-visible">
             <img src="${request.static_url('magpie.ui.home:static/info.png')}"
-                 alt="INFO" class="icon-info alert-info" />
+                 alt="INFO" class="icon-info alert-info" title="User effective permission resolution." />
             <meta name="source" content="https://commons.wikimedia.org/wiki/File:Infobox_info_icon.svg">
             <div class="alert-note-text">
-                Individual resources can be tested for effective access using the
-                <input type="button" value="?" class="permission-effective-button button-no-click">
-                <span>button next to the corresponding permission.</span>
+                <p>
+                    Individual resources can be tested for effective access using the
+                    <input type="button" value="?" class="permission-effective-button button-no-click">
+                    <span>button next to the corresponding permission.</span>
+                    <br>Displayed permissions combine user direct permissions and inherited group permissions.
+                </p>
+            </div>
+        </div>
+        <div class="alert-note alert-visible">
+            <img src="${request.static_url('magpie.ui.home:static/exclamation-triangle.png')}"
+                 alt="WARNING" class="icon-warning" title="Administrators effective permission resolution." />
+            <div class="alert-note-text">
+                <p>
+                    Users member of the administrative group have full effective access regardless of permissions.
+                </p>
             </div>
         </div>
     </div>

--- a/magpie/ui/management/templates/tree_scripts.js
+++ b/magpie/ui/management/templates/tree_scripts.js
@@ -3,12 +3,15 @@ $(document).ready(function() {
     *   Because other inputs/buttons are present on each tree item, the event is applied only on the 'tree-key'.
     *   We retrieve the containing list item to toggle its class which handle the display of collapsed/expanded.
     * */
-    $(".tree-key").on("click", function(e) {
-        e.preventDefault();
+    function toggle(event) {
+        event.preventDefault();
         // don't allow the event to fire horizontally or vertically up the tree
-        e.stopImmediatePropagation();
+        event.stopImmediatePropagation();
         let item = $(this).closest(".collapsible");
         // switch the class to collapse/expand the child according to current class applied
         item.toggleClass("expanded");
-    })
+    }
+
+    $(".tree-key").on("click", toggle)
+    $(".collapsible-marker").on("click", toggle)
 })

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -2,13 +2,14 @@
 
 
 <!-- renders a tree of nested service/resources using the provided item renderer function
-     see 'tree_toggle.js' for toggling even
+     see 'tree_scripts.js' for toggling even
 -->
 <%def name="render_tree(item_renderer, tree, level=0)">
     <ul class="tree-level-${level}">
     %for key in tree:
         %if tree[key]["children"]:
         <li class="collapsible expanded">
+        <div class="collapsible-marker"></div>
         %else:
         <li class="no-child">
         %endif
@@ -20,7 +21,7 @@
                     ${item_renderer(key, tree[key], level)}
                 </div>
             </div>
-            <div class="clear"></div>
+            <div class="clear underline"></div>
             %if tree[key]["children"]:
             ${render_tree(item_renderer, tree[key]["children"], level + 1)}
             %endif
@@ -34,12 +35,12 @@
 <%def name="render_resource_permission_tree(resources, permissions)">
     <form id="resources_permissions" action="${request.path}" method="post">
         <div>
-            <input type="submit" name="edit_permissions" value="Apply" title="Apply the permission changes"
+            <input type="submit" name="edit_permissions" value="Apply Permissions" title="Apply the permission changes"
                 %if inherit_groups_permissions:
                     disabled
-                    class="button theme equal-width disabled"
+                    class="button theme disabled"
                 %else:
-                    class="button theme equal-width"
+                    class="button theme"
                 %endif
             >
         </div>

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -34,7 +34,7 @@
 <!-- renderer of specific tree resources with applicable permissions (under a given service-type) -->
 <%def name="render_resource_permission_tree(resources, permissions)">
     <form id="resources_permissions" action="${request.path}" method="post">
-        <div>
+        <div class="permission-apply-container">
             <input type="submit" name="edit_permissions" value="Apply Permissions" title="Apply the permission changes"
                 %if inherit_groups_permissions:
                     disabled

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.1.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -3702,6 +3702,11 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
     def test_GetServiceTypeResources_CheckValues(self):
         utils.warn_version(self, "get service type resources", "0.9.1", skip=True)
 
+        if LooseVersion(self.version) >= LooseVersion("3.1"):
+            thredds_perms = [Permission.BROWSE.value, Permission.READ.value, Permission.WRITE.value]
+        else:
+            thredds_perms = [Permission.READ.value, Permission.WRITE.value]
+
         # evaluate different types of services
         for svc_type, svc_res_info in [
             # recursive child resource allowed
@@ -3713,10 +3718,10 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
             # child resource allowed only for specific types
             (ServiceTHREDDS.service_type,
                 {"directory": {
-                    "perms": [Permission.READ.value, Permission.WRITE.value],
+                    "perms": thredds_perms,
                     "child": True},
                  "file": {
-                     "perms": [Permission.READ.value, Permission.WRITE.value],
+                     "perms": thredds_perms,
                      "child": False}}),
             # no child allowed
             (ServiceAccess.service_type, {}),

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -154,7 +154,7 @@ class BaseTestCase(unittest.TestCase):
                                                      override_headers=admin_headers, override_cookies=admin_cookies)
             utils.check_or_try_logout_user(cls)
 
-    def setup(self):
+    def setUp(self):
         self.test_app = None  # reset: each test must redefine it if a custom one is needed
 
     def tearDown(self):

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -21,7 +21,7 @@ class TestServices(ti.SetupMagpieAdapter, ti.AdminTestCase, ti.BaseTestCase):
         cls.usr = get_constant("MAGPIE_TEST_ADMIN_USERNAME")
         cls.pwd = get_constant("MAGPIE_TEST_ADMIN_PASSWORD")
         cls.settings = cls.app.app.registry.settings
-        ti.SetupMagpieAdapter.setup(cls.settings)
+        cls.setup_adapter()
 
         cls.cookies = None
         cls.version = utils.TestSetup.get_Version(cls)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -310,8 +310,8 @@ class TestServices(ti.SetupMagpieAdapter, ti.AdminTestCase, ti.BaseTestCase):
             according to :class:`ServiceTHREDDS` implementation.
 
         .. seealso::
-            Reference test server to explore supported formats by THREDDS service (many files available):
-            https://remotetest.unidata.ucar.edu/thredds/dodsC/testdods/rtofs.nc.html
+            Reference test server to explore supported formats by THREDDS service (many files and formats available):
+            https://remotetest.unidata.ucar.edu/thredds/catalog/catalog.html
         """
         utils.TestSetup.create_TestGroup(self)
         utils.TestSetup.create_TestUser(self)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -485,8 +485,8 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         # create resources
         dir_id, dir_name = self.make_resource(models.Directory.resource_type_name, svc_id)
         file_id, file_name = self.make_resource(models.File.resource_type_name, dir_id, ".nc")
-        file_ncml_id, file_ncml_name = self.make_resource(models.File.resource_type_name, dir_id, ".ncml")
-        file_html_id, file_html_name = self.make_resource(models.File.resource_type_name, dir_id, ".nc.html")
+        _, file_ncml_name = self.make_resource(models.File.resource_type_name, dir_id, ".ncml")
+        _, file_html_name = self.make_resource(models.File.resource_type_name, dir_id, ".nc.html")
 
         # create permissions, using specific match to only evaluate explicitly the resolution modified by custom config
         bAM = PermissionSet(Permission.BROWSE, Access.ALLOW, Scope.MATCH)       # noqa

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -131,7 +131,7 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 
     @utils.mock_get_settings
     def setUp(self):
-        super(TestServices, self).setUp()
+        ti.UserTestCase.setUp(self)
         self.setup_adapter()
         self.cookies = None
         self.setup_admin()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -124,6 +124,7 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         cls.grp = get_constant("MAGPIE_ADMIN_GROUP")
         cls.usr = get_constant("MAGPIE_TEST_ADMIN_USERNAME")
         cls.pwd = get_constant("MAGPIE_TEST_ADMIN_PASSWORD")
+        cls.setup_admin()
 
         # following will be wiped on setup
         cls.test_user_name = "unittest-service-user"
@@ -134,7 +135,6 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         ti.UserTestCase.setUp(self)
         self.setup_adapter()
         self.cookies = None
-        self.setup_admin()
         self.headers, self.cookies = utils.check_or_try_login_user(self, self.usr, self.pwd, use_ui_form_submit=True)
         self.require = "cannot run tests without logged in user with '{}' permissions".format(self.grp)
         self.check_requirements()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -348,8 +348,9 @@ def mock_get_settings(test):
 
     @functools.wraps(test)
     def wrapped(*_, **__):
-        with mock.patch("magpie.utils.get_settings", side_effect=mocked):
-            return test(*_, **__)
+        with mock.patch("magpie.services.get_settings", side_effect=mocked), \
+             mock.patch("magpie.utils.get_settings", side_effect=mocked):
+                return test(*_, **__)
     return wrapped
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -353,7 +353,7 @@ def mock_get_settings(test):
     def wrapped(*_, **__):
         with mock.patch("magpie.services.get_settings", side_effect=mocked), \
              mock.patch("magpie.utils.get_settings", side_effect=mocked):
-                return test(*_, **__)  # pylint: disable=W0311
+                return test(*_, **__)  # pylint: disable=E117,W0311
     return wrapped
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -353,7 +353,7 @@ def mock_get_settings(test):
     def wrapped(*_, **__):
         with mock.patch("magpie.services.get_settings", side_effect=mocked), \
              mock.patch("magpie.utils.get_settings", side_effect=mocked):
-                return test(*_, **__)  # pylint: disable=E117,W0311
+            return test(*_, **__)
     return wrapped
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -351,10 +351,9 @@ def mock_get_settings(test):
 
     @functools.wraps(test)
     def wrapped(*_, **__):
-        # pylint: disable=W0311
         with mock.patch("magpie.services.get_settings", side_effect=mocked), \
              mock.patch("magpie.utils.get_settings", side_effect=mocked):
-                return test(*_, **__)
+                return test(*_, **__)  # pylint: disable=W0311
     return wrapped
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -351,6 +351,7 @@ def mock_get_settings(test):
 
     @functools.wraps(test)
     def wrapped(*_, **__):
+        # pylint: disable=W0311
         with mock.patch("magpie.services.get_settings", side_effect=mocked), \
              mock.patch("magpie.utils.get_settings", side_effect=mocked):
                 return test(*_, **__)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -228,10 +228,13 @@ def get_test_magpie_app(settings=None):
 def get_app_or_url(test_item):
     # type: (AnyMagpieTestItemType) -> TestAppOrUrlType
     """
-    Obtains the referenced Magpie local application or remote URL from `Test Case` implementation.
+    Obtains the referenced Magpie test application, local application or remote URL from `Test Case` implementation.
     """
     if isinstance(test_item, (TestApp, six.string_types)):
         return test_item
+    test_app = getattr(test_item, "test_app", None)
+    if test_app and isinstance(test_app, TestApp):
+        return test_app
     app_or_url = getattr(test_item, "app", None) or getattr(test_item, "url", None)
     if not app_or_url:
         raise ValueError("Invalid test class, application or URL could not be found.")
@@ -385,6 +388,7 @@ def mock_request(request_path_query="",     # type: Str
     request.content_type = content_type
     request.headers = headers or {}
     request.cookies = cookies or {}
+    request.matched_route = None  # cornice method
     if content_type:
         request.headers["Content-Type"] = content_type
     request.body = body
@@ -598,7 +602,7 @@ def check_or_try_login_user(test_item,                      # type: AnyMagpieTes
             return resp.headers, resp_cookies
 
     if auth is True:
-        body = TestSetup.get_UserInfo(app_or_url, override_body=body)
+        body = TestSetup.get_UserInfo(test_item, override_body=body)
         logged_user = body.get("user_name", "")
         if username != logged_user:
             raise AssertionError("invalid user")


### PR DESCRIPTION
Depends on #353 (rebased). 

- Adds additional `BROWSE` permission to `THEDDS` service (#361)
- Adds many doc details about service implementations.
- Fix and adds test cases for #157 
- Fixes and test some edge case that failed to grant access when target `Resource` was missing (not explicitly defined in db), but that parent `Resource` had recursive-scope `Permission`.

Fixes #157 
Fixes #234
Fixes #361