### PR TITLE
add catalog.* as exception prefix for ServiceTHREDDS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,19 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* Nothing yet.
+* Adjust the ``file_patterns`` of ``ServiceTHREDDS`` to employ Shell-like syntax to avoid parsing ambiguity of special
+  characters (notably ``.``). Previous regexes such as ``.*.nc`` could be incorrectly interpreted as *any* character
+  (``.*``) followed by ``.nc`` extension, but actually resolved to *any* character with final ``nc``, regardless of
+  the dot separator. Shell-like syntax enforces that dots are interpreted as literal values, and ``*`` can be used by
+  itself to represent *any*.
+* Added pattern support for ``prefixes`` entries of ``ServiceTHREDDS``.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
+* Add ``catalog.*`` by default as expected metadata prefix for ``ServiceTHREDDS``.
+  This resolves an issue where top-level THREDDS can be accessed as ``<PROXY_URL>/thredds/catalog.html`` which must be
+  resolved as ``BROWSE`` of the root directory, but was otherwise compared against the format-related *prefix* that is
+  expected at this sub-path position for any other accessed children resource.
 * Adjust visual alignment of UI notices on individual newlines when viewing user inherited permissions.
 
 `3.1.0 <https://github.com/Ouranosinc/Magpie/tree/3.1.0>`_ (2020-10-23)

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -214,14 +214,15 @@ by the below configuration.
         # minimal configuration requirements (where the real `THREDDS` service resides)
         # other optional parameters from `providers.cfg` can also be provided
         url: http://localhost:1234
-        type: thredds
+        type: threddsw
 
         # customizable request parsing methodology (specific to `thredds` type)
         file_patterns:
-          - .*.nc
+          - "*.nc"  # note: make sure to employ quotes when pattern can cause parsing issues of YAML format
         metadata_type:
           prefixes:
             - null  # note: special YAML value evaluated as `no-prefix`, use quotes if literal value is needed
+            - catalog.*  # note: special case where THREDDS top-level directory (root) is accessed for BROWSE
             - catalog
             - ncml
             - uddc
@@ -233,6 +234,18 @@ by the below configuration.
             - dap4
             - wcs
             - wms
+
+
+.. versionchanged:: 3.2
+    Added ``catalog.*`` by default to metadata prefixes that composes another valid URL variant to request
+    :attr:`Permission.BROWSE` directly on the top-level ``THREDDS`` service (directory), although ``<prefix>`` is
+    otherwise always expected at that second position path segment (see below).
+
+    Patterns provided by ``file_patterns`` employ Shell-like patterns. This is to avoid the confusion between the very
+    common ``.`` (dot) as file extension, that is otherwise interpreted as *any* character using Python regex syntax.
+
+    As of that version, the ``prefixes`` entries also support patterns, using the same syntax.
+
 
 Assuming a proxy intended to receive incoming requests configured with :class:`magpie.adapter.MagpieAdapter` such that
 ``{PROXY_URL}`` is the base path, the following path would point toward the above registered service::


### PR DESCRIPTION
- adjust patterns to use shell syntax (more natural against dir/file of thedds + avoid ambiguous dot as *any* ) 
- fix edge-case where `thredds/catalog.html`, `thredds/catalog.xml`, etc. (for top-level access), would attempt match against the `prefix` part of other URL and would fail, although equivalent paths `/thredds` and `/thredds/catalog/catalog.html` would correctly work (as expected None/catalog `prefix` is matched.