### PR TITLE
Fix UI user edit fields error message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ Features / Changes
   (resolves `#369 <https://github.com/Ouranosinc/Magpie/issues/369>`_).
 * Add function to parse output body and redact potential leaks of flagged fields.
 
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix validation of edited user password to handle and adequately indicate returned error on UI
+  (resolves `#370 <https://github.com/Ouranosinc/Magpie/issues/370>`_).
 
 `3.2.1 <https://github.com/Ouranosinc/Magpie/tree/3.2.1>`_ (2020-11-17)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,13 +9,17 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* Add better details of error cause in returned UI page
+* Add better details of HTTP error cause in returned UI page
   (resolves `#369 <https://github.com/Ouranosinc/Magpie/issues/369>`_).
+* Ensure that general programming internal errors are not bubbled up in UI error page.
 * Add function to parse output body and redact potential leaks of flagged fields.
+* Align HTML format and structure of all edit forms portions of `Users`, `Groups` and `Services` UI pages to simplify
+  and unify their rendering.
+* Add inline UI error messages to `User` edition fields.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
-* Fix validation of edited user password to handle and adequately indicate returned error on UI
+* Fix validation of edited user fields to handle and adequately indicate returned error on UI
   (resolves `#370 <https://github.com/Ouranosinc/Magpie/issues/370>`_).
 
 `3.2.1 <https://github.com/Ouranosinc/Magpie/tree/3.2.1>`_ (2020-11-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,12 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add better details of error cause in returned UI page
+  (resolves `#369 <https://github.com/Ouranosinc/Magpie/issues/369>`_).
+* Add function to parse output body and redact potential leaks of flagged fields.
+
 
 `3.2.1 <https://github.com/Ouranosinc/Magpie/tree/3.2.1>`_ (2020-11-17)
 ------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -519,6 +519,12 @@ test-remote: install-dev install	## run only remote tests with the environment P
 	@echo "Running remote tests..."
 	@bash -c '$(CONDA_CMD) pytest tests -vv -m "remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
+.PHONY: test-custom
+test-custom: install-dev install	## run custom marker tests using SPEC="<marker-specification>"
+	@echo "Running custom tests..."
+	@[ "${SPEC}" ] || ( echo ">> 'TESTS' is not set"; exit 1 )
+	@bash -c '$(CONDA_CMD) pytest tests -vv -m "${SPEC}" --junitxml "$(APP_ROOT)/tests/results.xml"'
+
 .PHONY: test-docker
 test-docker: docker-test			## alias for 'docker-test' target - WARNING: could build image if missing
 

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -444,7 +444,7 @@ priority over any :term:`Group` :term:`Permission`. Also, ``deny`` access is pri
 the default interpretation of protected access control defined by `Magpie`. When ``match`` and ``recursive`` scopes
 cause ambiguous resolution, the ``match`` :term:`Permission` is prioritized over inherited access via parent ``scope``.
 
-As a general of thumb, all :term:`Permission` are resolved such that more restrictive access applied *closer* to
+As a general rule of thumb, all :term:`Permission` are resolved such that more restrictive access applied *closer* to
 the actual :term:`Resource` for the targeted :term:`User` will have priority, both in terms of inheritance by tree
 hierarchy and by :term:`Group` memberships.
 

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -169,7 +169,7 @@ its children :term:`Resource` are :attr:`Permission.BROWSE`, :attr:`Permission.R
     provides *metadata* access to that file.
 
 Permission :attr:`Permission.READ` can be applied to all of the resources, but will only effectively make sense when
-attempting access of a specific :term:`Resource of type :class:`magpie.models.File`.
+attempting access of a specific :term:`Resource` of type :class:`magpie.models.File`.
 
 .. versionchanged:: 3.1
     Permission :attr:`Permission.READ` does not offer *metadata* content listing of :class:`magpie.models.Directory`

--- a/magpie/security.py
+++ b/magpie/security.py
@@ -47,8 +47,8 @@ def mask_credentials(container, redact="[REDACTED]", flags=None, parent=None):
         return any(_flag in _compare for _flag in flags)
 
     if isinstance(container, (list, tuple, set)):
-        for i in range(len(container)):
-            container[i] = mask_credentials(container[i], redact=redact, flags=flags, parent=parent)
+        for i, item in enumerate(container):
+            container[i] = mask_credentials(item, redact=redact, flags=flags, parent=parent)
         return container
 
     if isinstance(container, dict):

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -246,26 +246,35 @@ table thead {
 }
 
 .panel-line {
-    margin: 0.5em;
+    margin: 0.25em 0.5em;
+    font-family: arial, sans-serif;  /* same as table to ensure they match when table is not actually used */
 }
 
 table.panel-line {
-    margin: 0.25em;
+    margin: 0.25em 0.5em;
 }
 
 table.panel-line th,
 table.panel-line td {
     border: 0;
+    margin: 0.25em 0.25em;
     white-space: nowrap;
     padding: 0;  /* override global th/td */
+}
+
+.panel-line-entry {
+    margin: 0.25em 0;
 }
 
 .panel-error {
     margin-left: 0.5em;
 }
 
-.panel-line input[type="submit"] {
+.panel-line input[type="submit"],
+.panel-line-entry input[type="submit"] {
     height: auto;
+    float: right;
+    margin-left: 0.5em;
 }
 
 .panel-line-checkbox {
@@ -671,7 +680,7 @@ table.simple-list input[type="submit"] {
 }
 
 .tree-button.goto-service {
-    margin: 0.1em 0 0 -4em;
+    margin: 0.25em 0 0 -4em;
 }
 
 .tree-item-message {
@@ -692,7 +701,7 @@ div.tree-button {
     width: 5em;
     float: right;
     text-align: center;
-    margin: 0.1em 0 0 0;
+    margin-bottom: 0.15em;
 }
 
 .clear {
@@ -941,6 +950,10 @@ table.request-details thead tbody td th {
     padding: 1px;
 }
 
+.tab-panel-selector {
+    margin: 0.1em;
+}
+
 .current-tab-panel {
     background: white;
     padding: 1em;
@@ -961,6 +974,7 @@ a.current-tab:visited {
 
 .tab {
     min-width: 6em;  /* make tabs same width regardless of text length, but must be adjusted for longest one */
+    margin-bottom: 0.1em;   /* in case page is not wide enough, avoid wrapped tabs to be sticking on top of another */
     border-color: black;
 }
 

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -264,10 +264,22 @@ table.panel-line td {
 
 .panel-line-entry {
     margin: 0.25em 0;
+    min-height: 1em;
 }
 
-.panel-error {
-    margin-left: 0.5em;
+.panel-form-error>img {
+    width: 1em;
+    height: 1em;
+    margin: 0.1em 0.25em 0.15em 0;
+}
+
+.panel-form-error {
+    width: auto;
+    display: inline-flex;
+    float: left;
+    text-align: center;
+    margin-left: 0.25em;
+    margin-top: 0;
 }
 
 .panel-line input[type="submit"],
@@ -275,6 +287,30 @@ table.panel-line td {
     height: auto;
     float: right;
     margin-left: 0.5em;
+    min-width: 4em;  /* for save/edit buttons alignment when editing one field and others are still in non-edit mode */
+}
+
+/* textual field entry when in edit mode */
+.panel-line-entry input[type="password"],
+.panel-line-entry input[type="text"],
+.panel-line-entry input[type="url"] {
+    -webkit-appearance: none;
+    appearance: none;
+    height: 1.125em;
+    border: solid #666 1px;
+    font-size: 14px;
+    margin-bottom: 0.1em;
+}
+
+/* textual field entry when in non-edit mode */
+.panel-line-entry span {
+/*
+    background-color: lightgray;
+    border-color: black;
+    border-width: 0.15em;
+    border-style: inset;
+    padding: 0 0.25em;
+*/
 }
 
 .panel-line-checkbox {
@@ -288,6 +324,7 @@ table.panel-line td {
 
 .panel-entry {
     font-weight: bold;
+    margin-right: 0.5em;
 }
 
 .panel-value {

--- a/magpie/ui/management/templates/edit_group.mako
+++ b/magpie/ui/management/templates/edit_group.mako
@@ -38,71 +38,96 @@
                 <div class="panel-title">Details</div>
             </div>
             <div class="panel-fields">
-                <form id="edit_name" action="${request.path}" method="post">
-                    <span class="panel-entry">Name: </span>
-                    %if edit_mode == "edit_group_name" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                        <label>
-                        <input type="text" value="${group_name}" placeholder="group name" name="new_group_name"
-                               id="input_group_name" onkeyup="adjustWidth('input_group_name')">
-                        <input type="submit" value="Save" name="save_group_name" class="button theme">
-                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                        </label>
-                    %else:
-                        <label>
-                        <span class="panel-value">${group_name}</span>
-                        %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                        <input type="submit" value="Edit" name="edit_group_name" class="button theme">
-                        %endif
-                        </label>
-                    %endif
-                </form>
-                <form id="edit_description" action="${request.path}" method="post">
-                    <span class="panel-entry">Description: </span>
-                    %if edit_mode == "edit_description" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                        <label>
-                        <input type="text" placeholder="description" name="new_description"
-                               id="input_description" onkeyup="adjustWidth('input_description')"
-                            %if description:
-                                value="${description}"
-                            %endif
-                        >
-                        <input type="submit" value="Save" name="save_description" class="button theme">
-                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                        </label>
-                    %else:
-                        <label>
-                        <span class="panel-value">
-                            %if description:
-                                ${description}
-                            %else:
-                                n/a
-                            %endif
-                        </span>
-                        %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                        <input type="submit" value="Edit" name="edit_description" class="button theme">
-                        %endif
-                        </label>
-                    %endif
-                </form>
-                <form id="edit_discoverable" action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Discoverable: </span>
-                        <label class="checkbox-align panel-line-checkbox">
-                        <!-- when unchecked but checkbox pressed checkbox 'value' not actually sent -->
-                        <input type="hidden" value="${discoverable}" name="is_discoverable"/>
-                        <input type="checkbox" name="new_discoverable"
-                            %if discoverable:
-                               checked
-                            %endif
-                            %if group_name in MAGPIE_FIXED_GROUP_EDITS:
-                               disabled
-                            %else:
-                               onchange="document.getElementById('edit_discoverable').submit()"
-                            %endif
-                        >
-                        </label>
-                    </p>
-                </form>
+                <table class="panel-line">
+                    <tr>
+                        <td>
+                            <span class="panel-entry">Name: </span>
+                        </td>
+                        <td>
+                            <form id="edit_name" action="${request.path}" method="post">
+                                <div class="panel-line-entry">
+                                    %if edit_mode == "edit_group_name" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                                        <label>
+                                        <input type="text" placeholder="group name" name="new_group_name"
+                                               id="input_group_name" value="${group_name}"
+                                               onkeyup="adjustWidth('input_group_name')">
+                                        <input type="submit" value="Save" name="save_group_name" class="button theme">
+                                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                                        </label>
+                                    %else:
+                                        <label>
+                                        <span class="panel-line-textbox">${group_name}</span>
+                                        %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                                        <input type="submit" value="Edit" name="edit_group_name" class="button theme">
+                                        %endif
+                                        </label>
+                                    %endif
+                                </div>
+                            </form>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <span class="panel-entry">Description: </span>
+                        </td>
+                        <td>
+                            <form id="edit_description" action="${request.path}" method="post">
+                                <div class="panel-line-entry">
+                                    %if edit_mode == "edit_description" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                                        <label>
+                                        <input type="text" placeholder="description" name="new_description"
+                                               id="input_description" onkeyup="adjustWidth('input_description')"
+                                            %if description:
+                                                value="${description}"
+                                            %endif
+                                        >
+                                        <input type="submit" value="Save" name="save_description" class="button theme">
+                                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                                        </label>
+                                    %else:
+                                        <label>
+                                        <span class="panel-line-textbox">
+                                            %if description:
+                                                ${description}
+                                            %else:
+                                                n/a
+                                            %endif
+                                        </span>
+                                        %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                                        <input type="submit" value="Edit" name="edit_description" class="button theme">
+                                        %endif
+                                        </label>
+                                    %endif
+                                </div>
+                            </form>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <span class="panel-entry">Discoverable: </span>
+                        </td>
+                        <td>
+                            <form id="edit_discoverable" action="${request.path}" method="post">
+                                <div class="panel-line-entry">
+                                    <label class="checkbox-align panel-line-checkbox">
+                                    <!-- when unchecked but checkbox pressed checkbox 'value' not actually sent -->
+                                    <input type="hidden" value="${discoverable}" name="is_discoverable"/>
+                                    <input type="checkbox" name="new_discoverable"
+                                        %if discoverable:
+                                           checked
+                                        %endif
+                                        %if group_name in MAGPIE_FIXED_GROUP_EDITS:
+                                           disabled
+                                        %else:
+                                           onchange="document.getElementById('edit_discoverable').submit()"
+                                        %endif
+                                    >
+                                    </label>
+                                </div>
+                            </form>
+                        </td>
+                    </tr>
+                </table>
             </div>
         </div>
     </div>

--- a/magpie/ui/management/templates/edit_group.mako
+++ b/magpie/ui/management/templates/edit_group.mako
@@ -39,54 +39,50 @@
             </div>
             <div class="panel-fields">
                 <form id="edit_name" action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Name: </span>
-                        %if edit_mode == "edit_group_name" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                            <label>
-                            <input type="text" value="${group_name}" placeholder="group name" name="new_group_name"
-                                   id="input_group_name" onkeyup="adjustWidth('input_group_name')">
-                            <input type="submit" value="Save" name="save_group_name" class="button theme">
-                            <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                            </label>
-                        %else:
-                            <label>
-                            <span class="panel-value">${group_name}</span>
-                            %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                            <input type="submit" value="Edit" name="edit_group_name" class="button theme">
-                            %endif
-                            </label>
+                    <span class="panel-entry">Name: </span>
+                    %if edit_mode == "edit_group_name" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                        <label>
+                        <input type="text" value="${group_name}" placeholder="group name" name="new_group_name"
+                               id="input_group_name" onkeyup="adjustWidth('input_group_name')">
+                        <input type="submit" value="Save" name="save_group_name" class="button theme">
+                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                        </label>
+                    %else:
+                        <label>
+                        <span class="panel-value">${group_name}</span>
+                        %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                        <input type="submit" value="Edit" name="edit_group_name" class="button theme">
                         %endif
-                    </p>
+                        </label>
+                    %endif
                 </form>
                 <form id="edit_description" action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Description: </span>
-                        %if edit_mode == "edit_description" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                            <label>
-                            <input type="text" placeholder="description" name="new_description"
-                                   id="input_description" onkeyup="adjustWidth('input_description')"
-                                %if description:
-                                    value="${description}"
-                                %endif
-                            >
-                            <input type="submit" value="Save" name="save_description" class="button theme">
-                            <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                            </label>
-                        %else:
-                            <label>
-                            <span class="panel-value">
-                                %if description:
-                                    ${description}
-                                %else:
-                                    n/a
-                                %endif
-                            </span>
-                            %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
-                            <input type="submit" value="Edit" name="edit_description" class="button theme">
+                    <span class="panel-entry">Description: </span>
+                    %if edit_mode == "edit_description" and group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                        <label>
+                        <input type="text" placeholder="description" name="new_description"
+                               id="input_description" onkeyup="adjustWidth('input_description')"
+                            %if description:
+                                value="${description}"
                             %endif
-                            </label>
+                        >
+                        <input type="submit" value="Save" name="save_description" class="button theme">
+                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                        </label>
+                    %else:
+                        <label>
+                        <span class="panel-value">
+                            %if description:
+                                ${description}
+                            %else:
+                                n/a
+                            %endif
+                        </span>
+                        %if group_name not in MAGPIE_FIXED_GROUP_EDITS:
+                        <input type="submit" value="Edit" name="edit_description" class="button theme">
                         %endif
-                    </p>
+                        </label>
+                    %endif
                 </form>
                 <form id="edit_discoverable" action="${request.path}" method="post">
                     <p class="panel-line">
@@ -143,15 +139,17 @@
 
 <div class="tabs-panel">
 
-    %for svc_type in svc_types:
-        % if cur_svc_type == svc_type:
-            <a class="tab current-tab"
-               href="${request.route_url('edit_group', group_name=group_name, cur_svc_type=svc_type)}">${svc_type}</a>
-        % else:
-            <a class="tab theme"
-               href="${request.route_url('edit_group', group_name=group_name, cur_svc_type=svc_type)}">${svc_type}</a>
-        % endif
-    %endfor
+    <div class="tab-panel-selector">
+        %for svc_type in svc_types:
+            % if cur_svc_type == svc_type:
+                <a class="tab current-tab"
+                   href="${request.route_url('edit_group', group_name=group_name, cur_svc_type=svc_type)}">${svc_type}</a>
+            % else:
+                <a class="tab theme"
+                   href="${request.route_url('edit_group', group_name=group_name, cur_svc_type=svc_type)}">${svc_type}</a>
+            % endif
+        %endfor
+    </div>
 
     <div class="current-tab-panel">
         <div class="clear underline"></div>

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -69,75 +69,97 @@
                 <div class="panel-title">Details</div>
             </div>
             <div class="panel-fields">
-                <form action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Name: </span>
-                        %if edit_mode == "edit_name":
-                            <label>
-                            <input type="text" value="${service_name}" name="new_svc_name"
-                                   id="input_name" onkeyup="adjustWidth('input_name')">
-                            <input class="button theme" type="submit" value="Save" name="save_name">
-                            <input class="button cancel" type="submit" value="Cancel" name="no_edit">
-                            </label>
-                        %else:
-                            <label>
-                            <span class="panel-value">${service_name}</span>
-                            <input class="button theme" type="submit" value="Edit" name="edit_name">
-                            </label>
-                        %endif
-                    </p>
-                </form>
-                <form action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Protected URL: </span>
-                        %if edit_mode == "edit_url":
-                            <label>
-                            <input type="url" value="${service_url}" name="new_svc_url"
-                                   id="input_url" onkeyup="adjustWidth('input_url')">
-                            <input class="button theme" type="submit" value="Save" name="save_url">
-                            <input class="button cancel" type="submit" value="Cancel" name="no_edit">
-                            </label>
-                        %else:
-                            <label>
-                            <a href="${service_url}" class="panel-value">${service_url}</a>
-                            <input class="button theme" type="submit" value="Edit" name="edit_url">
-                            </label>
-                        %endif
-                    </p>
-                </form>
-                <p class="panel-line">
-                    <span class="panel-entry">Public URL: </span>
-                    <a href="${public_url}" class="panel-value">${public_url}</a>
-                </p>
-                <p class="panel-line">
-                    <span class="panel-entry">Type: </span>
-                    <span class="label label-info">${cur_svc_type}</span>
-                </p>
-                <p class="panel-line">
-                    <span class="panel-entry">Permissions: </span>
-                    %for perm in service_perm:
-                        <span class="label label-warning">${perm}</span>
-                    %endfor
-                </p>
-                <p class="panel-line">
-                    <span class="panel-entry">ID: </span>
-                    <span class="panel-value">${service_id}</span>
-                </p>
-                %if service_push_show:
-                    <div class="checkbox-align">
-                        <label for="push_phoenix_checkbox_details">
-                            <input type="hidden" name="service_push" value="off"/>
-                            %if service_push:
-                                <input type="checkbox" name="service_push"
-                                       id="push_phoenix_checkbox_details" checked/>
-                            %else:
-                                <input type="checkbox" name="service_push"
-                                       id="push_phoenix_checkbox_details"/>
-                            %endif
-                            <span>Push updates to Phoenix?</span>
-                        </label>
-                    </div>
-                %endif
+                <table class="panel-line">
+                    <tr>
+                        <td>
+                            <form action="${request.path}" method="post">
+                                <span class="panel-entry">Name: </span>
+                                %if edit_mode == "edit_name":
+                                    <label>
+                                    <input type="text" value="${service_name}" name="new_svc_name"
+                                           id="input_name" onkeyup="adjustWidth('input_name')">
+                                    <input class="button theme" type="submit" value="Save" name="save_name">
+                                    <input class="button cancel" type="submit" value="Cancel" name="no_edit">
+                                    </label>
+                                %else:
+                                    <label>
+                                    <span class="panel-value">${service_name}</span>
+                                    <input class="button theme" type="submit" value="Edit" name="edit_name">
+                                    </label>
+                                %endif
+                            </form>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <form action="${request.path}" method="post">
+                                <span class="panel-entry">Protected URL: </span>
+                                %if edit_mode == "edit_url":
+                                    <label>
+                                    <input type="url" value="${service_url}" name="new_svc_url"
+                                           id="input_url" onkeyup="adjustWidth('input_url')">
+                                    <input class="button theme" type="submit" value="Save" name="save_url">
+                                    <input class="button cancel" type="submit" value="Cancel" name="no_edit">
+                                    </label>
+                                %else:
+                                    <label>
+                                    <a href="${service_url}" class="panel-value">${service_url}</a>
+                                    <input class="button theme" type="submit" value="Edit" name="edit_url">
+                                    </label>
+                                %endif
+                            </form>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p class="panel-line-entry">
+                                <span class="panel-entry">Public URL: </span>
+                                <a href="${public_url}" class="panel-value">${public_url}</a>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p class="panel-line-entry">
+                                <span class="panel-entry">Type: </span>
+                                <span class="label label-info">${cur_svc_type}</span>
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p class="panel-line-entry">
+                                <span class="panel-entry">Permissions: </span>
+                                %for perm in service_perm:
+                                    <span class="label label-warning">${perm}</span>
+                                %endfor
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p class="panel-line-entry">
+                                <span class="panel-entry">ID: </span>
+                                <span class="panel-value">${service_id}</span>
+                                %if service_push_show:
+                                    <div class="checkbox-align">
+                                        <label for="push_phoenix_checkbox_details">
+                                            <input type="hidden" name="service_push" value="off"/>
+                                            %if service_push:
+                                                <input type="checkbox" name="service_push"
+                                                       id="push_phoenix_checkbox_details" checked/>
+                                            %else:
+                                                <input type="checkbox" name="service_push"
+                                                       id="push_phoenix_checkbox_details"/>
+                                            %endif
+                                            <span>Push updates to Phoenix?</span>
+                                        </label>
+                                    </div>
+                                %endif
+                            </p>
+                        </td>
+                    </tr>
+                </table>
             </div>
         </div>
 

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -72,74 +72,90 @@
                 <table class="panel-line">
                     <tr>
                         <td>
+                            <span class="panel-entry">Name: </span>
+                        </td>
+                        <td>
                             <form action="${request.path}" method="post">
-                                <span class="panel-entry">Name: </span>
-                                %if edit_mode == "edit_name":
-                                    <label>
-                                    <input type="text" value="${service_name}" name="new_svc_name"
-                                           id="input_name" onkeyup="adjustWidth('input_name')">
-                                    <input class="button theme" type="submit" value="Save" name="save_name">
-                                    <input class="button cancel" type="submit" value="Cancel" name="no_edit">
-                                    </label>
-                                %else:
-                                    <label>
-                                    <span class="panel-value">${service_name}</span>
-                                    <input class="button theme" type="submit" value="Edit" name="edit_name">
-                                    </label>
-                                %endif
+                                <div class="panel-line-entry">
+                                    %if edit_mode == "edit_name":
+                                        <label>
+                                        <input type="text" value="${service_name}" name="new_svc_name"
+                                               id="input_name" onkeyup="adjustWidth('input_name')">
+                                        <input class="button theme" type="submit" value="Save" name="save_name">
+                                        <input class="button cancel" type="submit" value="Cancel" name="no_edit">
+                                        </label>
+                                    %else:
+                                        <label>
+                                        <span class="panel-value">${service_name}</span>
+                                        <input class="button theme" type="submit" value="Edit" name="edit_name">
+                                        </label>
+                                    %endif
+                                </div>
                             </form>
                         </td>
                     </tr>
                     <tr>
                         <td>
+                            <span class="panel-entry">Protected URL: </span>
+                        </td>
+                        <td>
                             <form action="${request.path}" method="post">
-                                <span class="panel-entry">Protected URL: </span>
-                                %if edit_mode == "edit_url":
-                                    <label>
-                                    <input type="url" value="${service_url}" name="new_svc_url"
-                                           id="input_url" onkeyup="adjustWidth('input_url')">
-                                    <input class="button theme" type="submit" value="Save" name="save_url">
-                                    <input class="button cancel" type="submit" value="Cancel" name="no_edit">
-                                    </label>
-                                %else:
-                                    <label>
-                                    <a href="${service_url}" class="panel-value">${service_url}</a>
-                                    <input class="button theme" type="submit" value="Edit" name="edit_url">
-                                    </label>
-                                %endif
+                                <div class="panel-line-entry">
+                                    %if edit_mode == "edit_url":
+                                        <label>
+                                        <input type="url" value="${service_url}" name="new_svc_url"
+                                               id="input_url" onkeyup="adjustWidth('input_url')">
+                                        <input class="button theme" type="submit" value="Save" name="save_url">
+                                        <input class="button cancel" type="submit" value="Cancel" name="no_edit">
+                                        </label>
+                                    %else:
+                                        <label>
+                                        <a href="${service_url}" class="panel-value">${service_url}</a>
+                                        <input class="button theme" type="submit" value="Edit" name="edit_url">
+                                        </label>
+                                    %endif
+                                </div>
                             </form>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <p class="panel-line-entry">
-                                <span class="panel-entry">Public URL: </span>
+                            <span class="panel-entry">Public URL: </span>
+                        </td>
+                        <td>
+                            <div class="panel-line-entry">
                                 <a href="${public_url}" class="panel-value">${public_url}</a>
-                            </p>
+                            </div>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <p class="panel-line-entry">
-                                <span class="panel-entry">Type: </span>
+                            <span class="panel-entry">Type: </span>
+                        </td>
+                        <td>
+                            <div class="panel-line-entry">
                                 <span class="label label-info">${cur_svc_type}</span>
-                            </p>
+                            </div>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <p class="panel-line-entry">
-                                <span class="panel-entry">Permissions: </span>
+                            <span class="panel-entry">Permissions: </span>
+                        </td>
+                        <td>
+                            <div class="panel-line-entry">
                                 %for perm in service_perm:
                                     <span class="label label-warning">${perm}</span>
                                 %endfor
-                            </p>
+                            </div>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <p class="panel-line-entry">
-                                <span class="panel-entry">ID: </span>
+                            <span class="panel-entry">ID: </span>
+                        </td>
+                        <td>
+                            <div class="panel-line-entry">
                                 <span class="panel-value">${service_id}</span>
                                 %if service_push_show:
                                     <div class="checkbox-align">
@@ -156,7 +172,7 @@
                                         </label>
                                     </div>
                                 %endif
-                            </p>
+                            </div>
                         </td>
                     </tr>
                 </table>
@@ -174,7 +190,7 @@
     </div>
 </div>
 
-<%def name="render_item(key, value, level)">
+<%def name="render_item(_, value, level)">
     <form id="resource_${value['id']}" action="${request.path}" method="post">
         <input type="hidden" value="${value['id']}" name="resource_id">
         <div class="tree-button">

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -36,10 +36,12 @@
                 <table class="panel-line">
                     <tr>
                         <td>
+                            <span class="panel-entry">Username: </span>
+                        </td>
+                        <td>
                             <form id="edit_username" action="${request.path}" method="post">
-                                <p class="panel-line-entry">
-                                    <span class="panel-entry">Username: </span>
-                                    %if edit_mode == 'edit_username':
+                                <div class="panel-line-entry">
+                                    %if edit_mode == "edit_username":
                                         <label>
                                         <input type="text" placeholder="new user name" name="new_user_name"
                                                id="input_username" value="${user_name}"
@@ -49,16 +51,16 @@
                                         </label>
                                     %else:
                                         <label>
-                                        <span class="panel-value">${user_name}</span>
+                                        <span class="panel-line-textbox">${user_name}</span>
                                         <input type="submit" value="Edit" name="edit_username" class="button theme">
                                         </label>
                                     %endif
-                                </p>
+                                </div>
                             </form>
                         </td>
                         <td>
                         %if invalid_user_name:
-                            <div class="alert-form-error panel-error">
+                            <div class="panel-form-error">
                                 <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
                                      alt="ERROR" class="icon-error" />
                                 <div class="alert-form-text">
@@ -70,9 +72,11 @@
                     </tr>
                     <tr>
                         <td>
+                            <span class="panel-entry">Password: </span>
+                        </td>
+                        <td>
                             <form id="edit_password" action="${request.path}" method="post">
-                                <p class="panel-line-entry">
-                                    <span class="panel-entry">Password: </span>
+                                <div class="panel-line-entry">
                                     %if edit_mode == "edit_password":
                                         <label>
                                         <input type="password" placeholder="new password" name="new_user_password"
@@ -87,12 +91,12 @@
                                         <input type="submit" value="Edit" name="edit_password" class="button theme">
                                         </label>
                                     %endif
-                                </p>
+                                </div>
                             </form>
                         </td>
                         <td>
                         %if invalid_password:
-                            <div class="alert-form-error panel-error">
+                            <div class="panel-form-error">
                                 <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
                                      alt="ERROR" class="icon-error" />
                                 <div class="alert-form-text">
@@ -104,9 +108,11 @@
                     </tr>
                     <tr>
                         <td>
+                            <span class="panel-entry">Email: </span>
+                        </td>
+                        <td>
                             <form id="edit_email" action="${request.path}" method="post">
-                                <p class="panel-line-entry">
-                                    <span class="panel-entry">Email: </span>
+                                <div class="panel-line-entry">
                                     %if edit_mode == "edit_email":
                                         <label>
                                         <input type="email" placeholder="new email" name="new_user_email"
@@ -121,12 +127,12 @@
                                         <input type="submit" value="Edit" name="edit_email" class="button theme">
                                         </label>
                                     %endif
-                                </p>
+                                </div>
                             </form>
                         </td>
                         <td>
                         %if invalid_user_email:
-                            <div class="alert-form-error panel-error">
+                            <div class="panel-form-error">
                                 <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
                                      alt="ERROR" class="icon-error" />
                                 <div class="alert-form-text">

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -33,60 +33,110 @@
                 <div class="panel-title">Details</div>
             </div>
             <div class="panel-fields">
-                <form id="edit_username" action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Username: </span>
-                        %if edit_mode == 'edit_username':
-                            <label>
-                            <input type="text" placeholder="new user name" value="${user_name}" name="new_user_name"
-                                   id="input_username" onkeyup="adjustWidth('input_username')">
-                            <input type="submit" value="Save" name="save_username" class="button theme">
-                            <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                            </label>
-                        %else:
-                            <label>
-                            <span class="panel-value">${user_name}</span>
-                            <input type="submit" value="Edit" name="edit_username" class="button theme">
-                            </label>
+                <table class="panel-line">
+                    <tr>
+                        <td>
+                            <form id="edit_username" action="${request.path}" method="post">
+                                <p class="panel-line-entry">
+                                    <span class="panel-entry">Username: </span>
+                                    %if edit_mode == 'edit_username':
+                                        <label>
+                                        <input type="text" placeholder="new user name" name="new_user_name"
+                                               id="input_username" value="${user_name}"
+                                               onkeyup="adjustWidth('input_username')">
+                                        <input type="submit" value="Save" name="save_username" class="button theme">
+                                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                                        </label>
+                                    %else:
+                                        <label>
+                                        <span class="panel-value">${user_name}</span>
+                                        <input type="submit" value="Edit" name="edit_username" class="button theme">
+                                        </label>
+                                    %endif
+                                </p>
+                            </form>
+                        </td>
+                        <td>
+                        %if invalid_user_name:
+                            <div class="alert-form-error panel-error">
+                                <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
+                                     alt="ERROR" class="icon-error" />
+                                <div class="alert-form-text">
+                                    ${reason_user_name}
+                                </div>
+                            </div>
                         %endif
-                    </p>
-                </form>
-                <form id="edit_password" action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Password: </span>
-                        %if edit_mode == "edit_password":
-                            <label>
-                            <input type="password" placeholder="new password" value="" name="new_user_password"
-                                   id="input_password" onkeyup="adjustWidth('input_password')">
-                            <input type="submit" value="Save" name="save_password" class="button theme">
-                            <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                            </label>
-                        %else:
-                            <label>
-                            <span class="panel-value">***</span>
-                            <input type="submit" value="Edit" name="edit_password" class="button theme">
-                            </label>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <form id="edit_password" action="${request.path}" method="post">
+                                <p class="panel-line-entry">
+                                    <span class="panel-entry">Password: </span>
+                                    %if edit_mode == "edit_password":
+                                        <label>
+                                        <input type="password" placeholder="new password" name="new_user_password"
+                                               id="input_password" value=""
+                                               onkeyup="adjustWidth('input_password')">
+                                        <input type="submit" value="Save" name="save_password" class="button theme">
+                                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                                        </label>
+                                    %else:
+                                        <label>
+                                        <span class="panel-value">***</span>
+                                        <input type="submit" value="Edit" name="edit_password" class="button theme">
+                                        </label>
+                                    %endif
+                                </p>
+                            </form>
+                        </td>
+                        <td>
+                        %if invalid_password:
+                            <div class="alert-form-error panel-error">
+                                <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
+                                     alt="ERROR" class="icon-error" />
+                                <div class="alert-form-text">
+                                    ${reason_password}
+                                </div>
+                            </div>
                         %endif
-                    </p>
-                </form>
-                <form id="edit_email" action="${request.path}" method="post">
-                    <p class="panel-line">
-                        <span class="panel-entry">Email: </span>
-                        %if edit_mode == "edit_email":
-                            <label>
-                            <input type="email" placeholder="new email" value="${email}" name="new_user_email"
-                                   id="input_email" onkeyup="adjustWidth('input_url')">
-                            <input type="submit" value="Save" name="save_email" class="button theme">
-                            <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                            </label>
-                        %else:
-                            <label>
-                            <span class="panel-value">${email}</span>
-                            <input type="submit" value="Edit" name="edit_email" class="button theme">
-                            </label>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <form id="edit_email" action="${request.path}" method="post">
+                                <p class="panel-line-entry">
+                                    <span class="panel-entry">Email: </span>
+                                    %if edit_mode == "edit_email":
+                                        <label>
+                                        <input type="email" placeholder="new email" name="new_user_email"
+                                               id="input_email" value="${email}"
+                                               onkeyup="adjustWidth('input_url')">
+                                        <input type="submit" value="Save" name="save_email" class="button theme">
+                                        <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                                        </label>
+                                    %else:
+                                        <label>
+                                        <span class="panel-value">${email}</span>
+                                        <input type="submit" value="Edit" name="edit_email" class="button theme">
+                                        </label>
+                                    %endif
+                                </p>
+                            </form>
+                        </td>
+                        <td>
+                        %if invalid_user_email:
+                            <div class="alert-form-error panel-error">
+                                <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
+                                     alt="ERROR" class="icon-error" />
+                                <div class="alert-form-text">
+                                    ${reason_user_email}
+                                </div>
+                            </div>
                         %endif
-                    </p>
-                </form>
+                        </td>
+                    </tr>
+                </table>
             </div>
         </div>
     </div>
@@ -175,16 +225,17 @@
 <div class="clear"></div>
 
 <div class="tabs-panel">
-
-    %for svc_type in svc_types:
-        % if cur_svc_type == svc_type:
-            <a class="tab current-tab"
-               href="${request.route_url('edit_user', user_name=user_name, cur_svc_type=svc_type)}">${svc_type}</a>
-        % else:
-            <a class="tab theme"
-               href="${request.route_url('edit_user', user_name=user_name, cur_svc_type=svc_type)}">${svc_type}</a>
-        % endif
-    %endfor
+    <div class="tab-panel-selector">
+        %for svc_type in svc_types:
+            % if cur_svc_type == svc_type:
+                <a class="tab current-tab"
+                   href="${request.route_url('edit_user', user_name=user_name, cur_svc_type=svc_type)}">${svc_type}</a>
+            % else:
+                <a class="tab theme"
+                   href="${request.route_url('edit_user', user_name=user_name, cur_svc_type=svc_type)}">${svc_type}</a>
+            % endif
+        %endfor
+    </div>
 
     <div class="current-tab-panel">
         <div class="clear underline"></div>

--- a/magpie/ui/management/templates/view_services.mako
+++ b/magpie/ui/management/templates/view_services.mako
@@ -125,14 +125,17 @@
 </table>
 
 <div class="tabs-panel">
-
-    %for svc_type in svc_types:
-        % if cur_svc_type == svc_type:
-            <a class="tab current-tab" href="${request.route_url('view_services', cur_svc_type=svc_type)}">${svc_type}</a>
-        % else:
-            <a class="tab theme" href="${request.route_url('view_services', cur_svc_type=svc_type)}">${svc_type}</a>
-        % endif
-    %endfor
+    <div class="tab-panel-selector">
+        %for svc_type in svc_types:
+            % if cur_svc_type == svc_type:
+                <a class="tab current-tab"
+                   href="${request.route_url('view_services', cur_svc_type=svc_type)}">${svc_type}</a>
+            % else:
+                <a class="tab theme"
+                   href="${request.route_url('view_services', cur_svc_type=svc_type)}">${svc_type}</a>
+            % endif
+        %endfor
+    </div>
 
     <div class="current-tab-panel ">
         <table class="simple-list">

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -286,7 +286,7 @@ class ManagementViews(BaseViews):
 
     @view_config(route_name="edit_user", renderer="templates/edit_user.mako")
     def edit_user(self):
-        user_name = self.request.matchdict["user_name"]
+        user_name = self.request.matchdict["user_name"]  # keep reference to original name in case of update request
         cur_svc_type = self.request.matchdict["cur_svc_type"]
         inherit_grp_perms = self.request.matchdict.get("inherit_groups_permissions", False)
 
@@ -303,13 +303,21 @@ class ManagementViews(BaseViews):
         user_path = schemas.UserAPI.path.format(user_name=user_name)
         user_resp = request_api(self.request, user_path, "GET")
         check_response(user_resp)
+
+        # set default values needed by the page in case of early return due to error
         user_info = get_json(user_resp)["user"]
         user_info["edit_mode"] = "no_edit"
         user_info["own_groups"] = own_groups
         user_info["groups"] = all_groups
+        user_info["cur_svc_type"] = cur_svc_type
+        user_info["svc_types"] = svc_types
         user_info["inherit_groups_permissions"] = inherit_grp_perms
+        user_info["error_message"] = ""
+        user_info["last_sync"] = "Never"
+        user_info["ids_to_clean"] = []
+        user_info["out_of_sync"] = []
+        user_info["sync_implemented"] = False
         param_fields = ["password", "user_name", "user_email"]
-        error_message = ""
 
         for field in param_fields:
             user_info["invalid_{}".format(field)] = False
@@ -366,7 +374,7 @@ class ManagementViews(BaseViews):
                 is_save_user_info = True
             elif "force_sync" in self.request.POST:
                 _, errmsg = self.sync_services(services)
-                error_message += errmsg or ""
+                user_info["error_message"] += errmsg or ""
             elif "clean_all" in self.request.POST:
                 ids_to_clean = self.request.POST.get("ids_to_clean").split(";")
                 for id_ in ids_to_clean:
@@ -375,6 +383,7 @@ class ManagementViews(BaseViews):
             if is_save_user_info:
                 resp = request_api(self.request, user_path, "PATCH", data=user_info)
                 if resp.status_code in (HTTPBadRequest.code, HTTPUnprocessableEntity.code):
+                    requires_update_name = False  # revoke fetch new name because failure occurred
                     # attempt to retrieve the API more-specific reason why the operation is invalid
                     body = get_json(resp)
                     param_name = body.get("param", {}).get("name")
@@ -383,14 +392,14 @@ class ManagementViews(BaseViews):
                         if param_name == field:
                             user_info["invalid_{}".format(field)] = True
                             user_info["reason_{}".format(field)] = reason
-                            user_info.pop("password", None)  # just in case, remove to avoid leak
-                            return self.add_template_data(user_info)
-                check_response(resp)
-                # FIXME: need to commit updates since we are using the same session
-                #        otherwise, updated user doesn't exist yet in the db for next calls
-                self.request.tm.commit()
+                            break  # cannot return early because we are still missing other resources/permissions info
+                else:
+                    check_response(resp)
+                    # FIXME: need to commit updates since we are using the same session
+                    #        otherwise, updated user doesn't exist yet in the db for next calls
+                    self.request.tm.commit()
 
-            # always remove password from output
+            # ensure remove password from output (just in case)
             user_info.pop("password", None)
 
             if requires_update_name:
@@ -432,9 +441,8 @@ class ManagementViews(BaseViews):
         res_perms, ids_to_clean, last_sync_humanized, out_of_sync = info
 
         if out_of_sync:
-            error_message = self.make_sync_error_message(out_of_sync)
+            user_info["error_message"] = self.make_sync_error_message(out_of_sync)
 
-        user_info["error_message"] = error_message
         user_info["ids_to_clean"] = ";".join(ids_to_clean)
         user_info["last_sync"] = last_sync_humanized
         user_info["sync_implemented"] = sync_implemented

--- a/magpie/ui/user/templates/edit_current_user.mako
+++ b/magpie/ui/user/templates/edit_current_user.mako
@@ -58,20 +58,25 @@
                 <table class="panel-line">
                     <tr>
                         <td>
-                            <p class="panel-line-entry">
+                            <span class="panel-entry">Username: </span>
+                        </td>
+                        <td>
+                            <div class="panel-line-entry">
                                 <!-- username fixed -->
                                 <label>
-                                    <span class="panel-entry">Username: </span>
                                     ${user_name}
                                 </label>
-                            </p>
+                            </div>
                         </td>
+                        <td></td>
                     </tr>
                     <tr>
                         <td>
+                            <span class="panel-entry">Password: </span>
+                        </td>
+                        <td>
                             <form id="edit_password" action="${request.path}" method="post">
-                                <p class="panel-line-entry">
-                                    <span class="panel-entry">Password: </span>
+                                <div class="panel-line-entry">
                                     %if edit_mode == "edit_password":
                                         <label>
                                             <input type="password" placeholder="new password" name="new_user_password"
@@ -85,12 +90,12 @@
                                             <input type="submit" value="Edit" name="edit_password" class="button theme">
                                         </label>
                                     %endif
-                                </p>
+                                </div>
                             </form>
                         </td>
                         <td>
                         %if invalid_password:
-                            <div class="alert-form-error panel-error">
+                            <div class="panel-form-error">
                                 <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
                                      alt="ERROR" class="icon-error" />
                                 <div class="alert-form-text">
@@ -102,9 +107,11 @@
                     </tr>
                     <tr>
                         <td>
+                            <span class="panel-entry">Email: </span>
+                        </td>
+                        <td>
                             <form id="edit_email" action="${request.path}" method="post">
-                                <p class="panel-line-entry">
-                                    <span class="panel-entry">Email: </span>
+                                <div class="panel-line-entry">
                                     %if edit_mode == "edit_email":
                                         <label>
                                             <input type="email" placeholder="new email" name="new_user_email"
@@ -118,12 +125,12 @@
                                             <input type="submit" value="Edit" name="edit_email" class="button theme">
                                         </label>
                                     %endif
-                                </p>
+                                </div>
                             </form>
                         </td>
                         <td>
                         %if invalid_user_email:
-                            <div class="alert-form-error panel-error">
+                            <div class="panel-form-error">
                                 <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
                                      alt="ERROR" class="icon-error" />
                                 <div class="alert-form-text">

--- a/magpie/ui/user/templates/edit_current_user.mako
+++ b/magpie/ui/user/templates/edit_current_user.mako
@@ -58,32 +58,34 @@
                 <table class="panel-line">
                     <tr>
                         <td>
-                            <!-- username fixed -->
-                            <label>
-                                <span class="panel-entry">Username: </span>
-                                ${user_name}
-                            </label>
+                            <p class="panel-line-entry">
+                                <!-- username fixed -->
+                                <label>
+                                    <span class="panel-entry">Username: </span>
+                                    ${user_name}
+                                </label>
+                            </p>
                         </td>
                     </tr>
-                </table>
-                <table class="panel-line">
                     <tr>
                         <td>
                             <form id="edit_password" action="${request.path}" method="post">
-                            <span class="panel-entry">Password: </span>
-                            %if edit_mode == "edit_password":
-                                <label>
-                                    <input type="password" placeholder="new password" value="" name="new_user_password"
-                                           id="input_password" onkeyup="adjustWidth('input_password')">
-                                    <input type="submit" value="Save" name="save_password" class="button theme">
-                                    <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                                </label>
-                            %else:
-                                <label>
-                                    <span class="panel-value">***</span>
-                                    <input type="submit" value="Edit" name="edit_password" class="button theme">
-                                </label>
-                            %endif
+                                <p class="panel-line-entry">
+                                    <span class="panel-entry">Password: </span>
+                                    %if edit_mode == "edit_password":
+                                        <label>
+                                            <input type="password" placeholder="new password" name="new_user_password"
+                                                   id="input_password" value="" onkeyup="adjustWidth('input_password')">
+                                            <input type="submit" value="Save" name="save_password" class="button theme">
+                                            <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                                        </label>
+                                    %else:
+                                        <label>
+                                            <span class="panel-value">***</span>
+                                            <input type="submit" value="Edit" name="edit_password" class="button theme">
+                                        </label>
+                                    %endif
+                                </p>
                             </form>
                         </td>
                         <td>
@@ -98,25 +100,25 @@
                         %endif
                         </td>
                     </tr>
-                </table>
-                <table class="panel-line">
                     <tr>
                         <td>
                             <form id="edit_email" action="${request.path}" method="post">
-                            <span class="panel-entry">Email: </span>
-                            %if edit_mode == "edit_email":
-                                <label>
-                                    <input type="email" placeholder="new email" value="${email}" name="new_user_email"
-                                           id="input_email" onkeyup="adjustWidth('input_url')">
-                                    <input type="submit" value="Save" name="save_email" class="button theme">
-                                    <input type="submit" value="Cancel" name="no_edit" class="button cancel">
-                                </label>
-                            %else:
-                                <label>
-                                    <span class="panel-value">${email}</span>
-                                    <input type="submit" value="Edit" name="edit_email" class="button theme">
-                                </label>
-                            %endif
+                                <p class="panel-line-entry">
+                                    <span class="panel-entry">Email: </span>
+                                    %if edit_mode == "edit_email":
+                                        <label>
+                                            <input type="email" placeholder="new email" name="new_user_email"
+                                                   id="input_email" value="${email}" onkeyup="adjustWidth('input_url')">
+                                            <input type="submit" value="Save" name="save_email" class="button theme">
+                                            <input type="submit" value="Cancel" name="no_edit" class="button cancel">
+                                        </label>
+                                    %else:
+                                        <label>
+                                            <span class="panel-value">${email}</span>
+                                            <input type="submit" value="Edit" name="edit_email" class="button theme">
+                                        </label>
+                                    %endif
+                                </p>
                             </form>
                         </td>
                         <td>

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,15 +17,15 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-replace = 
+replace =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-	
+
 	* Nothing yet.
-	
+
 	`{new_version} <https://github.com/Ouranosinc/Magpie/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	------------------------------------------------------------------------------------
 
@@ -39,7 +39,7 @@ ignore-path = docs/_build,docs/autoapi
 [flake8]
 ignore = E501,W291,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	.git,
 	__pycache__,
 	build,
@@ -70,7 +70,7 @@ combine_as_imports = false
 branch = true
 source = ./
 include = magpie/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
@@ -78,15 +78,16 @@ omit =
 	magpie/typedefs.py
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict
 	--tb=native
-markers = 
+markers =
 	adapter: magpie adapter functional operations
 	defaults: magpie default users, providers and views
 	register: magpie methods employed in 'register' module
 	login: magpie login operations
 	services: magpie services operations
+	security: magpie security operations
 	resources: magpie resources operations
 	permissions: magpie permissions operations
 	groups: magpie groups operations

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -29,6 +29,7 @@ MAGPIE_TEST_ADAPTER = RunOptionDecorator("MAGPIE_TEST_ADAPTER", "magpie adapter 
 MAGPIE_TEST_REGISTER = RunOptionDecorator("MAGPIE_TEST_REGISTER", "magpie methods employed in 'register' module")
 MAGPIE_TEST_LOGIN = RunOptionDecorator("MAGPIE_TEST_LOGIN", "magpie login operations")
 MAGPIE_TEST_SERVICES = RunOptionDecorator("MAGPIE_TEST_SERVICES", "magpie services operations")
+MAGPIE_TEST_SECURITY = RunOptionDecorator("MAGPIE_TEST_SECURITY", "magpie security operations")
 MAGPIE_TEST_RESOURCES = RunOptionDecorator("MAGPIE_TEST_RESOURCES", "magpie resources operations")
 MAGPIE_TEST_PERMISSIONS = RunOptionDecorator("MAGPIE_TEST_PERMISSIONS", "magpie permissions operations")
 MAGPIE_TEST_GROUPS = RunOptionDecorator("MAGPIE_TEST_GROUPS", "magpie groups operations")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_security
+----------------------------------
+
+Tests for the security operations.
+"""
+import copy
+import unittest
+
+from magpie.security import mask_credentials
+from tests import runner, utils
+
+
+@runner.MAGPIE_TEST_LOCAL
+@runner.MAGPIE_TEST_SECURITY
+class TestSecurity(unittest.TestCase):
+    """
+    Validate operations of :mod:`magpie.security`.
+    """
+
+    def test_mask_credentials(self):
+        body = {
+            # regular request information shouldn't be modified
+            "code": 400,
+            "detail": "Some error with potential password leak.",
+            "type": "application/json",
+            "path": "/users/random-test-user",
+            "url": "http://localhost:2001/magpie/users/random-test-user",
+            "method": "PATCH",
+            # flagged password matches should be redacted
+            "password": "1234",  # noqa  # nosec
+            "param": {
+                "password_list": ["a", "b", "c"],  # noqa  # nosec
+                "conditions": {"not_in": False},
+                "value": 4,
+                "name": "password",  # noqa  # nosec
+                "password": "abcd",  # noqa  # nosec
+                "compare": "range(0, 12)",
+                "very": {
+                    "very": {
+                        "deep": {
+                            "passwords": ["x", "y", "z"],  # noqa  # nosec
+                            "nested": [
+                                {"password": "x", "else": "x"},  # noqa  # nosec
+                                {"password": "y", "else": "y"},  # noqa  # nosec
+                                {"password": "z", "else": "z"},  # noqa  # nosec
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        redact = "[REDACTED]"
+        expect = copy.deepcopy(body)
+        expect["password"] = redact  # noqa  # nosec
+        expect["param"]["password"] = redact  # noqa  # nosec
+        expect["param"]["password_list"] = [redact, redact, redact]  # noqa  # nosec
+        expect["param"]["very"]["very"]["deep"]["passwords"] = [redact, redact, redact]  # noqa  # nosec
+        for item in expect["param"]["very"]["very"]["deep"]["nested"]:  # noqa
+            item["password"] = redact  # noqa  # nosec
+
+        masked = mask_credentials(body, redact=redact)
+        utils.check_val_equal(masked, expect)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -51,7 +51,8 @@ def make_ows_parser(method="GET", content_type=None, params=None, body=""):
 @runner.MAGPIE_TEST_SERVICES
 class TestOWSParser(unittest.TestCase):
     """
-    Validate operations of :mod:`owsrequest` that is employed by multiple :term:`OWS`-based service implementations.
+    Validate operations of :mod:`magpie.owsrequest` that is employed by multiple :term:`OWS`-based service
+    implementations.
     """
 
     def test_ows_parser_factory(self):  # noqa: R0201
@@ -109,7 +110,7 @@ class TestOWSParser(unittest.TestCase):
 @runner.MAGPIE_TEST_FUNCTIONAL
 class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
     """
-    Test request parsing and ACL resolution against resource permissions for the various service implementations.
+    Test request parsing and :term:`ACL` resolution against resource permissions for various service implementations.
     """
     # pylint: disable=C0103,invalid-name
     __test__ = True
@@ -454,7 +455,6 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         svc_name = "unittest-service-thredds-custom"
         svc_type = ServiceTHREDDS.service_type
 
-        custom_settings = None
         with NamedTemporaryFile(mode="w", suffix=".yml") as config:
             # generate a custom config for test THREDDS service
             config.write(inspect.cleandoc("""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -643,11 +643,21 @@ def check_or_try_logout_user(test_item, msg=None):
     raise Exception("logout did not succeed" + msg)
 
 
+def visual_repr(item):
+    # type: (Any) -> Str
+    try:
+        if isinstance(item, (dict, list)):
+            return json_pkg.dumps(item, indent=4, ensure_ascii=False)
+    except Exception:
+        pass
+    return "'{}'".format(repr(item))
+
+
 def format_test_val_ref(val, ref, pre="Fail", msg=None):
     if is_null(msg):
-        _msg = "({0}) Failed condition between test and reference values.".format(pre)
+        _msg = "({}) Failed condition between test and reference values.".format(pre)
     else:
-        _msg = "({0}) Test value: '{1}', Reference value: '{2}'".format(pre, val, ref)
+        _msg = "({}) Test value: {}, Reference value: {}".format(pre, visual_repr(val), visual_repr(ref))
         if isinstance(msg, six.string_types):
             _msg = "{}\n{}".format(msg, _msg)
     return _msg


### PR DESCRIPTION
- fix UI error pre-validation of user fields (#369, #370)
- adjust rendered UI error in case of non-HTTP related error
- adjust HTML/CSS mismatches between various forms that were intended to be of 'similar' display format


Example below of displayed contextual error after [password 'Edit', set invalid value, 'Save' button] sequence

![image](https://user-images.githubusercontent.com/19194484/99753387-23eac380-2ab4-11eb-89b3-19584e661fc2.png)
