### PR TITLE
Store custom config JSON in db 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Features / Changes
   ``magpie.constants.get_constant``, avoiding inconsistent resolution of setting value versus environment variable
   wherever the settings container was not passed down everywhere over deeply nested function calls.
 * Handle `Twitcher`, `PostgreSQL` and `Phoenix` setting prefix conversion from corresponding environment variable names.
+* Store custom configuration of ``Service`` into database for same definition retrieval between `Magpie` and `Twitcher`
+  without need to provide the same configuration file to both on startup.
+* Display custom ``Service`` configuration as JSON/YAML on its corresponding UI edit page when applicable.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ Features / Changes
 * Align HTML format and structure of all edit forms portions of `Users`, `Groups` and `Services` UI pages to simplify
   and unify their rendering.
 * Add inline UI error messages to `User` edition fields.
+* Improve resolution of `Twitcher` URL using ``TWITCHER_HOST`` explicitly provided  setting (or environment variable)
+  before falling back to default ``HOSTNAME`` value.
+* Employ `Pyramid`'s local thread registry to resolve application settings if not explicitly provided to
+  ``magpie.constants.get_constant``, avoiding inconsistent resolution of setting value versus environment variable
+  wherever the settings container was not passed down everywhere over deeply nested function calls.
+* Handle `Twitcher`, `PostgreSQL` and `Phoenix` setting prefix conversion from corresponding environment variable names.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ database-history: conda-env _alembic    ## obtain database revision history
 .PHONY: database-revision
 database-revision: conda-env _alembic   ## create a new database revision
 	@[ "${DOC}" ] || ( echo ">> 'DOC' is not set. Provide a description."; exit 1 )
-	@bash -c '$(CONDA_CMD) alembic -c "$(APP_INI)" revision -m $(DOC)'
+	@bash -c '$(CONDA_CMD) alembic -c "$(APP_INI)" revision -m "$(DOC)"'
 
 .PHONY: database-version
 database-version: conda-env _alembic 	## retrieve current database revision ID

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -613,7 +613,8 @@ Following settings define parameters required by `Twitcher`_ (OWS Security Proxy
   .. versionadded:: 2.0
 
   Specifies the explicit hostname to employ in combination with ``TWITCHER_PROTECTED_PATH`` to form the complete base
-  service protected URL. Ignored if ``TWITCHER_PROTECTED_URL`` was provided directly.
+  service protected URL. Ignored if ``TWITCHER_PROTECTED_URL`` was provided directly. If not provided, hostname
+  resolution falls back to using ``HOSTNAME`` environment variable.
 
   .. note::
     The resulting URL will take the form ``https://{TWITCHER_HOST}[/twitcher]{TWITCHER_PROTECTED_PATH}`` to imitate

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -217,31 +217,41 @@ by the below configuration.
         type: thredds
 
         # customizable request parsing methodology (specific to `thredds` type)
-        file_patterns:
-          # note: make sure to employ quotes and double escapes to avoid parsing YAML error
-          - ".*\\.nc"
-        metadata_type:
-          prefixes:
-            - null  # note: special YAML value evaluated as `no-prefix`, use quotes if literal value is needed
-            - "catalog\\.\\w+"  # note: special case for `THREDDS` top-level directory (root) accessed for `BROWSE`
-            - catalog
-            - ncml
-            - uddc
-            - iso
-        data_type:
-          prefixes:
-            - fileServer
-            - dodsC
-            - dap4
-            - wcs
-            - wms
+        configuration:
+          # path prefix to skip (strip) before processing the rest of the path in case the
+          # registered service URL in Magpie does not have the same root as proxied by Twitcher public URL
+          skip_prefix: thredds
+          # define which pattern matches that will map different path variations into same file resources
+          # this can be used to consider two file extensions as the same resource to avoid duplication of permissions
+          file_patterns:
+            # note: make sure to employ quotes and double escapes to avoid parsing YAML error
+            #       patterns are **NOT** UNIX filters, but regex format (eg: dot is 'any-character', not a literal dot)
+            - ".*\\.nc"
+          # path prefix to resources to be considered as BROWSE-able metadata (directory listing or file details)
+          metadata_type:
+            prefixes:
+              - null  # note: special YAML value evaluated as `no-prefix`, use quotes if literal value is needed
+              - "catalog\\.\\w+"  # note: special case for `THREDDS` top-level directory (root) accessed for `BROWSE`
+              - catalog
+              - ncml
+              - uddc
+              - iso
+          # path prefix to resources to be considered as READ-able data (i.e.: file contents)
+          data_type:
+            prefixes:
+              - fileServer
+              - dodsC
+              - dap4
+              - wcs
+              - wms
 
 ..  warning:: Regular Expression Patterns
 
-    Ensure to properly escape special characters, notably the dot (``.``), to avoid granting unexpected permissions.
+    Ensure to properly escape special characters, notably the dot (``.``), to avoid granting unexpected permissions that
+    would match *any* character. Format employed in above patterns are traditional Regex, **not** UNIX style filters.
 
 .. versionchanged:: 3.2
-    Added ``catalog`` specific pattern by default to metadata prefixes that composes another valid URL variant to
+    Added ``catalog`` specific patterns by default to metadata prefixes that composes another valid URL variant to
     request :attr:`Permission.BROWSE` directly on the top-level ``THREDDS`` service (directory), although ``<prefix>``
     is otherwise always expected at that second position path segment (see below). The pattern allows multiple
     extensions to support the various representation modes of the ``catalog`` listing (e.g.: XML, HTML, etc.).
@@ -256,15 +266,21 @@ Assuming a proxy intended to receive incoming requests configured with :class:`m
 
 An incoming request will be parsed according to configured values against the following format::
 
-    {PROXY_URL}/LocalThredds/<prefix>/.../<file>
+    {PROXY_URL}/LocalThredds[/skip/prefix]/<prefix_type>/.../<file>
 
-The above template demonstrates that `Magpie` will attempt to match the ``<prefix>`` part with any of the listed
-``prefixes`` in the configuration. If a match is found, the corresponding *metadata* or *data* content will be assumed,
-according to where the match entry was located, to determine whether the requested :term:`Resource` should be validated
-respectively for :attr:`Permission.BROWSE` or :attr:`Permission.READ` access. If no ``<prefix>`` can be resolved, the
-permission will be immediately assumed as :attr:`Access.DENY` regardless of type. To allow top-level access directly on
-the :term:`Service`'s root without ``<prefix>``, it is important to provide ``null`` within the desired ``prefixes``
-list. Duplicates between the two lists of ``prefixes`` will favor entries in ``metadata_type`` over ``data_type``.
+The above template demonstrates that `Magpie` will attempt to match the ``<prefix_type>`` part of the request path with
+any of the listed ``prefixes`` in the configuration. The ``<prefix_type>`` location in the path will be determined by
+the next part following configuration value defined by ``skip_prefix`` (any number of sub-parts). If ``skip_prefix``
+cannot be located in the request path, the first part after the service name is simply assumed as the ``<prefix_type>``
+to lookup.
+
+If a match is found between the various ``prefixes`` and ``<prefix_type>``, the corresponding *metadata* or *data*
+content will be assumed, according to where the match entry was located, to determine whether the requested
+:term:`Resource` should be validated respectively for :attr:`Permission.BROWSE` or :attr:`Permission.READ` access.
+If no ``<prefix_type>`` can be resolved, the :term:`Permission` will be immediately assumed as :attr:`Access.DENY`
+regardless of type. To allow top-level access directly on the :term:`Service`'s root without ``<prefix_type>``, it is
+important to provide ``null`` within the desired ``prefixes`` list. Duplicates between the two lists of ``prefixes``
+will favor entries in ``metadata_type`` over ``data_type``.
 
 After resolution of the content type from ``<prefix>``, the resolution of any amount of :class:`magpie.models.Directory`
 :term:`Resource` will be attempted. Any missing children directory :term:`Resource` will terminate the lookup process
@@ -273,13 +289,15 @@ immediately, and :term:`ACL` will be resolved considering :attr:`Scope.RECURSIVE
 
 Once the last element of the path is reached, the ``file_patterns`` will be applied against ``<file>`` in order to
 attempt extracting the targeted :class:`magpie.models.File` :term:`Resource`. Patterns are applied until the first
-positive match is found. Therefore, order is important if providing multiple. For example, if the path ended with
-``file.ncml`` and, that both ``.*.ncml`` and ``.*.nc`` where defined in the configuration in that specific order, the
-result will first match ``.*.ncml``, and the final :class:`magpie.models.File` :term:`Resource` value will be considered
-as ``file.ncml`` for lookup. In this case, another request using only ``file.nc`` would lookup an entirely different
-:term:`Resource`, since the second pattern would be the first valid match. On the other hand, if only ``.*.nc`` was
-defined in ``file_patterns``, the matched pattern would convert both the names ``file.ncml`` and ``file.nc`` to
-``file.nc``, which will lookup exactly the same :class:`magpie.models.File` reference.
+positive match is found. Therefore, order is important if providing multiple patterns. For example, if the path ended
+with ``file.ncml`` and, that both ``.*\\.ncml`` and ``.*\\.nc`` where defined in the configuration in that specific
+order, the result will first match ``.*\\.ncml``, and the final :class:`magpie.models.File` :term:`Resource` value will
+be considered as ``file.ncml`` for lookup. In this case, another request using only ``file.nc`` would lookup an entirely
+different :term:`Resource`, since the second pattern would be the first successful match. On the other hand, if only
+``.*\\.nc`` was defined in ``file_patterns``, the matched pattern would convert both the names ``file.ncml`` and
+``file.nc`` to ``file.nc``, which will lookup exactly the same :class:`magpie.models.File` reference. The most common
+usage of this feature is to support additional extension suffixes as the same file with regrouped permissions such that
+``file.nc``, ``file.nc.ascii?``, ``file.nc.html``, etc. all correspond to single and common :term:`Resource`.
 
 To summarize, if ``file_patterns`` produces a match, that matched portion will be used as lookup value of the
 :term:`Resource`. Otherwise, if not any match could be found amongst all the ``file_patterns``, the plain ``<file>``

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -19,9 +19,9 @@ from magpie.security import get_auth_config
 from magpie.utils import CONTENT_TYPE_JSON, SingletonMeta, get_logger, get_magpie_url, get_settings
 
 # WARNING:
-#   twitcher available only when this module is imported from it
-#   installed during tests for evaluation
-#   module 'magpie.adapter' should not be imported from magpie package
+#   Twitcher available only when this module is imported from it.
+#   It is installed during tests for evaluation.
+#   Module 'magpie.adapter' should not be imported from 'magpie' package.
 from twitcher.adapter.base import AdapterInterface  # noqa
 from twitcher.owsproxy import owsproxy_defaultconfig  # noqa
 

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -77,7 +77,7 @@ class MagpieOWSSecurity(OWSSecurityInterface):
         Only update if `MAGPIE_COOKIE_NAME` is missing and is retrievable from `access_token` in `Authorization` header.
         Counter-validate the login procedure by calling Magpie's `/session` which should indicated a logged user.
         """
-        token_name = get_constant("MAGPIE_COOKIE_NAME", settings_name=request.registry.settings)
+        token_name = get_constant("MAGPIE_COOKIE_NAME", settings_container=request.registry.settings)
         if "Authorization" in request.headers and token_name not in request.cookies:
             magpie_prov = request.params.get("provider", "WSO2")
             magpie_path = ProviderSigninAPI.path.format(provider_name=magpie_prov)

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -16,9 +16,9 @@ from magpie.services import service_factory
 from magpie.utils import CONTENT_TYPE_JSON, get_logger, get_magpie_url, get_settings
 
 # WARNING:
-#   twitcher available only when this module is imported from it
-#   installed during tests for evaluation
-#   module 'magpie.adapter' should not be imported from magpie package
+#   Twitcher available only when this module is imported from it.
+#   It is installed during tests for evaluation.
+#   Module 'magpie.adapter' should not be imported from 'magpie' package.
 from twitcher.owsexceptions import OWSAccessForbidden  # noqa
 from twitcher.owssecurity import OWSSecurityInterface  # noqa
 from twitcher.utils import parse_service_name  # noqa

--- a/magpie/adapter/magpieservice.py
+++ b/magpie/adapter/magpieservice.py
@@ -12,9 +12,9 @@ from magpie.models import Service as MagpieService
 from magpie.utils import CONTENT_TYPE_JSON, get_admin_cookies, get_logger, get_magpie_url, get_settings
 
 # WARNING:
-#   twitcher available only when this module is imported from it
-#   installed during tests for evaluation
-#   module 'magpie.adapter' should not be imported from magpie package
+#   Twitcher available only when this module is imported from it.
+#   It is installed during tests for evaluation.
+#   Module 'magpie.adapter' should not be imported from 'magpie' package.
 from twitcher.datatype import Service  # noqa
 from twitcher.exceptions import ServiceNotFound  # noqa
 from twitcher.store import ServiceStoreInterface  # noqa

--- a/magpie/alembic/versions/2020-11-20_cfe64807c143_add_service_custom_configuration_field.py
+++ b/magpie/alembic/versions/2020-11-20_cfe64807c143_add_service_custom_configuration_field.py
@@ -1,0 +1,25 @@
+"""
+Add service custom configuration field.
+
+Revision ID: cfe64807c143
+Revises: 9b8e5d37f684
+Create Date: 2020-11-20 15:05:10.353336
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "cfe64807c143"
+down_revision = "9b8e5d37f684"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("services", sa.Column("configuration", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("services", "configuration")

--- a/magpie/api/__init__.py
+++ b/magpie/api/__init__.py
@@ -4,7 +4,7 @@ LOGGER = get_logger(__name__)
 
 
 def includeme(config):
-    LOGGER.info("Adding api routes...")
+    LOGGER.info("Adding API routes...")
 
     # Add all the admin ui routes
     config.include("magpie.api.home")

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -687,9 +687,9 @@ class GroupDetailBodySchema(GroupPublicBodySchema, GroupInfoBodySchema):
 
 
 class ServiceConfigurationSchema(colander.MappingSchema):
-    description="Custom configuration of the service. Expected format and fields specific to each service type."
-    missing=colander.drop
-    default=colander.null
+    description = "Custom configuration of the service. Expected format and fields specific to each service type."
+    missing = colander.drop
+    default = colander.null
 
 
 class ServiceSummarySchema(colander.MappingSchema):

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -66,9 +66,8 @@ def main(global_config=None, **settings):  # noqa: F811
                                        raise_missing=False, raise_not_set=False, print_missing=True))
     prov_cfg = combined_config or get_constant("MAGPIE_PROVIDERS_CONFIG_PATH", settings, default_value="",
                                                raise_missing=False, raise_not_set=False, print_missing=True)
-    settings["magpie.services"] = magpie_register_services_from_config(prov_cfg, push_to_phoenix=push_phoenix,
-                                                                       force_update=True, disable_getcapabilities=False,
-                                                                       db_session=db_session)
+    magpie_register_services_from_config(prov_cfg, push_to_phoenix=push_phoenix, force_update=True,
+                                         disable_getcapabilities=False, db_session=db_session)
 
     print_log("Register configuration permissions...", LOGGER)
     perm_cfg = combined_config or get_constant("MAGPIE_PERMISSIONS_CONFIG_PATH", settings, default_value="",

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -86,6 +86,7 @@ def main(global_config=None, **settings):  # noqa: F811
 
     # don't use scan otherwise modules like 'magpie.adapter' are
     # automatically found and cause import errors on missing packages
+    print_log("Including Magpie modules...", LOGGER)
     config.include("magpie")
     # config.scan("magpie")
 

--- a/magpie/constants.py
+++ b/magpie/constants.py
@@ -69,7 +69,7 @@ except IOError:
 
 def _get_default_log_level():
     """
-    Get logging level from INI configuration file. Fallback to default ``INFO`` if it cannot be retrieved.
+    Get logging level from INI configuration file or fallback to default ``INFO`` if it cannot be retrieved.
     """
     _default_log_lvl = "INFO"
     try:
@@ -162,7 +162,10 @@ _REGEX_ASCII_ONLY = re.compile(r"\W|^(?=\d)")
 
 def get_constant_setting_name(name):
     """
-    Lower-case name and replace all non-ascii chars by `_`. Then, convert known prefixes with their dotted name.
+    Find the equivalent setting name of the provided environment variable name.
+
+    Lower-case name and replace all non-ascii chars by `_`.
+    Then, convert known prefixes with their dotted name.
     """
     name = re.sub(_REGEX_ASCII_ONLY, "_", name.strip().lower())
     for prefix in ["magpie", "twitcher", "postgres", "phoenix"]:

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -256,6 +256,8 @@ def set_sqlalchemy_log_level(magpie_log_level):
 
 
 def includeme(config):
+    LOGGER.info("Adding DB session...")
+
     # use pyramid_tm to hook the transaction lifecycle to the request
     config.include("pyramid_tm")
     session_factory = get_session_factory(get_engine(config))

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -246,6 +246,16 @@ class Service(Resource):
         # project-api, geoserver-api,...
         return sa.Column(sa.UnicodeText(), nullable=True)
 
+    @declared_attr
+    def configuration(self):
+        """
+        Configuration modifiers for parsing access to resources and permissions.
+
+        .. seealso::
+            - :meth:`magpie.services.ServiceInterface.get_config`
+        """
+        return sa.Column(sa.JSON(), nullable=True)
+
     @staticmethod
     def by_service_name(service_name, db_session):
         db = get_db_session(db_session)

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -450,7 +450,7 @@ def _magpie_register_services_with_db_session(services_dict, db_session, push_to
     for svc_name, svc_values in services_dict.items():
         svc_new_url = svc_values["url"]
         svc_type = svc_values["type"]
-
+        svc_config = svc_values.get("configuration")
         svc_sync_type = svc_values.get("sync_type")
         if force_update and svc_name in existing_services_names:
             svc = models.Service.by_service_name(svc_name, db_session=db_session)
@@ -462,6 +462,7 @@ def _magpie_register_services_with_db_session(services_dict, db_session, push_to
                           .format(url_old=svc.url, url_new=svc_new_url, svc=svc_name), logger=LOGGER)
                 svc.url = svc_new_url
             svc.sync_type = svc_sync_type
+            svc.configuration = svc_config
         elif not force_update and svc_name in existing_services_names:
             print_log("Skipping service [{svc}] (conflict)" .format(svc=svc_name), logger=LOGGER)
         else:
@@ -470,6 +471,7 @@ def _magpie_register_services_with_db_session(services_dict, db_session, push_to
                                  resource_type=models.Service.resource_type_name,
                                  url=svc_new_url,
                                  type=svc_type,
+                                 configuration=svc_config,
                                  sync_type=svc_sync_type)  # noqa
             db_session.add(svc)
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -16,7 +16,6 @@ from magpie.api import exception as ax
 from magpie.constants import get_constant
 from magpie.owsrequest import ows_parser_factory
 from magpie.permissions import Access, Permission, PermissionSet, PermissionType, Scope
-from magpie.utils import get_settings
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -683,22 +683,42 @@ class ServiceTHREDDS(ServiceInterface):
         models.File: permissions,
     }
 
+    def __init__(self, *_, **__):
+        super(ServiceTHREDDS, self).__init__(*_, **__)
+        self._config = None
+
     def get_config(self):
         # type: () -> ConfigDict
-        cfg = super(ServiceTHREDDS, self).get_config()
-        cfg.setdefault("file_patterns", [".*\\.nc"])
-        cfg.setdefault("data_type", {"prefixes": []})
-        if not cfg["data_type"]["prefixes"]:
-            cfg["data_type"]["prefixes"] = ["fileServer", "dodsC", "dap4", "wcs", "wms"]
-        cfg.setdefault("metadata_type", {"prefixes": []})
-        if not cfg["metadata_type"]["prefixes"]:
-            cfg["metadata_type"]["prefixes"] = [None, "catalog\\.\\w+", "catalog", "ncml", "uddc", "iso"]
-        return cfg
+        if self._config is not None:
+            return self._config
+
+        self._config = super(ServiceTHREDDS, self).get_config()
+        self._config.setdefault("skip_prefix", "thredds")
+        self._config.setdefault("file_patterns", [".*\\.nc"])
+        self._config.setdefault("data_type", {"prefixes": []})
+        if not self._config["data_type"]["prefixes"]:
+            self._config["data_type"]["prefixes"] = ["fileServer", "dodsC", "dap4", "wcs", "wms"]
+        self._config.setdefault("metadata_type", {"prefixes": []})
+        if not self._config["metadata_type"]["prefixes"]:
+            self._config["metadata_type"]["prefixes"] = [None, "catalog\\.\\w+", "catalog", "ncml", "uddc", "iso"]
+        return self._config
+
+    def get_path_parts(self):
+        cfg = self.get_config()
+        path_parts = self._get_request_path_parts()
+        skip_prefix = cfg["skip_prefix"]
+        if path_parts and skip_prefix:
+            full_path = "/".join(path_parts)
+            skip_prefix = skip_prefix.lstrip("/").rstrip("/")
+            if full_path.startswith(skip_prefix):
+                path_parts = full_path.split(skip_prefix)[-1].split("/")
+                return path_parts[1:]  # remove extra '' added by split
+        return path_parts
 
     def resource_requested(self):
-        path_parts = self._get_request_path_parts()
+        path_parts = self.get_path_parts()
 
-        # handle optional prefix or remove it
+        # handle optional prefix as targeting the service directly
         if len(path_parts) < 2:
             return self.service, True
         path_parts = path_parts[1:]
@@ -731,14 +751,16 @@ class ServiceTHREDDS(ServiceInterface):
         return found_resource, target
 
     def permission_requested(self):
-        path_parts = self._get_request_path_parts() or [None]  # in case of no `<prefix>`, simulate as `null`
-        path_prefix = path_parts[0]
         cfg = self.get_config()
+        path_parts = self.get_path_parts()
+        path_prefix = None  # in case of no `<prefix>`, simulate as `null`
+        if path_parts:
+            path_prefix = path_parts[0]
         for prefixes, permission in [
             (cfg["metadata_type"]["prefixes"], Permission.BROWSE),  # first to favor BROWSE over READ prefix conflicts
             (cfg["data_type"]["prefixes"], Permission.READ),
         ]:
-            for prefix in prefixes:
+            for prefix in prefixes:  # type: Str
                 if path_prefix is None and prefix is None:
                     return permission
                 try:

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -691,7 +691,7 @@ class ServiceTHREDDS(ServiceInterface):
         if self._config is not None:
             return self._config
 
-        self._config = super(ServiceTHREDDS, self).get_config()
+        self._config = super(ServiceTHREDDS, self).get_config() or {}
         self._config.setdefault("skip_prefix", "thredds")
         self._config.setdefault("file_patterns", [".*\\.nc"])
         self._config.setdefault("data_type", {"prefixes": []})

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -217,9 +217,9 @@ class ServiceInterface(object):
     def get_config(self):
         # type: () -> ConfigDict
         """
-        Obtains the configuration of the registered service during startup.
+        Obtains the custom configuration of the registered service.
         """
-        return get_settings(self.request).get("magpie.services", {}).get(self.service.resource_name, {})
+        return self.service.configuration
 
     @classmethod
     def get_resource_permissions(cls, resource_type_name):
@@ -739,12 +739,13 @@ class ServiceTHREDDS(ServiceInterface):
             (cfg["data_type"]["prefixes"], Permission.READ),
         ]:
             for prefix in prefixes:
+                if path_prefix is None and prefix is None:
+                    return permission
                 try:
                     path_prefix = re.match(prefix, path_prefix)[0]
+                    return permission
                 except (TypeError, KeyError):  # fail match or fail to extract pattern group
                     pass
-                if prefix == path_prefix:
-                    return permission
         return None  # automatically deny
 
 

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -77,4 +77,4 @@ if TYPE_CHECKING:
     # registered configurations
     ConfigItem = Dict[Str, JSON]
     ConfigList = List[ConfigItem]
-    ConfigDict = Dict[Str, Union[ConfigItem, ConfigList, JSON]]
+    ConfigDict = Dict[Str, Union[Str, ConfigItem, ConfigList, JSON]]

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -232,6 +232,17 @@ table thead {
     font-weight: bold;
 }
 
+.panel-message {
+    margin: 1em;
+    display: inline-flex;
+}
+
+.panel-message-text {
+    margin-left: 0.25em;
+    margin-top: -0.05em;
+    text-align: left;
+}
+
 .subsection {
     background-color: #CCCCCC;
 }
@@ -1021,6 +1032,34 @@ a.tab:visited {
     text-align: center;
     text-decoration: none;
     display: inline-block;
+}
+
+/*---service configuration languages---*/
+
+.panel-code-language {
+    background: #DDDDDD;
+    padding: 1px;
+}
+
+.code-language-selector {
+    margin: 0.1em;
+}
+
+.current-code-language {
+    background: white;
+    padding: 0.5em 1em 0.25em;
+    margin: 0;
+    border: 1px solid white;
+}
+
+.code-language-option {
+    min-width: 6em;  /* make tabs same width regardless of text length, but must be adjusted for longest one */
+    margin-bottom: 0.1em;   /* in case page is not wide enough, avoid wrapped tabs to be sticking on top of another */
+    border-color: black;
+}
+
+.current-option {
+
 }
 
 /*---service details---*/

--- a/magpie/ui/home/static/themes/blue.css
+++ b/magpie/ui/home/static/themes/blue.css
@@ -23,3 +23,7 @@ input[type="button"]:focus {
     background-color: #5CA3BF;
     text-decoration: none;
 }
+
+.button-active {
+    background-color: #5CA3BF;
+}

--- a/magpie/ui/home/static/themes/green.css
+++ b/magpie/ui/home/static/themes/green.css
@@ -23,3 +23,7 @@ input[type="button"]:focus  {
     background-color: #5CBF60;
     text-decoration: none;
 }
+
+.button-active {
+    background-color: #5CBF60;
+}

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -1,5 +1,11 @@
 <%inherit file="magpie.ui.management:templates/tree_scripts.mako"/>
 <%namespace name="tree" file="magpie.ui.management:templates/tree_scripts.mako"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/styles/default.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/highlight.min.js"></script>
+<script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/languages/json.min.js"></script>
+<script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.4.0/languages/yaml.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+
 
 <%block name="breadcrumb">
 <li><a href="${request.route_url('home')}">Home</a></li>
@@ -178,6 +184,56 @@
                 </table>
             </div>
         </div>
+
+        %if service_configuration:
+        <div class="panel-box">
+            <div class="panel-heading subsection">
+                <div class="panel-title">Configuration</div>
+            </div>
+            <div class="panel-message">
+                <img src="${request.static_url('magpie.ui.home:static/info.png')}"
+                     alt="INFO" class="icon-info alert-info" title="Service Configuration." />
+                <meta name="source" content="https://commons.wikimedia.org/wiki/File:Infobox_info_icon.svg">
+                <div class="panel-message-text">
+                    This service employs the following custom configuration.
+                </div>
+            </div>
+            <div class="clear"></div>
+            <div class="panel-code-language">
+                <script>
+                    function show_language(language) {
+                        let jsonButton = $("#button-json");
+                        let yamlButton = $("#button-yaml");
+                        let jsonConfig = $("#config-json");
+                        let yamlConfig = $("#config-yaml");
+                        if (language === "json") {
+                            jsonButton.addClass("button-active");
+                            yamlButton.removeClass("button-active");
+                            jsonConfig.removeClass("hidden");
+                            yamlConfig.addClass("hidden");
+                        }
+                        else if (language === "yaml") {
+                            jsonButton.removeClass("button-active");
+                            yamlButton.addClass("button-active");
+                            jsonConfig.addClass("hidden");
+                            yamlConfig.removeClass("hidden");
+                        }
+                    }
+                </script>
+                <div class="code-language-selector">
+                    <input type="button" value="JSON" onclick="show_language('json')"
+                           id="button-json" class="code-language-option button theme button-active">
+                    <input type="button" value="YAML" onclick="show_language('yaml')"
+                           id="button-yaml" class="code-language-option button theme">
+                </div>
+                <div class="current-code-language">
+                    <!-- newlines matter between 'pre', they will add extra whitespace -->
+                    <pre id="config-json"><code class="language-json">${service_config_json}</code></pre>
+                    <pre id="config-yaml" class="hidden"><code class="language-yaml">${service_config_yaml}</code></pre>
+                </div>
+            </div>
+        </div>
+        %endif
 
         <div class="panel-box">
             <div class="panel-heading subsection">

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -149,7 +149,6 @@
                 dataType: "json",
                 contentType: "application/json",
                 success: function (data) {
-                    console.log("AJAX OK");
                     let permissions = data["permissions"];
                     let result = $("#PermissionEffectiveFailure_" + resourceId + "_" + permName);
                     $.each(permissions, function(_, perm){

--- a/magpie/ui/management/templates/view_services.mako
+++ b/magpie/ui/management/templates/view_services.mako
@@ -137,7 +137,7 @@
         %endfor
     </div>
 
-    <div class="current-tab-panel ">
+    <div class="current-tab-panel">
         <table class="simple-list">
             <thead class="theme">
             <tr>

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import humanize
 import six
 import transaction
+import yaml
 from pyramid.httpexceptions import (
     HTTPBadRequest,
     HTTPConflict,
@@ -970,11 +971,29 @@ class ManagementViews(BaseViews):
         # future editions on the page will transfer the last saved state
         service_push_show = cur_svc_type in register.SERVICES_PHOENIX_ALLOWED
         service_push = asbool(self.request.POST.get("service_push", False))
+        service_info = {
+            "edit_mode": "no_edit",
+            "public_url": register.get_twitcher_protected_service_url(service_name),
+            "service_name": service_name,
+            "service_url": service_url,
+            "service_perm": service_perm,
+            "service_id": service_id,
+            "service_push": service_push,
+            "service_push_show": service_push_show,
+            "cur_svc_type": cur_svc_type,
+        }
 
-        service_info = {"edit_mode": "no_edit", "service_name": service_name, "service_url": service_url,
-                        "public_url": register.get_twitcher_protected_service_url(service_name),
-                        "service_perm": service_perm, "service_id": service_id, "service_push": service_push,
-                        "service_push_show": service_push_show, "cur_svc_type": cur_svc_type}
+        svc_config = service_data["configuration"]
+        if not svc_config:
+            service_info["service_configuration"] = None
+            service_info["service_config_json"] = None
+            service_info["service_config_yaml"] = None
+        else:
+            svc_cfg_json = json.dumps(svc_config, ensure_ascii=False, indent=4).strip()
+            svc_cfg_yaml = yaml.safe_dump(svc_config, allow_unicode=True, indent=4, sort_keys=False).strip()
+            service_info["service_configuration"] = True
+            service_info["service_config_json"] = svc_cfg_json
+            service_info["service_config_yaml"] = svc_cfg_yaml
 
         if "edit_name" in self.request.POST:
             service_info["edit_mode"] = "edit_name"

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -369,8 +369,8 @@ def get_twitcher_protected_service_url(magpie_service_name, hostname=None):
         if not twitcher_proxy.startswith("/twitcher"):
             twitcher_proxy = "/twitcher" + twitcher_proxy
         hostname = (hostname or
-                    get_constant("HOSTNAME", raise_not_set=False, raise_missing=False) or
-                    get_constant("TWITCHER_HOST", raise_not_set=False, raise_missing=False))
+                    get_constant("TWITCHER_HOST", raise_not_set=False, raise_missing=False) or
+                    get_constant("HOSTNAME", raise_not_set=False, raise_missing=False))
         if not hostname:
             raise ConfigurationError("Missing or unset TWITCHER_PROTECTED_URL, TWITCHER_HOST or HOSTNAME value.")
         twitcher_proxy_url = "https://{0}{1}".format(hostname, twitcher_proxy)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
     from typing import Dict, Optional, Tuple, Union
 
-    from magpie.typedefs import Str
+    from magpie.typedefs import JSON, Str
 
 
 def make_ows_parser(method="GET", content_type=None, params=None, body=""):
@@ -454,51 +454,58 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         """
         svc_name = "unittest-service-thredds-custom"
         svc_type = ServiceTHREDDS.service_type
+        utils.TestSetup.delete_TestService(self, override_service_name=svc_name)
 
         with NamedTemporaryFile(mode="w", suffix=".yml") as config:
             # generate a custom config for test THREDDS service
             config.write(inspect.cleandoc("""
                 providers:
                     {name}:
+                        # mandatory provider settings
                         url: http://localhost
                         type: {type}
-                        file_patterns:
-                            # note: following patterns should have only one-double backslash escape each,
-                            #       but needs quadruple in this case because of 2-steps (dump to YAML, read from YAML)
-                            - ".*\\\\.ncml"   # should be matched before plain '.nc' and correspond to another resource
-                            - ".*\\\\.nc"
-                        data_type:
-                            prefixes:
-                                # only allow these variants, other should be blocked ("dap4", "wcs", "wms")
-                                - dodsC
-                                - fileServer
-                        metadata_type:
-                            prefixes:
-                                # only allow these variants, others should be blocked ("ncml", "uddc", "iso")
-                                - null
-                                - catalog
+                        # custom configuration definition
+                        configuration:
+                            file_patterns:
+                                # note: 
+                                #   following patterns should have only one-double backslash escape each,
+                                #   but needs quadruple in this case because of 2-steps (dump to YAML, read from YAML)
+                                - ".*\\\\.ncml"   # matched before plain '.nc', will correspond to another resource
+                                - ".*\\\\.nc"
+                            data_type:
+                                prefixes:
+                                    # only allow these variants, other should be blocked ("dap4", "wcs", "wms")
+                                    - dodsC
+                                    - fileServer
+                            metadata_type:
+                                prefixes:
+                                    # only allow these variants, others should be blocked ("ncml", "uddc", "iso")
+                                    - null
+                                    - catalog
                 permissions:  # fill only because required
             """.format(name=svc_name, type=svc_type)))
             config.flush()  # force write to file
             settings = {"magpie.config_path": config.name}
+            # trigger application startup to load providers configuration
+            utils.get_test_magpie_app(settings)
 
-            # validate that app can retrieve the custom settings from providers
-            test_app = utils.get_test_magpie_app(settings)
-            custom_settings = test_app.app.registry.settings  # retrieve custom + resolved app settings
-            utils.check_val_is_in("magpie.services", custom_settings)
-            utils.check_val_is_in(svc_name, custom_settings["magpie.services"])
-            svc_settings = custom_settings["magpie.services"][svc_name]
-            utils.check_val_is_in("file_patterns", svc_settings)
-            utils.check_val_is_in("data_type", svc_settings)
-            utils.check_val_is_in("metadata_type", svc_settings)
-            utils.check_val_equal(svc_settings["file_patterns"], [".*\\.ncml", ".*\\.nc"])
-            utils.check_val_equal(svc_settings["data_type"]["prefixes"], ["dodsC", "fileServer"])
-            utils.check_val_equal(svc_settings["metadata_type"]["prefixes"], [None, "catalog"])
-
-        utils.TestSetup.delete_TestService(self, override_service_name=svc_name)
-        body = utils.TestSetup.create_TestService(self, override_service_name=svc_name, override_service_type=svc_type)
+        # obtain service to view applied config
+        path = "/services/{}".format(svc_name)
+        resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
+        body = utils.check_response_basic_info(resp, 200, expected_method="GET")
         info = utils.TestSetup.get_ResourceInfo(self, override_body=body)
         svc_id = info["resource_id"]
+
+        # validate that created service on startup has custom settings from providers config file
+        utils.check_val_is_in("configuration", info)
+        svc_config = info["configuration"]  # type: JSON
+        utils.check_val_not_equal(svc_config, None)
+        utils.check_val_is_in("file_patterns", svc_config)
+        utils.check_val_is_in("data_type", svc_config)
+        utils.check_val_is_in("metadata_type", svc_config)
+        utils.check_val_equal(svc_config["file_patterns"], [".*\\.ncml", ".*\\.nc"])
+        utils.check_val_equal(svc_config["data_type"]["prefixes"], ["dodsC", "fileServer"])
+        utils.check_val_equal(svc_config["metadata_type"]["prefixes"], [None, "catalog"])
 
         # create resources
         dir_id, dir_name = self.make_resource(models.Directory.resource_type_name, svc_id)
@@ -517,13 +524,13 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 
         # directory can be accessed only via catalog according to permissions
         path = "/ows/proxy/{}/catalog/{}".format(svc_name, dir_name)
-        req = self.mock_request(path, method="GET", settings=custom_settings)
+        req = self.mock_request(path, method="GET", settings=settings)
         msg = "Directory catalog access should be allowed. Using [GET, {}]".format(path)
         utils.check_no_raise(lambda: self.ows.check_request(req), msg=msg)
         # using the same catalog prefix with any file is invalid (catalog is BROWSE metadata, files require READ data)
         for test_file in [file_name, file_html_name, file_ncml_name]:
             path = "/ows/proxy/{}/catalog/{}/{}".format(svc_name, dir_name, test_file)
-            req = self.mock_request(path, method="GET", settings=custom_settings)
+            req = self.mock_request(path, method="GET", settings=settings)
             msg = "File catalog access should be denied. Using [GET, {}]".format(path)
             utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden, msg=msg)
 
@@ -535,12 +542,12 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         for prefix in known_prefixes:
             for test_file in allowed_files:
                 path = "/ows/proxy/{}/{}/{}/{}".format(svc_name, prefix, dir_name, test_file)
-                req = self.mock_request(path, method="GET", settings=custom_settings)
+                req = self.mock_request(path, method="GET", settings=settings)
                 msg = "File access should be allowed. Using [GET, {}]".format(path)
                 utils.check_no_raise(lambda: self.ows.check_request(req), msg=msg)
             # file NCML must be parsed as completely different resource, and therefore be denied even with valid prefix
             path = "/ows/proxy/{}/{}/{}/{}".format(svc_name, prefix, dir_name, file_ncml_name)
-            req = self.mock_request(path, method="GET", settings=custom_settings)
+            req = self.mock_request(path, method="GET", settings=settings)
             msg = "File pattern should make parsing of NCML resource separate than NC file, and should be denied. "
             msg += "Using [GET, {}]".format(path)
             utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden, msg=msg)
@@ -551,7 +558,7 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         for prefix in unknown_prefixes:
             for target in allowed_resources:
                 path = "/ows/proxy/{}/{}/{}".format(svc_name, prefix, target)
-                req = self.mock_request(path, method="GET", settings=custom_settings)
+                req = self.mock_request(path, method="GET", settings=settings)
                 msg = "Allowed resources should be resolved as denied when using an unregistered configuration prefix."
                 msg += "Using [GET, {}]".format(path)
                 utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden, msg=msg)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -351,8 +351,8 @@ def mock_get_settings(test):
 
     @functools.wraps(test)
     def wrapped(*_, **__):
-        with mock.patch("magpie.services.get_settings", side_effect=mocked), \
-             mock.patch("magpie.utils.get_settings", side_effect=mocked):
+        # mock.patch("magpie.services.get_settings", side_effect=mocked)
+        with mock.patch("magpie.utils.get_settings", side_effect=mocked):
             return test(*_, **__)
     return wrapped
 


### PR DESCRIPTION
@tlvu @dbyrns 

## Context 

Regarding comments in https://github.com/bird-house/birdhouse-deploy/pull/102

This PR adds the JSON config from `providers.cfg` / `config.yml` and stores it directly into postgres. 
This allows Twitcher to retrieve the same config later on.

Below samples use this config: 
``` yaml
providers:
  TestThredds:
    url: http://${HOSTNAME}:8000/thredds
    type: thredds
    configuration:
      file_patterns:
        # note: make sure to employ quotes and double escapes to avoid parsing YAML error
        - ".+\\.nc"
      metadata_type:
        prefixes:
          - null  # note: special YAML value evaluated as `no-prefix`, use quotes if literal value is needed
          - "\\w+\\.gif"  # favicon, threddsIcon, etc.
          - "\\w+\\.txt"  # licence
          - "\\w+\\.css"  # tds.css
          - "catalog\\.\\w+"  # note: special case for `THREDDS` top-level directory (root) accessed for `BROWSE`
          - catalog
          - ncml
      data_type:
        prefixes:
          - fileServer
          - dodsC
          - dap4
```

As shown on the right side, I can successfully access the resources (with anonymous recursive applied on TestThredds)

![image](https://user-images.githubusercontent.com/19194484/99861447-0c6b1380-2b64-11eb-9ad8-e644776d10a6.png)

Now, there is still an issue with THREDDS as illustrated above. PAVICS/DACCS stack registers THREDDS service with the prefix `/thredds` within the URL in Magpie, as done in my example. All references of THREDDS UI assume to be at the root (without the prefix) and therefore point to wrong location 
(aka `<>/twitcher/ows/proxy/TestThredds/thredds/favicon.ico` becomes `<real THREDDS>/thredds/thredds/favicon.ico`). 

![image](https://user-images.githubusercontent.com/19194484/99861472-2147a700-2b64-11eb-929f-a1ae498308ff.png)

The clean thing to do is therefore to register *without* the `/thredds` prefix in Magpie, but then every request via Twitcher must be as follows: `<>/twitcher/ows/proxy/TestThredds/thredds/...`. 
In the case of PAVICS/DACCS, this looks a bit odd because the service-name is also `thredds`, making request formatted like such: 
`<>/twitcher/ows/proxy/thredds/thredds/...`

I can correctly access the icons using this method, but it seems Thredd's UI insists on using the wrong root
![image](https://user-images.githubusercontent.com/19194484/99865779-27e11900-2b7a-11eb-890a-d76c4e90af4b.png)


## Question

What do we do? 

1. We modify the URL of DACCS, but this will probably impact a lot of references that already assume only one `/thredds`.
2. "Too bad" for icons?
3. Rebase the corresponding icons/css within real Thredds to they can be found under `/thredds/thredds`? 
4. other idea?

From Magpie's point of view, I cannot do much more. It is the service that sends the hardcoded `/thredds/...` UI requests.

 


