### PR TITLE
fix visual alignment of perm inherited notices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,13 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
 * Nothing yet.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Adjust visual alignment of UI notices on individual newlines when viewing user inherited permissions.
 
 `3.1.0 <https://github.com/Ouranosinc/Magpie/tree/3.1.0>`_ (2020-10-23)
 ------------------------------------------------------------------------------------

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -458,7 +458,7 @@ table.panel-line td {
 .icon-info {
     width: 1.25em;
     height: 1.25em;
-    margin-top: 0.15em;
+    margin-top: 0.05em;
 }
 
 .icon-color-invert {

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -123,8 +123,8 @@
 <h3>Permissions</h3>
 
 <div class="option-container">
-    <form id="toggle_visible_perms" action="${request.path}" method="post">
-        <div class="option-section">
+    <div class="option-section">
+        <form id="toggle_visible_perms" action="${request.path}" method="post">
             <label class="checkbox-align">
             <input type="checkbox" value="${inherit_groups_permissions}" name="toggle_inherit_groups_permissions"
                    onchange="document.getElementById('toggle_visible_perms').submit()"
@@ -139,10 +139,10 @@
             View inherited group permissions and effective user permissions.
             </span>
             </label>
-        </div>
-    </form>
-
+        </form>
+    </div>
     %if inherit_groups_permissions:
+    <div class="clear"></div>
     <div class="option-section">
         <div class="alert-note alert-visible">
             <img src="${request.static_url('magpie.ui.home:static/info.png')}"
@@ -157,6 +157,9 @@
                 </p>
             </div>
         </div>
+    </div>
+    <div class="clear"></div>
+    <div class="option-section">
         <div class="alert-note alert-visible">
             <img src="${request.static_url('magpie.ui.home:static/exclamation-triangle.png')}"
                  alt="WARNING" class="icon-warning" title="Administrators effective permission resolution." />
@@ -169,6 +172,7 @@
     </div>
     %endif
 </div>
+<div class="clear"></div>
 
 <div class="tabs-panel">
 


### PR DESCRIPTION
Minor UI fix. 

Before / after :

![image](https://user-images.githubusercontent.com/19194484/97626356-0e780180-1a00-11eb-808c-d1cbe552a1f2.png)
