### PR TITLE
tmp-url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+* Add URL endpoint to receive temporary tokens to complete pending operations.
 
 `3.5.0 <https://github.com/Ouranosinc/Magpie/tree/3.5.0>`_ (2021-01-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,13 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
 * Add URL endpoint to receive temporary tokens to complete pending operations.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix rendering of path parameter details within OpenAPI schemas.
 
 `3.5.0 <https://github.com/Ouranosinc/Magpie/tree/3.5.0>`_ (2021-01-06)
 ------------------------------------------------------------------------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -771,14 +771,12 @@ this :term:`Authentication` procedure.
 GitHub Settings
 ~~~~~~~~~~~~~~~~~
 
-To use `GitHub`_ authentication provider, variables ``GITHUB_CLIENT_ID`` and ``GITHUB_CLIENT_SECRET`` must be
-configured. These settings correspond to the values retrieved from following steps described in
-`Creating an OAuth App`_.
+To use `GitHub_AuthN`_ authentication provider, variables ``GITHUB_CLIENT_ID`` and ``GITHUB_CLIENT_SECRET``
+must be configured. These settings correspond to the values retrieved from following steps described in
+`Creating an OAuth App <Github_OAuthApp`_.
 
 Furthermore, the callback URL used for configuring the OAuth application on Github must match the running `Magpie`
 instance URL. For this reason, the values of ``MAGPIE_URL``, ``MAGPIE_HOST`` and ``HOSTNAME`` must be considered.
-
-.. _Creating an OAuth App: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
 
 WSO2 Settings
 ~~~~~~~~~~~~~~~~~
@@ -792,7 +790,4 @@ To use `WSO2`_ authentication provider, following variables must be set:
 - ``WSO2_SSL_VERIFY``
 
 To configure your `Magpie` instance as a trusted application for ``WSO2`` (and therefore retrieve values of above
-parameters), please refer to `WSO2 Identity Server Documentation`_.
-
-
-.. _WSO2 Identity Server Documentation: https://docs.wso2.com/display/IS550/WSO2+Identity+Server+Documentation
+parameters), please refer to `WSO2 Identity Server Documentation <WSO2_doc>`_.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -753,7 +753,7 @@ this :term:`Authentication` procedure.
 |                                +-----------------------------------------------------------------------+
 |                                | *Swedish Meteorological and Hydrological Institute* (`SMHI`_)         |
 +--------------------------------+-----------------------------------------------------------------------+
-| ``OAuth2``                     | `GitHub`_ Authentication                                              |
+| ``OAuth2``                     | `GitHub_AuthN`_ Authentication                                        |
 |                                +-----------------------------------------------------------------------+
 |                                | `WSO2`_ Open Source Identity Server                                   |
 +--------------------------------+-----------------------------------------------------------------------+
@@ -773,7 +773,7 @@ GitHub Settings
 
 To use `GitHub_AuthN`_ authentication provider, variables ``GITHUB_CLIENT_ID`` and ``GITHUB_CLIENT_SECRET``
 must be configured. These settings correspond to the values retrieved from following steps described in
-`Creating an OAuth App <Github_OAuthApp`_.
+`Creating an OAuth App <Github_OAuthApp>`_.
 
 Furthermore, the callback URL used for configuring the OAuth application on Github must match the running `Magpie`
 instance URL. For this reason, the values of ``MAGPIE_URL``, ``MAGPIE_HOST`` and ``HOSTNAME`` must be considered.

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -89,6 +89,7 @@ employed by `Magpie`:
         ``inherited`` (with ``ed``) is now the *official* parameter. The older variant remains supported and equivalent.
 
 .. _`resolved permissions`:
+
 - **Resolved Permissions**:
     Specific interpretation of :term:`Inherited Permissions` when there are multiple :term:`Applied Permissions`
     combinations to the :term:`User` and/or his :term:`Group` memberships. The *resolution* of all those definitions
@@ -803,7 +804,7 @@ This example will demonstrate the simultaneous resolution of all following conce
 It is recommended to have a general understanding of all the concepts by going though corresponding sections that
 describe them individually and in more details.
 
-We start by defining the following :term:`Service` and :term:`Resource` hierarchy. We employ the `ServiceAPI`_
+We start by defining the following :term:`Service` and :term:`Resource` hierarchy. We employ the :ref:`ServiceAPI`
 implementation that only allows one type of :term:`Resource` (i.e.: ``route``), and that easily converts path elements
 into the given hierarchy. In this case, every :term:`Resource` can be applied with either :attr:`Permission.READ`
 (``r``) or :attr:`Permission.WRITE` (``w``).

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -30,13 +30,15 @@
 .. _LLNL: https://www.llnl.gov/
 .. _PCMDI: http://pcmdi.llnl.gov
 .. _SMHI: https://www.smhi.se
-.. _GitHub: https://developer.github.com/v3/#authentication
+.. _GitHub_AuthN: https://docs.github.com/developers/apps/identifying-and-authorizing-users-for-github-apps
+.. _Github_OAuthApp: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
 .. _WSO2: https://wso2.com/
+.. _WSO2_doc: https://docs.wso2.com/display/IS550/WSO2+Identity+Server+Documentation
 
 .. file/source references
 .. _configuration: configuration.rst
 .. _constants.py: https://github.com/Ouranosinc/Magpie/tree/master/magpie/constants.py
-.. _`docker-compose.yml.example`: https://github.com/Ouranosinc/Magpie/tree/master/docker-compose.yml.example
+.. _docker-compose.yml.example: https://github.com/Ouranosinc/Magpie/tree/master/docker-compose.yml.example
 .. _magpie-cron: https://github.com/Ouranosinc/Magpie/tree/master/magpie-cron
 .. _magpie.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/magpie.env.example
 .. _magpie.ini: https://github.com/Ouranosinc/Magpie/tree/master/config/magpie.ini

--- a/magpie/alembic/versions/2021-01-04_954a9d7fe740_temporary_url_table.py
+++ b/magpie/alembic/versions/2021-01-04_954a9d7fe740_temporary_url_table.py
@@ -1,0 +1,36 @@
+"""
+Temporary URL table
+
+Revision ID: 954a9d7fe740
+Revises: cfe64807c143
+Create Date: 2021-01-04 12:56:22.298527
+"""
+
+import datetime
+import sqlalchemy as sa
+import uuid
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+
+# revision identifiers, used by Alembic.
+revision = "954a9d7fe740"
+down_revision = "cfe64807c143"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table("tmp_tokens",
+                    sa.Column("token", UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True),
+                    sa.Column("operation", sa.Unicode(32), nullable=False),
+                    sa.Column("user_id", sa.Integer,
+                              sa.ForeignKey("users.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=True),
+                    sa.Column("group_id", sa.Integer(),
+                              sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=True),
+                    sa.Column("created", sa.DateTime, default=datetime.datetime.utcnow)
+                    )
+
+
+def downgrade():
+    op.drop_table("tmp_tokens")

--- a/magpie/alembic/versions/2021-01-04_954a9d7fe740_temporary_url_table.py
+++ b/magpie/alembic/versions/2021-01-04_954a9d7fe740_temporary_url_table.py
@@ -1,5 +1,5 @@
 """
-Temporary URL table
+Temporary URL table.
 
 Revision ID: 954a9d7fe740
 Revises: cfe64807c143

--- a/magpie/api/exception.py
+++ b/magpie/api/exception.py
@@ -45,6 +45,7 @@ RAISE_RECURSIVE_SAFEGUARD_COUNT = 0
 # utility parameter validation regexes for 'matches' argument
 PARAM_REGEX = r"^[A-Za-z0-9]+(?:[\s_\-\.][A-Za-z0-9]+)*$"    # request parameters
 EMAIL_REGEX = colander.EMAIL_RE
+UUID_REGEX = colander.UUID_REGEX
 URL_REGEX = colander.URL_REGEX
 INDEX_REGEX = r"^[0-9]+$"
 

--- a/magpie/api/login/login.py
+++ b/magpie/api/login/login.py
@@ -89,7 +89,7 @@ def signin_in_param(request):
     return request.invoke_subrequest(subreq, use_tweens=True)
 
 
-@s.SigninAPI.post(schema=s.Signin_POST_RequestSchema(), tags=[s.SessionTag], response_schemas=s.Signin_POST_responses)
+@s.SigninAPI.post(schema=s.Signin_POST_RequestSchema, tags=[s.SessionTag], response_schemas=s.Signin_POST_responses)
 @view_config(route_name=s.SigninAPI.name, request_method="POST", permission=NO_PERMISSION_REQUIRED)
 def sign_in(request):
     """

--- a/magpie/api/management/group/group_views.py
+++ b/magpie/api/management/group/group_views.py
@@ -34,7 +34,7 @@ def create_group_view(request):
     return gu.create_group(group_name, group_desc, group_disc, request.db)
 
 
-@s.GroupAPI.get(tags=[s.GroupsTag], response_schemas=s.Group_GET_responses)
+@s.GroupAPI.get(schema=s.Group_GET_RequestSchema(), tags=[s.GroupsTag], response_schemas=s.Group_GET_responses)
 @view_config(route_name=s.GroupAPI.name, request_method="GET")
 def get_group_view(request):
     """
@@ -110,7 +110,8 @@ def delete_group_view(request):
     return ax.valid_http(http_success=HTTPOk, detail=s.Group_DELETE_OkResponseSchema.description)
 
 
-@s.GroupUsersAPI.get(tags=[s.GroupsTag], response_schemas=s.GroupUsers_GET_responses)
+@s.GroupUsersAPI.get(schema=s.GroupUsers_GET_RequestSchema(), tags=[s.GroupsTag],
+                     response_schemas=s.GroupUsers_GET_responses)
 @view_config(route_name=s.GroupUsersAPI.name, request_method="GET")
 def get_group_users_view(request):
     """
@@ -124,7 +125,8 @@ def get_group_users_view(request):
                          content={"user_names": sorted(user_names)})
 
 
-@s.GroupServicesAPI.get(tags=[s.GroupsTag], response_schemas=s.GroupServices_GET_responses)
+@s.GroupServicesAPI.get(schema=s.GroupServices_GET_RequestSchema(), tags=[s.GroupsTag],
+                        response_schemas=s.GroupServices_GET_responses)
 @view_config(route_name=s.GroupServicesAPI.name, request_method="GET")
 def get_group_services_view(request):
     """
@@ -134,7 +136,8 @@ def get_group_services_view(request):
     return gu.get_group_services_response(group, request.db)
 
 
-@s.GroupServicePermissionsAPI.get(tags=[s.GroupsTag], response_schemas=s.GroupServicePermissions_GET_responses)
+@s.GroupServicePermissionsAPI.get(schema=s.GroupServicePermissions_GET_RequestSchema(), tags=[s.GroupsTag],
+                                  response_schemas=s.GroupServicePermissions_GET_responses)
 @view_config(route_name=s.GroupServicePermissionsAPI.name, request_method="GET")
 def get_group_service_permissions_view(request):
     """
@@ -199,7 +202,8 @@ def delete_group_service_permission_name_view(request):
     return gu.delete_group_resource_permission_response(group, service, permission, db_session=request.db)
 
 
-@s.GroupResourcesAPI.get(tags=[s.GroupsTag], response_schemas=s.GroupResources_GET_responses)
+@s.GroupResourcesAPI.get(schema=s.GroupResources_GET_RequestSchema(), tags=[s.GroupsTag],
+                         response_schemas=s.GroupResources_GET_responses)
 @view_config(route_name=s.GroupResourcesAPI.name, request_method="GET")
 def get_group_resources_view(request):
     """
@@ -214,7 +218,8 @@ def get_group_resources_view(request):
                          content={"resources": grp_res_json})
 
 
-@s.GroupResourcePermissionsAPI.get(tags=[s.GroupsTag], response_schemas=s.GroupResourcePermissions_GET_responses)
+@s.GroupResourcePermissionsAPI.get(schema=s.GroupResourcePermissions_GET_RequestSchema(), tags=[s.GroupsTag],
+                                   response_schemas=s.GroupResourcePermissions_GET_responses)
 @view_config(route_name=s.GroupResourcePermissionsAPI.name, request_method="GET")
 def get_group_resource_permissions_view(request):
     """
@@ -279,7 +284,8 @@ def delete_group_resource_permission_name_view(request):
     return gu.delete_group_resource_permission_response(group, resource, permission, db_session=request.db)
 
 
-@s.GroupServiceResourcesAPI.get(tags=[s.GroupsTag], response_schemas=s.GroupServiceResources_GET_responses)
+@s.GroupServiceResourcesAPI.get(schema=s.GroupServiceResources_GET_RequestSchema(), tags=[s.GroupsTag],
+                                response_schemas=s.GroupServiceResources_GET_responses)
 @view_config(route_name=s.GroupServiceResourcesAPI.name, request_method="GET")
 def get_group_service_resources_view(request):
     """

--- a/magpie/api/management/group/group_views.py
+++ b/magpie/api/management/group/group_views.py
@@ -22,7 +22,7 @@ def get_groups_view(request):
                          content={"group_names": group_names})
 
 
-@s.GroupsAPI.post(schema=s.Groups_POST_RequestSchema(), tags=[s.GroupsTag], response_schemas=s.Groups_POST_responses)
+@s.GroupsAPI.post(schema=s.Groups_POST_RequestSchema, tags=[s.GroupsTag], response_schemas=s.Groups_POST_responses)
 @view_config(route_name=s.GroupsAPI.name, request_method="POST")
 def create_group_view(request):
     """
@@ -34,7 +34,7 @@ def create_group_view(request):
     return gu.create_group(group_name, group_desc, group_disc, request.db)
 
 
-@s.GroupAPI.get(schema=s.Group_GET_RequestSchema(), tags=[s.GroupsTag], response_schemas=s.Group_GET_responses)
+@s.GroupAPI.get(schema=s.Group_GET_RequestSchema, tags=[s.GroupsTag], response_schemas=s.Group_GET_responses)
 @view_config(route_name=s.GroupAPI.name, request_method="GET")
 def get_group_view(request):
     """
@@ -45,7 +45,7 @@ def get_group_view(request):
                          content={"group": gf.format_group(group, db_session=request.db)})
 
 
-@s.GroupAPI.patch(schema=s.Group_PATCH_RequestSchema(), tags=[s.GroupsTag], response_schemas=s.Group_PATCH_responses)
+@s.GroupAPI.patch(schema=s.Group_PATCH_RequestSchema, tags=[s.GroupsTag], response_schemas=s.Group_PATCH_responses)
 @view_config(route_name=s.GroupAPI.name, request_method="PATCH")
 def edit_group_view(request):
     """
@@ -90,7 +90,7 @@ def edit_group_view(request):
     return ax.valid_http(http_success=HTTPOk, detail=s.Group_PATCH_OkResponseSchema.description)
 
 
-@s.GroupAPI.delete(schema=s.Group_DELETE_RequestSchema(), tags=[s.GroupsTag], response_schemas=s.Group_DELETE_responses)
+@s.GroupAPI.delete(schema=s.Group_DELETE_RequestSchema, tags=[s.GroupsTag], response_schemas=s.Group_DELETE_responses)
 @view_config(route_name=s.GroupAPI.name, request_method="DELETE")
 def delete_group_view(request):
     """
@@ -110,7 +110,7 @@ def delete_group_view(request):
     return ax.valid_http(http_success=HTTPOk, detail=s.Group_DELETE_OkResponseSchema.description)
 
 
-@s.GroupUsersAPI.get(schema=s.GroupUsers_GET_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupUsersAPI.get(schema=s.GroupUsers_GET_RequestSchema, tags=[s.GroupsTag],
                      response_schemas=s.GroupUsers_GET_responses)
 @view_config(route_name=s.GroupUsersAPI.name, request_method="GET")
 def get_group_users_view(request):
@@ -125,7 +125,7 @@ def get_group_users_view(request):
                          content={"user_names": sorted(user_names)})
 
 
-@s.GroupServicesAPI.get(schema=s.GroupServices_GET_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupServicesAPI.get(schema=s.GroupServices_GET_RequestSchema, tags=[s.GroupsTag],
                         response_schemas=s.GroupServices_GET_responses)
 @view_config(route_name=s.GroupServicesAPI.name, request_method="GET")
 def get_group_services_view(request):
@@ -136,7 +136,7 @@ def get_group_services_view(request):
     return gu.get_group_services_response(group, request.db)
 
 
-@s.GroupServicePermissionsAPI.get(schema=s.GroupServicePermissions_GET_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupServicePermissionsAPI.get(schema=s.GroupServicePermissions_GET_RequestSchema, tags=[s.GroupsTag],
                                   response_schemas=s.GroupServicePermissions_GET_responses)
 @view_config(route_name=s.GroupServicePermissionsAPI.name, request_method="GET")
 def get_group_service_permissions_view(request):
@@ -148,7 +148,7 @@ def get_group_service_permissions_view(request):
     return gu.get_group_service_permissions_response(group, service, request.db)
 
 
-@s.GroupServicePermissionsAPI.post(schema=s.GroupServicePermissions_POST_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupServicePermissionsAPI.post(schema=s.GroupServicePermissions_POST_RequestSchema, tags=[s.GroupsTag],
                                    response_schemas=s.GroupServicePermissions_POST_responses)
 @view_config(route_name=s.GroupServicePermissionsAPI.name, request_method="POST")
 def create_group_service_permission_view(request):
@@ -161,7 +161,7 @@ def create_group_service_permission_view(request):
     return gu.create_group_resource_permission_response(group, service, permission, request.db, overwrite=False)
 
 
-@s.GroupServicePermissionsAPI.put(schema=s.GroupServicePermissions_PUT_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupServicePermissionsAPI.put(schema=s.GroupServicePermissions_PUT_RequestSchema, tags=[s.GroupsTag],
                                   response_schemas=s.GroupServicePermissions_PUT_responses)
 @view_config(route_name=s.GroupServicePermissionsAPI.name, request_method="PUT")
 def replace_group_service_permissions_view(request):
@@ -176,7 +176,7 @@ def replace_group_service_permissions_view(request):
     return gu.create_group_resource_permission_response(group, service, permission, request.db, overwrite=True)
 
 
-@s.GroupServicePermissionsAPI.delete(schema=s.GroupServicePermissions_DELETE_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupServicePermissionsAPI.delete(schema=s.GroupServicePermissions_DELETE_RequestSchema, tags=[s.GroupsTag],
                                      response_schemas=s.GroupServicePermissions_DELETE_responses)
 @view_config(route_name=s.GroupServicePermissionsAPI.name, request_method="DELETE")
 def delete_group_service_permission_view(request):
@@ -189,7 +189,7 @@ def delete_group_service_permission_view(request):
     return gu.delete_group_resource_permission_response(group, service, permission, db_session=request.db)
 
 
-@s.GroupServicePermissionAPI.delete(schema=s.GroupServicePermissionName_DELETE_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupServicePermissionAPI.delete(schema=s.GroupServicePermissionName_DELETE_RequestSchema, tags=[s.GroupsTag],
                                     response_schemas=s.GroupServicePermissionName_DELETE_responses)
 @view_config(route_name=s.GroupServicePermissionAPI.name, request_method="DELETE")
 def delete_group_service_permission_name_view(request):
@@ -202,7 +202,7 @@ def delete_group_service_permission_name_view(request):
     return gu.delete_group_resource_permission_response(group, service, permission, db_session=request.db)
 
 
-@s.GroupResourcesAPI.get(schema=s.GroupResources_GET_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupResourcesAPI.get(schema=s.GroupResources_GET_RequestSchema, tags=[s.GroupsTag],
                          response_schemas=s.GroupResources_GET_responses)
 @view_config(route_name=s.GroupResourcesAPI.name, request_method="GET")
 def get_group_resources_view(request):
@@ -218,7 +218,7 @@ def get_group_resources_view(request):
                          content={"resources": grp_res_json})
 
 
-@s.GroupResourcePermissionsAPI.get(schema=s.GroupResourcePermissions_GET_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupResourcePermissionsAPI.get(schema=s.GroupResourcePermissions_GET_RequestSchema, tags=[s.GroupsTag],
                                    response_schemas=s.GroupResourcePermissions_GET_responses)
 @view_config(route_name=s.GroupResourcePermissionsAPI.name, request_method="GET")
 def get_group_resource_permissions_view(request):
@@ -230,7 +230,7 @@ def get_group_resource_permissions_view(request):
     return gu.get_group_resource_permissions_response(group, resource, db_session=request.db)
 
 
-@s.GroupResourcePermissionsAPI.post(schema=s.GroupResourcePermissions_POST_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupResourcePermissionsAPI.post(schema=s.GroupResourcePermissions_POST_RequestSchema, tags=[s.GroupsTag],
                                     response_schemas=s.GroupResourcePermissions_POST_responses)
 @view_config(route_name=s.GroupResourcePermissionsAPI.name, request_method="POST")
 def create_group_resource_permissions_view(request):
@@ -243,7 +243,7 @@ def create_group_resource_permissions_view(request):
     return gu.create_group_resource_permission_response(group, resource, permission, db_session=request.db)
 
 
-@s.GroupResourcePermissionsAPI.put(schema=s.GroupResourcePermissions_PUT_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupResourcePermissionsAPI.put(schema=s.GroupResourcePermissions_PUT_RequestSchema, tags=[s.GroupsTag],
                                    response_schemas=s.GroupResourcePermissions_PUT_responses)
 @view_config(route_name=s.GroupResourcePermissionsAPI.name, request_method="PUT")
 def replace_group_resource_permissions_view(request):
@@ -258,7 +258,7 @@ def replace_group_resource_permissions_view(request):
     return gu.create_group_resource_permission_response(group, resource, permission, request.db, overwrite=True)
 
 
-@s.GroupResourcePermissionsAPI.delete(schema=s.GroupResourcePermissions_DELETE_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupResourcePermissionsAPI.delete(schema=s.GroupResourcePermissions_DELETE_RequestSchema, tags=[s.GroupsTag],
                                       response_schemas=s.GroupResourcePermissions_DELETE_responses)
 @view_config(route_name=s.GroupResourcePermissionsAPI.name, request_method="DELETE")
 def delete_group_resource_permissions_view(request):
@@ -271,7 +271,7 @@ def delete_group_resource_permissions_view(request):
     return gu.delete_group_resource_permission_response(group, resource, permission, db_session=request.db)
 
 
-@s.GroupResourcePermissionAPI.delete(schema=s.GroupResourcePermissionName_DELETE_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupResourcePermissionAPI.delete(schema=s.GroupResourcePermissionName_DELETE_RequestSchema, tags=[s.GroupsTag],
                                      response_schemas=s.GroupResourcePermissionName_DELETE_responses)
 @view_config(route_name=s.GroupResourcePermissionAPI.name, request_method="DELETE")
 def delete_group_resource_permission_name_view(request):
@@ -284,7 +284,7 @@ def delete_group_resource_permission_name_view(request):
     return gu.delete_group_resource_permission_response(group, resource, permission, db_session=request.db)
 
 
-@s.GroupServiceResourcesAPI.get(schema=s.GroupServiceResources_GET_RequestSchema(), tags=[s.GroupsTag],
+@s.GroupServiceResourcesAPI.get(schema=s.GroupServiceResources_GET_RequestSchema, tags=[s.GroupsTag],
                                 response_schemas=s.GroupServiceResources_GET_responses)
 @view_config(route_name=s.GroupServiceResourcesAPI.name, request_method="GET")
 def get_group_service_resources_view(request):

--- a/magpie/api/management/register/__init__.py
+++ b/magpie/api/management/register/__init__.py
@@ -8,4 +8,5 @@ def includeme(config):
     LOGGER.info("Adding API register...")
     config.add_route(**s.service_api_route_info(s.RegisterGroupsAPI))
     config.add_route(**s.service_api_route_info(s.RegisterGroupAPI))
+    config.add_route(**s.service_api_route_info(s.TemporaryUrlAPI))
     config.scan()

--- a/magpie/api/management/register/register_utils.py
+++ b/magpie/api/management/register/register_utils.py
@@ -1,12 +1,14 @@
 from typing import TYPE_CHECKING
 
-from pyramid.httpexceptions import HTTPForbidden, HTTPNotFound
+from pyramid.httpexceptions import HTTPForbidden, HTTPGone, HTTPNotFound, HTTPInternalServerError, HTTPNotImplemented
 from ziggurat_foundations.models.services.group import GroupService
+from ziggurat_foundations.models.services.user import UserService
 
 from magpie.api import exception as ax
 from magpie.api import schemas as s
-from magpie.models import Group
-from magpie.utils import CONTENT_TYPE_JSON
+from magpie.api.management.user import user_utils as uu
+from magpie import models
+from magpie.utils import CONTENT_TYPE_JSON, ExtendedEnum
 
 if TYPE_CHECKING:
     from typing import List
@@ -16,19 +18,52 @@ if TYPE_CHECKING:
     from magpie.typedefs import Str
 
 
+class TokenOperation(ExtendedEnum):
+    """
+    Supported operations by the temporary tokens.
+    """
+    GROUP_ACCEPT_TERMS = "group-accept-terms"
+    USER_PASSWORD_RESET = "user-password-reset"
+
+
+def handle_temporary_token(tmp_token, db_session):
+    # type: (models.TemporaryToken, Session) -> None
+    """
+    Handles the operation according to the provided temporary token.
+    """
+    if tmp_token.expired():
+        token = tmp_token.token
+        tmp_token.delete(db_session)
+        ax.raise_http(HTTPGone, content={"token": str(token)}, detail=s.TemporaryUrl_GET_GoneResponseSchema.description)
+    ax.verify_param(tmp_token.operation, is_in=True, param_compare=TokenOperation.values(),
+                    param_name="token", http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
+    if tmp_token.operation == TokenOperation.GROUP_ACCEPT_TERMS:
+        ax.verify_param(tmp_token.group, not_none=True,
+                        http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
+        ax.verify_param(tmp_token.user, not_none=True,
+                        http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
+        uu.assign_user_group(tmp_token.user, tmp_token.group, db_session)
+    if tmp_token.operation == TokenOperation.USER_PASSWORD_RESET:
+        ax.verify_param(tmp_token.user, not_none=True,
+                        http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
+        # TODO: reset procedure
+        ax.raise_http(HTTPNotImplemented, detail="Not Implemented")
+    tmp_token.delete(db_session)
+
+
 def get_discoverable_groups(db_session):
-    # type: (Session) -> List[Group]
+    # type: (Session) -> List[models.Group]
     """
     Get all existing group that are marked as publicly discoverable from the database.
     """
     groups = ax.evaluate_call(
-        lambda: [grp for grp in GroupService.all(Group, db_session=db_session) if grp.discoverable],
+        lambda: [grp for grp in GroupService.all(models.Group, db_session=db_session) if grp.discoverable],
         http_error=HTTPForbidden, msg_on_fail=s.RegisterGroups_GET_ForbiddenResponseSchema.description)
     return groups
 
 
 def get_discoverable_group_by_name(group_name, db_session):
-    # type: (Str, Session) -> Group
+    # type: (Str, Session) -> models.Group
     """
     Obtains the requested discoverable group by name.
 

--- a/magpie/api/management/register/register_utils.py
+++ b/magpie/api/management/register/register_utils.py
@@ -32,9 +32,9 @@ def handle_temporary_token(tmp_token, db_session):
     Handles the operation according to the provided temporary token.
     """
     if tmp_token.expired():
-        token = tmp_token.token
-        tmp_token.delete(db_session)
-        ax.raise_http(HTTPGone, content={"token": str(token)}, detail=s.TemporaryUrl_GET_GoneResponseSchema.description)
+        str_token = str(tmp_token.token)
+        db_session.delete(tmp_token)
+        ax.raise_http(HTTPGone, content={"token": str_token}, detail=s.TemporaryURL_GET_GoneResponseSchema.description)
     ax.verify_param(tmp_token.operation, is_in=True, param_compare=TokenOperation.values(),
                     param_name="token", http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
     if tmp_token.operation == TokenOperation.GROUP_ACCEPT_TERMS:
@@ -48,7 +48,7 @@ def handle_temporary_token(tmp_token, db_session):
                         http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
         # TODO: reset procedure
         ax.raise_http(HTTPNotImplemented, detail="Not Implemented")
-    tmp_token.delete(db_session)
+    db_session.delete(tmp_token)
 
 
 def get_discoverable_groups(db_session):

--- a/magpie/api/management/register/register_utils.py
+++ b/magpie/api/management/register/register_utils.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 from pyramid.httpexceptions import HTTPForbidden, HTTPGone, HTTPNotFound, HTTPInternalServerError, HTTPNotImplemented
 from ziggurat_foundations.models.services.group import GroupService
-from ziggurat_foundations.models.services.user import UserService
 
 from magpie.api import exception as ax
 from magpie.api import schemas as s
@@ -23,7 +22,7 @@ class TokenOperation(ExtendedEnum):
     Supported operations by the temporary tokens.
     """
     GROUP_ACCEPT_TERMS = "group-accept-terms"
-    USER_PASSWORD_RESET = "user-password-reset"
+    USER_PASSWORD_RESET = "user-password-reset"  # nosec: B105
 
 
 def handle_temporary_token(tmp_token, db_session):

--- a/magpie/api/management/register/register_views.py
+++ b/magpie/api/management/register/register_views.py
@@ -100,12 +100,12 @@ def handle_temporary_url(request):
     """
     Handles the operation according to the provided temporary URL token.
     """
-    token = ar.get_value_matchdict_checked(request, key="token", pattern=ax.UUID_REGEX)
-    token = token.split(":")[-1]  # remove optional prefix if any
+    str_token = ar.get_value_matchdict_checked(request, key="token", pattern=ax.UUID_REGEX)
+    str_token = str_token.split(":")[-1]  # remove optional prefix if any (e.g.: 'urn:uuid:')
     db_session = request.db
-    tmp_url = models.TemporaryToken.by_token(token, db_session=db_session)
-    ax.verify_param(tmp_url, not_none=True,
-                    http_error=HTTPNotFound, content={"token": str(token)},
+    tmp_token = models.TemporaryToken.by_token(str_token, db_session=db_session)
+    ax.verify_param(tmp_token, not_none=True,
+                    http_error=HTTPNotFound, content={"token": str(str_token)},
                     msg_on_fail=s.TemporaryURL_GET_NotFoundResponseSchema.description)
-    ru.handle_temporary_token(tmp_url, db_session=db_session)
+    ru.handle_temporary_token(tmp_token, db_session=db_session)
     return ax.valid_http(http_success=HTTPOk, detail=s.TemporaryURL_GET_OkResponseSchema.description)

--- a/magpie/api/management/register/register_views.py
+++ b/magpie/api/management/register/register_views.py
@@ -41,7 +41,8 @@ def get_discoverable_groups_view(request):
                          detail=s.RegisterGroups_GET_OkResponseSchema.description)
 
 
-@s.RegisterGroupAPI.get(tags=[s.GroupsTag, s.LoggedUserTag, s.RegisterTag],
+@s.RegisterGroupAPI.get(schema=s.RegisterGroup_GET_RequestSchema,
+                        tags=[s.GroupsTag, s.LoggedUserTag, s.RegisterTag],
                         response_schemas=s.RegisterGroup_GET_responses)
 @view_config(route_name=s.RegisterGroupAPI.name, request_method="GET", permission=Authenticated)
 def get_discoverable_group_info_view(request):
@@ -92,8 +93,9 @@ def leave_discoverable_group_view(request):
     return ax.valid_http(http_success=HTTPOk, detail=s.RegisterGroup_DELETE_OkResponseSchema.description)
 
 
-@s.TemporaryUrlAPI.get(tags=[s.RegisterTag], response_schemas=s.TemporaryURL_GET_responses)
-@view_config(route_name=s.RegisterGroupAPI.name, request_method="GET", permission=NO_PERMISSION_REQUIRED)
+@s.TemporaryUrlAPI.get(schema=s.TemporaryURL_GET_RequestSchema, tags=[s.RegisterTag],
+                       response_schemas=s.TemporaryURL_GET_responses)
+@view_config(route_name=s.TemporaryUrlAPI.name, request_method="GET", permission=NO_PERMISSION_REQUIRED)
 def handle_temporary_url(request):
     """
     Handles the operation according to the provided temporary URL token.
@@ -104,6 +106,6 @@ def handle_temporary_url(request):
     tmp_url = models.TemporaryToken.by_token(token, db_session=db_session)
     ax.verify_param(tmp_url, not_none=True,
                     http_error=HTTPNotFound, content={"token": str(token)},
-                    msg_on_fail=s.TemporaryUrl_GET_NotFoundResponseSchema.description)
+                    msg_on_fail=s.TemporaryURL_GET_NotFoundResponseSchema.description)
     ru.handle_temporary_token(tmp_url, db_session=db_session)
-    return ax.valid_http(http_success=HTTPOk, detail=s.TemporaryUrl_GET_OkResponseSchema.description)
+    return ax.valid_http(http_success=HTTPOk, detail=s.TemporaryURL_GET_OkResponseSchema.description)

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -32,7 +32,8 @@ def get_resources_view(request):
     return ax.valid_http(http_success=HTTPOk, detail=s.Resources_GET_OkResponseSchema.description, content=res_json)
 
 
-@s.ResourceAPI.get(tags=[s.ResourcesTag], response_schemas=s.Resource_GET_responses)
+@s.ResourceAPI.get(schema=s.Resource_GET_RequestSchema, tags=[s.ResourcesTag],
+                   response_schemas=s.Resource_GET_responses)
 @view_config(route_name=s.ResourceAPI.name, request_method="GET")
 def get_resource_view(request):
     """
@@ -61,7 +62,7 @@ def create_resource_view(request):
     return ru.create_resource(resource_name, resource_display_name, resource_type, parent_id, request.db)
 
 
-@s.ResourceAPI.delete(schema=s.Resource_DELETE_RequestSchema(), tags=[s.ResourcesTag],
+@s.ResourceAPI.delete(schema=s.Resource_DELETE_RequestSchema, tags=[s.ResourcesTag],
                       response_schemas=s.Resources_DELETE_responses)
 @view_config(route_name=s.ResourceAPI.name, request_method="DELETE")
 def delete_resource_view(request):
@@ -71,7 +72,7 @@ def delete_resource_view(request):
     return ru.delete_resource(request)
 
 
-@s.ResourceAPI.patch(schema=s.Resource_PATCH_RequestSchema(), tags=[s.ResourcesTag],
+@s.ResourceAPI.patch(schema=s.Resource_PATCH_RequestSchema, tags=[s.ResourcesTag],
                      response_schemas=s.Resource_PATCH_responses)
 @view_config(route_name=s.ResourceAPI.name, request_method="PATCH")
 def update_resource(request):
@@ -112,7 +113,8 @@ def update_resource(request):
                                   "old_resource_name": res_old_name, "new_resource_name": res_new_name})
 
 
-@s.ResourcePermissionsAPI.get(tags=[s.ResourcesTag], response_schemas=s.ResourcePermissions_GET_responses)
+@s.ResourcePermissionsAPI.get(schema=s.ResourcePermissions_GET_RequestSchema, tags=[s.ResourcesTag],
+                              response_schemas=s.ResourcePermissions_GET_responses)
 @view_config(route_name=s.ResourcePermissionsAPI.name, request_method="GET")
 def get_resource_permissions_view(request):
     """

--- a/magpie/api/management/service/service_views.py
+++ b/magpie/api/management/service/service_views.py
@@ -39,7 +39,7 @@ def get_service_types_view(request):  # noqa: F811
                          detail=s.ServiceTypes_GET_OkResponseSchema.description)
 
 
-@s.ServiceTypeAPI.get(schema=s.ServiceTypes_GET_RequestSchema(), tags=[s.ServicesTag],
+@s.ServiceTypeAPI.get(schema=s.ServiceTypes_GET_RequestSchema, tags=[s.ServicesTag],
                       response_schemas=s.ServiceType_GET_responses)
 @view_config(route_name=s.ServiceTypeAPI.name, request_method="GET")
 def get_services_by_type_view(request):
@@ -49,7 +49,7 @@ def get_services_by_type_view(request):
     return get_services_runner(request)
 
 
-@s.ServicesAPI.get(schema=s.Services_GET_RequestSchema(), tags=[s.ServicesTag],
+@s.ServicesAPI.get(schema=s.Services_GET_RequestSchema, tags=[s.ServicesTag],
                    response_schemas=s.Services_GET_responses)
 @view_config(route_name=s.ServicesAPI.name, request_method="GET")
 def get_services_view(request):
@@ -93,7 +93,7 @@ def get_services_runner(request):
                          detail=s.Services_GET_OkResponseSchema.description)
 
 
-@s.ServicesAPI.post(schema=s.Services_POST_RequestBodySchema(), tags=[s.ServicesTag],
+@s.ServicesAPI.post(schema=s.Services_POST_RequestBodySchema, tags=[s.ServicesTag],
                     response_schemas=s.Services_POST_responses)
 @view_config(route_name=s.ServicesAPI.name, request_method="POST")
 def register_service_view(request):
@@ -109,7 +109,7 @@ def register_service_view(request):
     return su.create_service(service_name, service_type, service_url, service_push, service_cfg, db_session=request.db)
 
 
-@s.ServiceAPI.patch(schema=s.Service_PATCH_RequestSchema(), tags=[s.ServicesTag],
+@s.ServiceAPI.patch(schema=s.Service_PATCH_RequestSchema, tags=[s.ServicesTag],
                     response_schemas=s.Service_PATCH_responses)
 @view_config(route_name=s.ServiceAPI.name, request_method="PATCH")
 def update_service_view(request):
@@ -181,7 +181,7 @@ def get_service_view(request):
                          content={"service": service_info})
 
 
-@s.ServiceAPI.delete(schema=s.Service_DELETE_RequestSchema(), tags=[s.ServicesTag],
+@s.ServiceAPI.delete(schema=s.Service_DELETE_RequestSchema, tags=[s.ServicesTag],
                      response_schemas=s.Service_DELETE_responses)
 @view_config(route_name=s.ServiceAPI.name, request_method="DELETE")
 def unregister_service_view(request):
@@ -222,7 +222,7 @@ def get_service_permissions_view(request):
                          content=format_permissions(svc_perms, PermissionType.ALLOWED))
 
 
-@s.ServiceResourceAPI.delete(schema=s.ServiceResource_DELETE_RequestSchema(), tags=[s.ServicesTag],
+@s.ServiceResourceAPI.delete(schema=s.ServiceResource_DELETE_RequestSchema, tags=[s.ServicesTag],
                              response_schemas=s.ServiceResource_DELETE_responses)
 @view_config(route_name=s.ServiceResourceAPI.name, request_method="DELETE")
 def delete_service_resource_view(request):
@@ -232,7 +232,8 @@ def delete_service_resource_view(request):
     return ru.delete_resource(request)
 
 
-@s.ServiceResourcesAPI.get(tags=[s.ServicesTag], response_schemas=s.ServiceResources_GET_responses)
+@s.ServiceResourcesAPI.get(schema=s.ServiceResources_GET_RequestSchema, tags=[s.ServicesTag],
+                           response_schemas=s.ServiceResources_GET_responses)
 @view_config(route_name=s.ServiceResourcesAPI.name, request_method="GET")
 def get_service_resources_view(request):
     """
@@ -277,7 +278,8 @@ def create_service_resource_view(request):
                               parent_id=parent_id, db_session=db_session)
 
 
-@s.ServiceTypeResourcesAPI.get(tags=[s.ServicesTag], response_schemas=s.ServiceTypeResources_GET_responses)
+@s.ServiceTypeResourcesAPI.get(schema=s.ServiceTypeResources_GET_RequestSchema, tags=[s.ServicesTag],
+                               response_schemas=s.ServiceTypeResources_GET_responses)
 @view_config(route_name=s.ServiceTypeResourcesAPI.name, request_method="GET")
 def get_service_type_resources_view(request):
     """
@@ -299,7 +301,8 @@ def get_service_type_resources_view(request):
                          content={"resource_types": _get_resource_types_info(resource_types_names)})
 
 
-@s.ServiceTypeResourceTypesAPI.get(tags=[s.ServicesTag], response_schemas=s.ServiceTypeResourceTypes_GET_responses)
+@s.ServiceTypeResourceTypesAPI.get(schema=s.ServiceTypeResourceTypes_GET_RequestSchema, tags=[s.ServicesTag],
+                                   response_schemas=s.ServiceTypeResourceTypes_GET_responses)
 @view_config(route_name=s.ServiceTypeResourceTypesAPI.name, request_method="GET")
 def get_service_type_resource_types_view(request):
     """

--- a/magpie/api/management/service/service_views.py
+++ b/magpie/api/management/service/service_views.py
@@ -109,7 +109,7 @@ def register_service_view(request):
     return su.create_service(service_name, service_type, service_url, service_push, service_cfg, db_session=request.db)
 
 
-@s.ServiceAPI.patch(schema=s.Service_PATCH_RequestBodySchema(), tags=[s.ServicesTag],
+@s.ServiceAPI.patch(schema=s.Service_PATCH_RequestSchema(), tags=[s.ServicesTag],
                     response_schemas=s.Service_PATCH_responses)
 @view_config(route_name=s.ServiceAPI.name, request_method="PATCH")
 def update_service_view(request):

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -27,7 +27,7 @@ from magpie.services import service_factory
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Dict, Iterable, List, Optional
+    from typing import Iterable, List, Optional
 
     from pyramid.httpexceptions import HTTPException
     from pyramid.request import Request
@@ -171,7 +171,7 @@ def assign_user_group(user, group, db_session):
     ax.verify_param(user.id, param_compare=[usr.id for usr in group.users], not_in=True, with_param=False,
                     http_error=HTTPConflict, content={"user_name": user.user_name, "group_name": group.group_name},
                     msg_on_fail=s.UserGroups_POST_ConflictResponseSchema.description)
-    ax.evaluate_call(lambda: request.db.add(models.UserGroup(group_id=group.id, user_id=user.id)),  # noqa
+    ax.evaluate_call(lambda: db_session.add(models.UserGroup(group_id=group.id, user_id=user.id)),  # noqa
                      fallback=lambda: db_session.rollback(), http_error=HTTPForbidden,
                      msg_on_fail=s.UserGroups_POST_RelationshipForbiddenResponseSchema.description,
                      content={"user_name": user.user_name, "group_name": group.group_name})

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -36,7 +36,7 @@ def get_users_view(request):
                          detail=s.Users_GET_OkResponseSchema.description)
 
 
-@s.UsersAPI.post(schema=s.Users_POST_RequestSchema(), tags=[s.UsersTag], response_schemas=s.Users_POST_responses)
+@s.UsersAPI.post(schema=s.Users_POST_RequestSchema, tags=[s.UsersTag], response_schemas=s.Users_POST_responses)
 @view_config(route_name=s.UsersAPI.name, request_method="POST")
 def create_user_view(request):
     """
@@ -49,8 +49,8 @@ def create_user_view(request):
     return uu.create_user(user_name, password, email, group_name, db_session=request.db)
 
 
-@s.UserAPI.patch(schema=s.User_PATCH_RequestSchema(), tags=[s.UsersTag], response_schemas=s.User_PATCH_responses)
-@s.LoggedUserAPI.patch(schema=s.User_PATCH_RequestSchema(), tags=[s.LoggedUserTag],
+@s.UserAPI.patch(schema=s.User_PATCH_RequestSchema, tags=[s.UsersTag], response_schemas=s.User_PATCH_responses)
+@s.LoggedUserAPI.patch(schema=s.User_PATCH_RequestSchema, tags=[s.LoggedUserTag],
                        response_schemas=s.LoggedUser_PATCH_responses)
 @view_config(route_name=s.UserAPI.name, request_method="PATCH", permission=MAGPIE_LOGGED_PERMISSION)
 def update_user_view(request):
@@ -106,9 +106,10 @@ def update_user_view(request):
     return ax.valid_http(http_success=HTTPOk, detail=s.Users_PATCH_OkResponseSchema.description)
 
 
-@s.UserAPI.get(tags=[s.UsersTag], api_security=s.SecurityEveryoneAPI, response_schemas=s.User_GET_responses)
-@s.LoggedUserAPI.get(tags=[s.LoggedUserTag], api_security=s.SecurityEveryoneAPI,
-                     response_schemas=s.LoggedUser_GET_responses)
+@s.UserAPI.get(schema=s.User_GET_RequestSchema, tags=[s.UsersTag],
+               response_schemas=s.User_GET_responses, api_security=s.SecurityEveryoneAPI)
+@s.LoggedUserAPI.get(schema=s.User_GET_RequestSchema, tags=[s.LoggedUserTag],
+                     response_schemas=s.LoggedUser_GET_responses, api_security=s.SecurityEveryoneAPI)
 @view_config(route_name=s.UserAPI.name, request_method="GET", permission=MAGPIE_CONTEXT_PERMISSION)
 def get_user_view(request):
     """
@@ -119,8 +120,8 @@ def get_user_view(request):
                          detail=s.User_GET_OkResponseSchema.description)
 
 
-@s.UserAPI.delete(schema=s.User_DELETE_RequestSchema(), tags=[s.UsersTag], response_schemas=s.User_DELETE_responses)
-@s.LoggedUserAPI.delete(schema=s.User_DELETE_RequestSchema(), tags=[s.LoggedUserTag],
+@s.UserAPI.delete(schema=s.User_DELETE_RequestSchema, tags=[s.UsersTag], response_schemas=s.User_DELETE_responses)
+@s.LoggedUserAPI.delete(schema=s.User_DELETE_RequestSchema, tags=[s.LoggedUserTag],
                         response_schemas=s.LoggedUser_DELETE_responses)
 @view_config(route_name=s.UserAPI.name, request_method="DELETE", permission=MAGPIE_LOGGED_PERMISSION)
 def delete_user_view(request):
@@ -137,9 +138,10 @@ def delete_user_view(request):
     return ax.valid_http(http_success=HTTPOk, detail=s.User_DELETE_OkResponseSchema.description)
 
 
-@s.UserGroupsAPI.get(tags=[s.UsersTag], api_security=s.SecurityEveryoneAPI, response_schemas=s.UserGroups_GET_responses)
-@s.LoggedUserGroupsAPI.get(tags=[s.LoggedUserTag], api_security=s.SecurityEveryoneAPI,
-                           response_schemas=s.LoggedUserGroups_GET_responses)
+@s.UserGroupsAPI.get(schema=s.UserGroups_GET_RequestSchema, tags=[s.UsersTag],
+                     response_schemas=s.UserGroups_GET_responses, api_security=s.SecurityEveryoneAPI)
+@s.LoggedUserGroupsAPI.get(schema=s.UserGroups_GET_RequestSchema, tags=[s.LoggedUserTag],
+                           response_schemas=s.LoggedUserGroups_GET_responses, api_security=s.SecurityEveryoneAPI)
 @view_config(route_name=s.UserGroupsAPI.name, request_method="GET", permission=MAGPIE_CONTEXT_PERMISSION)
 def get_user_groups_view(request):
     """
@@ -151,9 +153,9 @@ def get_user_groups_view(request):
                          detail=s.UserGroups_GET_OkResponseSchema.description)
 
 
-@s.UserGroupsAPI.post(schema=s.UserGroups_POST_RequestSchema(), tags=[s.UsersTag],
+@s.UserGroupsAPI.post(schema=s.UserGroups_POST_RequestSchema, tags=[s.UsersTag],
                       response_schemas=s.UserGroups_POST_responses)
-@s.LoggedUserGroupsAPI.post(schema=s.UserGroups_POST_RequestSchema(), tags=[s.LoggedUserTag],
+@s.LoggedUserGroupsAPI.post(schema=s.UserGroups_POST_RequestSchema, tags=[s.LoggedUserTag],
                             response_schemas=s.LoggedUserGroups_POST_responses)
 @view_config(route_name=s.UserGroupsAPI.name, request_method="POST")
 def assign_user_group_view(request):
@@ -167,9 +169,9 @@ def assign_user_group_view(request):
                          content={"user_name": user.user_name, "group_name": group.group_name})
 
 
-@s.UserGroupAPI.delete(schema=s.UserGroup_DELETE_RequestSchema(), tags=[s.UsersTag],
+@s.UserGroupAPI.delete(schema=s.UserGroup_DELETE_RequestSchema, tags=[s.UsersTag],
                        response_schemas=s.UserGroup_DELETE_responses)
-@s.LoggedUserGroupAPI.delete(schema=s.UserGroup_DELETE_RequestSchema(), tags=[s.LoggedUserTag],
+@s.LoggedUserGroupAPI.delete(schema=s.UserGroup_DELETE_RequestSchema, tags=[s.LoggedUserTag],
                              response_schemas=s.LoggedUserGroup_DELETE_responses)
 @view_config(route_name=s.UserGroupAPI.name, request_method="DELETE")
 def delete_user_group_view(request):
@@ -264,9 +266,9 @@ def get_user_resource_permissions_view(request):
                                                      effective_permissions=effective_perms)
 
 
-@s.UserResourcePermissionsAPI.post(schema=s.UserResourcePermissions_POST_RequestSchema(), tags=[s.UsersTag],
+@s.UserResourcePermissionsAPI.post(schema=s.UserResourcePermissions_POST_RequestSchema, tags=[s.UsersTag],
                                    response_schemas=s.UserResourcePermissions_POST_responses)
-@s.LoggedUserResourcePermissionsAPI.post(schema=s.UserResourcePermissions_POST_RequestSchema(), tags=[s.LoggedUserTag],
+@s.LoggedUserResourcePermissionsAPI.post(schema=s.UserResourcePermissions_POST_RequestSchema, tags=[s.LoggedUserTag],
                                          response_schemas=s.LoggedUserResourcePermissions_POST_responses)
 @view_config(route_name=s.UserResourcePermissionsAPI.name, request_method="POST")
 def create_user_resource_permissions_view(request):
@@ -279,9 +281,9 @@ def create_user_resource_permissions_view(request):
     return uu.create_user_resource_permission_response(user, resource, permission, request.db, overwrite=False)
 
 
-@s.UserResourcePermissionsAPI.put(schema=s.UserResourcePermissions_PUT_RequestSchema(), tags=[s.UsersTag],
+@s.UserResourcePermissionsAPI.put(schema=s.UserResourcePermissions_PUT_RequestSchema, tags=[s.UsersTag],
                                   response_schemas=s.UserResourcePermissions_PUT_responses)
-@s.LoggedUserResourcePermissionsAPI.put(schema=s.UserResourcePermissions_PUT_RequestSchema(), tags=[s.LoggedUserTag],
+@s.LoggedUserResourcePermissionsAPI.put(schema=s.UserResourcePermissions_PUT_RequestSchema, tags=[s.LoggedUserTag],
                                         response_schemas=s.LoggedUserResourcePermissions_PUT_responses)
 @view_config(route_name=s.UserResourcePermissionsAPI.name, request_method="PUT")
 def replace_user_resource_permissions_view(request):
@@ -296,9 +298,9 @@ def replace_user_resource_permissions_view(request):
     return uu.create_user_resource_permission_response(user, resource, permission, request.db, overwrite=True)
 
 
-@s.UserResourcePermissionsAPI.delete(schema=s.UserResourcePermissions_DELETE_RequestSchema(), tags=[s.UsersTag],
+@s.UserResourcePermissionsAPI.delete(schema=s.UserResourcePermissions_DELETE_RequestSchema, tags=[s.UsersTag],
                                      response_schemas=s.UserResourcePermissions_DELETE_responses)
-@s.LoggedUserResourcePermissionsAPI.delete(schema=s.UserResourcePermissions_DELETE_RequestSchema(),
+@s.LoggedUserResourcePermissionsAPI.delete(schema=s.UserResourcePermissions_DELETE_RequestSchema,
                                            tags=[s.LoggedUserTag],
                                            response_schemas=s.LoggedUserResourcePermissions_DELETE_responses)
 @view_config(route_name=s.UserResourcePermissionsAPI.name, request_method="DELETE")
@@ -312,9 +314,9 @@ def delete_user_resource_permissions_view(request):
     return uu.delete_user_resource_permission_response(user, resource, permission, request.db)
 
 
-@s.UserResourcePermissionAPI.delete(schema=s.UserResourcePermissionName_DELETE_RequestSchema(), tags=[s.UsersTag],
+@s.UserResourcePermissionAPI.delete(schema=s.UserResourcePermissionName_DELETE_RequestSchema, tags=[s.UsersTag],
                                     response_schemas=s.UserResourcePermissionName_DELETE_responses)
-@s.LoggedUserResourcePermissionAPI.delete(schema=s.UserResourcePermissionName_DELETE_RequestSchema(),
+@s.LoggedUserResourcePermissionAPI.delete(schema=s.UserResourcePermissionName_DELETE_RequestSchema,
                                           tags=[s.LoggedUserTag],
                                           response_schemas=s.LoggedUserResourcePermissionName_DELETE_responses)
 @view_config(route_name=s.UserResourcePermissionAPI.name, request_method="DELETE")
@@ -328,10 +330,10 @@ def delete_user_resource_permission_name_view(request):
     return uu.delete_user_resource_permission_response(user, resource, permission, request.db)
 
 
-@s.UserServicesAPI.get(tags=[s.UsersTag], schema=s.UserServices_GET_RequestSchema,
-                       api_security=s.SecurityEveryoneAPI, response_schemas=s.UserServices_GET_responses)
-@s.LoggedUserServicesAPI.get(tags=[s.LoggedUserTag], api_security=s.SecurityEveryoneAPI,
-                             response_schemas=s.LoggedUserServices_GET_responses)
+@s.UserServicesAPI.get(schema=s.UserServices_GET_RequestSchema, tags=[s.UsersTag],
+                       response_schemas=s.UserServices_GET_responses, api_security=s.SecurityEveryoneAPI)
+@s.LoggedUserServicesAPI.get(schema=s.UserServices_GET_RequestSchema, tags=[s.LoggedUserTag],
+                             response_schemas=s.LoggedUserServices_GET_responses, api_security=s.SecurityEveryoneAPI)
 @view_config(route_name=s.UserServicesAPI.name, request_method="GET", permission=MAGPIE_CONTEXT_PERMISSION)
 def get_user_services_view(request):
     """
@@ -352,10 +354,10 @@ def get_user_services_view(request):
                          detail=s.UserServices_GET_OkResponseSchema.description)
 
 
-@s.UserServicePermissionsAPI.get(schema=s.UserServicePermissions_GET_RequestSchema,
+@s.UserServicePermissionsAPI.get(schema=s.UserServicePermissions_GET_RequestSchema(),
                                  tags=[s.UsersTag], api_security=s.SecurityEveryoneAPI,
                                  response_schemas=s.UserServicePermissions_GET_responses)
-@s.LoggedUserServicePermissionsAPI.get(schema=s.UserServicePermissions_GET_RequestSchema,
+@s.LoggedUserServicePermissionsAPI.get(schema=s.UserServicePermissions_GET_RequestSchema(),
                                        tags=[s.LoggedUserTag], api_security=s.SecurityEveryoneAPI,
                                        response_schemas=s.LoggedUserServicePermissions_GET_responses)
 @view_config(route_name=s.UserServicePermissionsAPI.name, request_method="GET", permission=MAGPIE_CONTEXT_PERMISSION)

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -4,7 +4,6 @@ User Views, both for specific user-name provided as request path variable and sp
 from pyramid.httpexceptions import HTTPBadRequest, HTTPConflict, HTTPCreated, HTTPForbidden, HTTPNotFound, HTTPOk
 from pyramid.settings import asbool
 from pyramid.view import view_config
-from ziggurat_foundations.models.services.group import GroupService
 from ziggurat_foundations.models.services.resource import ResourceService
 from ziggurat_foundations.models.services.user import UserService
 

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -50,16 +50,6 @@ InfoAPI = {
     "contact": {"name": __meta__.__maintainer__, "email": __meta__.__email__, "url": __meta__.__url__}
 }
 
-# Tags
-APITag = "API"
-SessionTag = "Session"
-UsersTag = "User"
-LoggedUserTag = "Logged User"
-GroupsTag = "Group"
-RegisterTag = "Register"
-ResourcesTag = "Resource"
-ServicesTag = "Service"
-
 
 # Security
 SecurityCookieAuthAPI = {"cookieAuth": {"type": "apiKey", "in": "cookie", "name": get_constant("MAGPIE_COOKIE_NAME")}}
@@ -86,7 +76,8 @@ def get_security(service, method):
     return SecurityAdministratorAPI if "security" not in args else args["security"]
 
 
-# Service Routes
+# Path definitions (from services and parameters)
+
 def service_api_route_info(service_api, **kwargs):
     kwargs.update({
         "name": service_api.name,
@@ -97,6 +88,7 @@ def service_api_route_info(service_api, **kwargs):
     return kwargs
 
 
+# Service Routes
 _LOGGED_USER_VALUE = get_constant("MAGPIE_LOGGED_USER")
 LoggedUserBase = "/users/{}".format(_LOGGED_USER_VALUE)
 
@@ -276,8 +268,145 @@ HomepageAPI = Service(
     path="/",
     name="homepage")
 TemporaryUrlAPI = Service(
-    path="tmp/{token}",
+    path="/tmp/{token}",
     name="temporary_url")
+
+
+# Path parameters
+GroupNameParameter = colander.SchemaNode(
+    colander.String(),
+    description="Registered user group.",
+    example="users",)
+UserNameParameter = colander.SchemaNode(
+    colander.String(),
+    description="Registered local user.",
+    example="toto",)
+ProviderNameParameter = colander.SchemaNode(
+    colander.String(),
+    description="External identity provider.",
+    example="DKRZ",
+    validator=colander.OneOf(get_provider_names()))
+PermissionNameParameter = colander.SchemaNode(
+    colander.String(),
+    description="Permissions applicable to the service/resource.",
+    example=Permission.READ.value,)
+ResourceIdParameter = colander.SchemaNode(
+    colander.String(),
+    description="Registered resource ID.",
+    example="123")
+ResourceTypeParameter = colander.SchemaNode(
+    colander.String(),
+    description="Known resource type.",
+    example="process")
+ServiceNameParameter = colander.SchemaNode(
+    colander.String(),
+    description="Registered service name.",
+    example="my-wps")
+ServiceTypeParameter = colander.SchemaNode(
+    colander.String(),
+    description="Known service type.",
+    example="wps")
+TokenParameter = colander.SchemaNode(
+    colander.String(),
+    description="Temporary URL token.",
+    example=str(uuid.uuid4()))
+
+
+class ServiceType_RequestPathSchema(colander.MappingSchema):
+    service_type = ServiceTypeParameter
+
+
+class Service_RequestPathSchema(colander.MappingSchema):
+    service_name = ServiceNameParameter
+
+
+class Resource_RequestPathSchema(colander.MappingSchema):
+    resource_id = ResourceIdParameter
+
+
+class ServiceResource_RequestPathSchema(colander.MappingSchema):
+    service_name = ServiceNameParameter
+    resource_id = ResourceIdParameter
+
+
+class Permission_RequestPathSchema(colander.MappingSchema):
+    permission_name = PermissionNameParameter
+
+
+class Group_RequestPathSchema(colander.MappingSchema):
+    group_name = GroupNameParameter
+
+
+class User_RequestPathSchema(colander.MappingSchema):
+    user_name = UserNameParameter
+
+
+class UserGroup_RequestPathSchema(colander.MappingSchema):
+    user_name = UserNameParameter
+    group_name = GroupNameParameter
+
+
+class GroupService_RequestPathSchema(colander.MappingSchema):
+    group_name = GroupNameParameter
+    service_name = UserNameParameter
+
+
+class GroupServicePermission_RequestPathSchema(colander.MappingSchema):
+    group_name = GroupNameParameter
+    service_name = UserNameParameter
+    permission_name = PermissionNameParameter
+
+
+class GroupResource_RequestPathSchema(colander.MappingSchema):
+    group_name = GroupNameParameter
+    resource_id = ResourceIdParameter
+
+
+class GroupResourcePermission_RequestPathSchema(colander.MappingSchema):
+    group_name = GroupNameParameter
+    resource_id = ResourceIdParameter
+    permission_name = PermissionNameParameter
+
+
+class UserService_RequestPathSchema(colander.MappingSchema):
+    user_name = UserNameParameter
+    service_name = UserNameParameter
+
+
+class UserServicePermission_RequestPathSchema(colander.MappingSchema):
+    user_name = UserNameParameter
+    service_name = UserNameParameter
+    permission_name = PermissionNameParameter
+
+
+class UserResource_RequestPathSchema(colander.MappingSchema):
+    user_name = UserNameParameter
+    resource_id = ResourceIdParameter
+
+
+class UserResourcePermission_RequestPathSchema(colander.MappingSchema):
+    user_name = UserNameParameter
+    resource_id = ResourceIdParameter
+    permission_name = PermissionNameParameter
+
+
+class Provider_RequestPathSchema(colander.MappingSchema):
+    provider_name = ProviderNameParameter
+
+
+class TemporaryURL_RequestPathSchema(colander.MappingSchema):
+    token = TokenParameter
+
+
+# Tags
+APITag = "API"
+SessionTag = "Session"
+UsersTag = "User"
+LoggedUserTag = "Logged User"
+GroupsTag = "Group"
+RegisterTag = "Register"
+ResourcesTag = "Resource"
+ServicesTag = "Service"
 
 TAG_DESCRIPTIONS = {
     APITag: "General information about the API.",
@@ -298,39 +427,7 @@ TAG_DESCRIPTIONS = {
     ServicesTag: "Management of service definitions, children resources and their applicable permissions.",
 }
 
-
-# Common path parameters
-GroupNameParameter = colander.SchemaNode(
-    colander.String(),
-    description="Registered user group.",
-    example="users",)
-UserNameParameter = colander.SchemaNode(
-    colander.String(),
-    description="Registered local user.",
-    example="toto",)
-ProviderNameParameter = colander.SchemaNode(
-    colander.String(),
-    description="External identity provider.",
-    example="DKRZ",
-    validator=colander.OneOf(get_provider_names())
-)
-PermissionNameParameter = colander.SchemaNode(
-    colander.String(),
-    description="Permissions applicable to the service/resource.",
-    example=Permission.READ.value,)
-ResourceIdParameter = colander.SchemaNode(
-    colander.String(),
-    description="Registered resource ID.",
-    example="123")
-ServiceNameParameter = colander.SchemaNode(
-    colander.String(),
-    description="Registered service name.",
-    example="my-wps")
-TokenParameter = colander.SchemaNode(
-    colander.String(),
-    description="Temporary URL token.",
-    example=str(uuid.uuid4()))
-
+# Header definitions
 
 class AcceptType(colander.SchemaNode):
     schema_type = colander.String
@@ -347,14 +444,14 @@ class ContentType(colander.SchemaNode):
     missing = colander.drop
 
 
-class HeaderRequestSchemaAPI(colander.MappingSchema):
+class RequestHeaderSchemaAPI(colander.MappingSchema):
     accept = AcceptType(name="Accept", validator=colander.OneOf(SUPPORTED_ACCEPT_TYPES),
                         description="Desired MIME type for the response body content.")
     content_type = ContentType(validator=colander.OneOf(KNOWN_CONTENT_TYPES),
                                description="MIME content type of the request body.")
 
 
-class HeaderRequestSchemaUI(colander.MappingSchema):
+class RequestHeaderSchemaUI(colander.MappingSchema):
     content_type = ContentType(default=CONTENT_TYPE_HTML, example=CONTENT_TYPE_HTML,
                                description="MIME content type of the request body.")
 
@@ -405,7 +502,7 @@ class PhoenixServicePushOption(colander.SchemaNode):
 
 
 class BaseRequestSchemaAPI(colander.MappingSchema):
-    header = HeaderRequestSchemaAPI()
+    header = RequestHeaderSchemaAPI()
     querystring = QueryRequestSchemaAPI()
 
 
@@ -1158,6 +1255,10 @@ class Service_CheckConfig_UnprocessableEntityResponseSchema(BaseResponseSchemaAP
 Services_GET_RequestSchema = ServiceTypes_GET_RequestSchema
 
 
+class Service_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Service_RequestPathSchema()
+
+
 class Service_GET_ResponseBodySchema(BaseResponseBodySchema):
     service = ServiceDetailSchema()
 
@@ -1246,7 +1347,7 @@ class Services_POST_InternalServerErrorResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPInternalServerError.code, description=description)
 
 
-class Service_PATCH_ResponseBodySchema(colander.MappingSchema):
+class Service_PATCH_RequestBodySchema(colander.MappingSchema):
     service_name = colander.SchemaNode(
         colander.String(),
         description="New service name to apply to service specified in path",
@@ -1265,8 +1366,9 @@ class Service_PATCH_ResponseBodySchema(colander.MappingSchema):
     configuration = ServiceConfigurationSchema()
 
 
-class Service_PATCH_RequestBodySchema(BaseRequestSchemaAPI):
-    body = Service_PATCH_ResponseBodySchema()
+class Service_PATCH_RequestSchema(BaseRequestSchemaAPI):
+    path = Service_RequestPathSchema()
+    body = Service_PATCH_RequestBodySchema()
 
 
 class Service_PATCH_OkResponseSchema(BaseResponseSchemaAPI):
@@ -1294,9 +1396,12 @@ class Service_PATCH_ConflictResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
+Service_DELETE_RequestBodySchema = Resource_DELETE_RequestBodySchema
+
+
 class Service_DELETE_RequestSchema(BaseRequestSchemaAPI):
-    body = Resource_DELETE_RequestBodySchema()
-    service_name = ServiceNameParameter
+    path = Service_RequestPathSchema()
+    body = Service_DELETE_RequestBodySchema()
 
 
 class Service_DELETE_OkResponseSchema(BaseResponseSchemaAPI):
@@ -1321,6 +1426,7 @@ class ServicePermissions_ResponseBodySchema(BaseResponseBodySchema):
 
 class ServicePermissions_GET_OkResponseSchema(BaseResponseSchemaAPI):
     description = "Get service permissions successful."
+    path = Service_RequestPathSchema()
     body = ServicePermissions_ResponseBodySchema(code=HTTPOk.code, description=description)
 
 
@@ -1335,7 +1441,7 @@ class ServicePermissions_GET_BadRequestResponseSchema(BaseResponseSchemaAPI):
 
 # create service's resource use same method as direct resource create
 class ServiceResources_POST_RequestSchema(Resources_POST_RequestSchema):
-    service_name = ServiceNameParameter
+    path = Service_RequestPathSchema()
 
 
 ServiceResources_POST_CreatedResponseSchema = Resources_POST_CreatedResponseSchema
@@ -1672,8 +1778,8 @@ class UserGroups_POST_RequestBodySchema(colander.MappingSchema):
 
 
 class UserGroups_POST_RequestSchema(BaseRequestSchemaAPI):
+    path = User_RequestPathSchema()
     body = UserGroups_POST_RequestBodySchema()
-    user_name = UserNameParameter
 
 
 class UserGroups_POST_ResponseBodySchema(BaseResponseBodySchema):
@@ -1863,9 +1969,8 @@ class UserResourcePermissions_POST_RequestBodySchema(colander.MappingSchema):
 
 
 class UserResourcePermissions_POST_RequestSchema(BaseRequestSchemaAPI):
+    path = UserResource_RequestPathSchema()
     body = UserResourcePermissions_POST_RequestBodySchema()
-    resource_id = ResourceIdParameter
-    user_name = UserNameParameter
 
 
 UserResourcePermissions_PUT_RequestSchema = UserResourcePermissions_POST_RequestSchema
@@ -1927,10 +2032,8 @@ UserResourcePermissionName_DELETE_BadRequestResponseSchema = UserResourcePermiss
 
 
 class UserResourcePermissionName_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = UserResourcePermission_RequestPathSchema()
     body = colander.MappingSchema(default={})
-    user_name = UserNameParameter
-    resource_id = ResourceIdParameter
-    permission_name = PermissionNameParameter
 
 
 class UserResourcePermissionName_DELETE_OkResponseSchema(BaseResponseSchemaAPI):
@@ -1948,9 +2051,8 @@ class UserResourcePermissions_DELETE_RequestBodySchema(colander.MappingSchema):
 
 
 class UserResourcePermissions_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = UserResource_RequestPathSchema()
     body = UserResourcePermissions_DELETE_RequestBodySchema()
-    user_name = UserNameParameter
-    resource_id = ResourceIdParameter
 
 
 UserResourcePermissions_DELETE_OkResponseSchema = UserResourcePermissionName_DELETE_OkResponseSchema
@@ -1973,9 +2075,8 @@ class UserServiceResources_GET_QuerySchema(QueryRequestSchemaAPI):
 
 
 class UserServiceResources_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = UserService_RequestPathSchema()
     querystring = UserServiceResources_GET_QuerySchema()
-    user_name = UserNameParameter
-    service_name = ServiceNameParameter
 
 
 class UserServicePermissions_POST_RequestBodySchema(colander.MappingSchema):
@@ -1991,9 +2092,8 @@ class UserServicePermissions_POST_RequestBodySchema(colander.MappingSchema):
 
 
 class UserServicePermissions_POST_RequestSchema(BaseRequestSchemaAPI):
+    path = UserService_RequestPathSchema()
     body = UserServicePermissions_POST_RequestBodySchema()
-    user_name = UserNameParameter
-    service_name = ServiceNameParameter
 
 
 UserServicePermissions_PUT_RequestSchema = UserServicePermissions_POST_RequestSchema
@@ -2004,16 +2104,13 @@ class UserServicePermissions_DELETE_RequestBodySchema(colander.MappingSchema):
 
 
 class UserServicePermissions_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = UserService_RequestPathSchema()
     body = UserResourcePermissions_DELETE_RequestBodySchema()
-    user_name = UserNameParameter
-    resource_id = ResourceIdParameter
 
 
 class UserServicePermissionName_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = UserServicePermission_RequestPathSchema()
     body = colander.MappingSchema(default={})
-    user_name = UserNameParameter
-    service_name = ServiceNameParameter
-    permission_name = PermissionNameParameter
 
 
 class UserServices_GET_QuerySchema(QueryRequestSchemaAPI):
@@ -2023,8 +2120,8 @@ class UserServices_GET_QuerySchema(QueryRequestSchemaAPI):
 
 
 class UserServices_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = User_RequestPathSchema()
     querystring = UserServices_GET_QuerySchema()
-    user_name = UserNameParameter
 
 
 class UserServices_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -2042,9 +2139,8 @@ class UserServicePermissions_GET_QuerySchema(QueryRequestSchemaAPI):
 
 
 class UserServicePermissions_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = UserService_RequestPathSchema()
     querystring = UserServicePermissions_GET_QuerySchema()
-    user_name = UserNameParameter
-    service_name = ServiceNameParameter
 
 
 class UserServicePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -2142,6 +2238,10 @@ class Groups_POST_ConflictResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
+class Group_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
+
+
 class Group_GET_ResponseBodySchema(BaseResponseBodySchema):
     group = GroupDetailBodySchema()
 
@@ -2166,8 +2266,8 @@ class Group_PATCH_RequestBodySchema(colander.MappingSchema):
 
 
 class Group_PATCH_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
     body = Group_PATCH_RequestBodySchema()
-    group_name = GroupNameParameter
 
 
 class Group_PATCH_OkResponseSchema(BaseResponseSchemaAPI):
@@ -2202,8 +2302,8 @@ class Group_PATCH_ConflictResponseSchema(BaseResponseSchemaAPI):
 
 
 class Group_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
     body = colander.MappingSchema(default={})
-    group_name = GroupNameParameter
 
 
 class Group_DELETE_OkResponseSchema(BaseResponseSchemaAPI):
@@ -2221,6 +2321,10 @@ class Group_DELETE_ReservedKeyword_ForbiddenResponseSchema(BaseResponseSchemaAPI
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
+class GroupUsers_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
+
+
 class GroupUsers_GET_ResponseBodySchema(BaseResponseBodySchema):
     user_names = UserNamesListSchema()
 
@@ -2233,6 +2337,10 @@ class GroupUsers_GET_OkResponseSchema(BaseResponseSchemaAPI):
 class GroupUsers_GET_ForbiddenResponseSchema(BaseResponseSchemaAPI):
     description = "Failed to obtain group user names from db."
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
+
+
+class GroupServices_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
 
 
 class GroupServices_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -2252,6 +2360,10 @@ class GroupServices_InternalServerErrorResponseSchema(BaseResponseSchemaAPI):
     description = "Failed to populate group services."
     body = GroupServices_InternalServerErrorResponseBodySchema(
         code=HTTPInternalServerError.code, description=description)
+
+
+class GroupServicePermissions_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupService_RequestPathSchema()
 
 
 class GroupServicePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -2293,15 +2405,13 @@ class GroupServicePermissions_POST_RequestBodySchema(colander.MappingSchema):
 
 
 class GroupServicePermissions_POST_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupService_RequestPathSchema()
     body = GroupServicePermissions_POST_RequestBodySchema()
-    group_name = GroupNameParameter
-    service_name = ServiceNameParameter
 
 
 class GroupResourcePermissions_POST_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupResource_RequestPathSchema()
     body = GroupServicePermissions_POST_RequestBodySchema()
-    group_name = GroupNameParameter
-    resource_id = ResourceIdParameter
 
 
 class GroupResourcePermissions_Check_ResponseBodySchema(BaseResponseBodySchema):
@@ -2358,10 +2468,8 @@ class GroupResourcePermissions_PUT_OkResponseSchema(BaseResponseSchemaAPI):
 
 
 class GroupResourcePermissionName_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupResourcePermission_RequestPathSchema()
     body = colander.MappingSchema(default={})
-    group_name = GroupNameParameter
-    resource_id = ResourceIdParameter
-    permission_name = PermissionNameParameter
 
 
 class GroupResourcePermissions_DELETE_RequestBodySchema(colander.MappingSchema):
@@ -2372,9 +2480,8 @@ class GroupResourcePermissions_DELETE_RequestBodySchema(colander.MappingSchema):
 
 
 class GroupResourcePermissions_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupResource_RequestPathSchema()
     body = GroupResourcePermissions_DELETE_RequestBodySchema()
-    group_name = GroupNameParameter
-    resource_id = ResourceIdParameter
 
 
 class GroupResourcesPermissions_InternalServerErrorResponseBodySchema(InternalServerErrorResponseBodySchema):
@@ -2400,6 +2507,10 @@ class GroupResourcePermissions_InternalServerErrorResponseSchema(BaseResponseSch
         code=HTTPInternalServerError.code, description=description)
 
 
+class GroupResources_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
+
+
 class GroupResources_GET_ResponseBodySchema(BaseResponseBodySchema):
     resources = ResourcesSchemaNode()
 
@@ -2419,6 +2530,10 @@ class GroupResources_GET_InternalServerErrorResponseSchema(BaseResponseSchemaAPI
         code=HTTPInternalServerError.code, description=description)
 
 
+class GroupResourcePermissions_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupResource_RequestPathSchema()
+
+
 class GroupResourcePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
     permissions_names = PermissionNameListSchema(
         description="List of resource permissions applied to the referenced group.",
@@ -2432,6 +2547,10 @@ class GroupResourcePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
 class GroupResourcePermissions_GET_OkResponseSchema(BaseResponseSchemaAPI):
     description = "Get group resource permissions successful."
     body = GroupResourcePermissions_GET_ResponseBodySchema(code=HTTPOk.code, description=description)
+
+
+class GroupServiceResources_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupService_RequestPathSchema()
 
 
 class GroupServiceResources_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -2452,10 +2571,8 @@ class GroupServicePermission_DELETE_RequestBodySchema(colander.MappingSchema):
 
 
 class GroupServicePermissionName_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = GroupServicePermission_RequestPathSchema()
     body = GroupServicePermission_DELETE_RequestBodySchema()
-    group_name = GroupNameParameter
-    service_name = ServiceNameParameter
-    permission_name = PermissionNameParameter
 
 
 class GroupServicePermission_DELETE_ResponseBodySchema(BaseResponseBodySchema):
@@ -2511,6 +2628,10 @@ class RegisterGroups_GET_ForbiddenResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
+class RegisterGroup_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
+
+
 class RegisterGroup_GET_ResponseBodySchema(BaseResponseBodySchema):
     group = GroupPublicBodySchema()  # not detailed because authenticated route has limited information
 
@@ -2521,8 +2642,8 @@ class RegisterGroup_GET_OkResponseSchema(BaseResponseSchemaAPI):
 
 
 class RegisterGroup_POST_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
     body = colander.MappingSchema(description="Nothing required.")
-    group_name = GroupNameParameter
 
 
 class RegisterGroup_POST_ResponseBodySchema(BaseResponseBodySchema):
@@ -2554,8 +2675,8 @@ class RegisterGroup_POST_ConflictResponseSchema(BaseResponseSchemaAPI):
 
 
 class RegisterGroup_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = Group_RequestPathSchema()
     body = colander.MappingSchema(description="Nothing required.")
-    group_name = GroupNameParameter
 
 
 class RegisterGroup_DELETE_OkResponseSchema(BaseResponseSchemaAPI):
@@ -2568,21 +2689,21 @@ RegisterGroup_DELETE_ForbiddenResponseSchema = UserGroup_DELETE_ForbiddenRespons
 RegisterGroup_DELETE_NotFoundResponseSchema = UserGroup_DELETE_NotFoundResponseSchema
 
 
-class TemporaryUrl_GET_RequestSchema(BaseRequestSchemaAPI):
-    token = TokenParameter
+class TemporaryURL_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = TemporaryURL_RequestPathSchema()
 
 
-class TemporaryUrl_GET_OkResponseSchema(BaseResponseSchemaAPI):
+class TemporaryURL_GET_OkResponseSchema(BaseResponseSchemaAPI):
     description = "Successful operation from provided temporary URL token."
     body = BaseResponseBodySchema(code=HTTPOk.code, description=description)
 
 
-class TemporaryUrl_GET_NotFoundResponseSchema(BaseResponseSchemaAPI):
+class TemporaryURL_GET_NotFoundResponseSchema(BaseResponseSchemaAPI):
     description = "Could not find any operation matching temporary URL token."
     body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
 
 
-class TemporaryUrl_GET_GoneResponseSchema(BaseResponseSchemaAPI):
+class TemporaryURL_GET_GoneResponseSchema(BaseResponseSchemaAPI):
     description = "Temporary URL token is expired."
     body = BaseResponseBodySchema(code=HTTPGone.code, description=description)
 
@@ -2618,7 +2739,7 @@ class Providers_GET_OkResponseSchema(BaseResponseSchemaAPI):
     body = Providers_GET_ResponseBodySchema(code=HTTPOk.code, description=description)
 
 
-class ProviderSignin_GET_HeaderRequestSchema(HeaderRequestSchemaAPI):
+class ProviderSignin_GET_RequestHeaderSchema(RequestHeaderSchemaAPI):
     Authorization = colander.SchemaNode(
         colander.String(),
         missing=colander.drop,
@@ -2637,8 +2758,8 @@ class ProviderSignin_GET_HeaderRequestSchema(HeaderRequestSchemaAPI):
 
 
 class ProviderSignin_GET_RequestSchema(BaseRequestSchemaAPI):
-    header = ProviderSignin_GET_HeaderRequestSchema()
-    provider_name = ProviderNameParameter
+    path = Provider_RequestPathSchema()
+    header = ProviderSignin_GET_RequestHeaderSchema()
 
 
 class ProviderSignin_GET_FoundResponseBodySchema(BaseResponseBodySchema):
@@ -2771,7 +2892,7 @@ class Homepage_GET_OkResponseSchema(BaseResponseSchemaAPI):
 
 class SwaggerAPI_GET_OkResponseSchema(colander.MappingSchema):
     description = TitleAPI
-    header = HeaderRequestSchemaUI()
+    header = RequestHeaderSchemaUI()
     body = colander.SchemaNode(colander.String(), example="This page!")
 
 
@@ -3410,10 +3531,10 @@ RegisterGroup_DELETE_responses = {
     "404": RegisterGroup_DELETE_NotFoundResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
-TemporaryUrl_GET_responses = {
-    "200": TemporaryUrl_GET_OkResponseSchema(),
-    "404": TemporaryUrl_GET_NotFoundResponseSchema(),
-    "410": TemporaryUrl_GET_GoneResponseSchema(),
+TemporaryURL_GET_responses = {
+    "200": TemporaryURL_GET_OkResponseSchema(),
+    "404": TemporaryURL_GET_NotFoundResponseSchema(),
+    "410": TemporaryURL_GET_GoneResponseSchema(),
     "422": UnprocessableEntityResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -268,7 +268,7 @@ HomepageAPI = Service(
     path="/",
     name="homepage")
 TemporaryUrlAPI = Service(
-    path="/tmp/{token}",
+    path="/tmp/{token}",  # nosec: B108
     name="temporary_url")
 
 
@@ -428,6 +428,7 @@ TAG_DESCRIPTIONS = {
 }
 
 # Header definitions
+
 
 class AcceptType(colander.SchemaNode):
     schema_type = colander.String

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -950,6 +950,10 @@ class Resources_ResponseBodySchema(BaseResponseBodySchema):
     resources = ResourcesSchemaNode()
 
 
+class Resource_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Resource_RequestPathSchema()
+
+
 class Resource_MatchDictCheck_ForbiddenResponseSchema(BaseResponseSchemaAPI):
     description = "Resource query by id refused by db."
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
@@ -988,8 +992,8 @@ class Resource_PATCH_RequestBodySchema(colander.MappingSchema):
 
 
 class Resource_PATCH_RequestSchema(BaseRequestSchemaAPI):
+    path = Resource_RequestPathSchema()
     body = Resource_PATCH_RequestBodySchema()
-    resource_id = ResourceIdParameter
 
 
 class Resource_PATCH_ResponseBodySchema(BaseResponseBodySchema):
@@ -1036,8 +1040,8 @@ class Resource_DELETE_RequestBodySchema(colander.MappingSchema):
 
 
 class Resource_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = Resource_RequestPathSchema()
     body = Resource_DELETE_RequestBodySchema()
-    resource_id = ResourceIdParameter
 
 
 class Resource_DELETE_OkResponseSchema(BaseResponseSchemaAPI):
@@ -1107,6 +1111,10 @@ class Resources_POST_NotFoundResponseSchema(BaseResponseSchemaAPI):
 class Resources_POST_ConflictResponseSchema(BaseResponseSchemaAPI):
     description = "Resource name already exists at requested tree level for creation."
     body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
+
+
+class ResourcePermissions_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Resource_RequestPathSchema()
 
 
 class ResourcePermissions_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -1467,6 +1475,10 @@ ServiceResource_DELETE_ForbiddenResponseSchema = Resource_DELETE_ForbiddenRespon
 ServiceResource_DELETE_OkResponseSchema = Resource_DELETE_OkResponseSchema
 
 
+class ServiceResources_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = Service_RequestPathSchema()
+
+
 class ServiceResources_GET_ResponseBodySchema(BaseResponseBodySchema):
     service_name = Resource_ServiceWithChildrenResourcesContainerBodySchema(name="{service_name}")
 
@@ -1474,6 +1486,10 @@ class ServiceResources_GET_ResponseBodySchema(BaseResponseBodySchema):
 class ServiceResources_GET_OkResponseSchema(BaseResponseSchemaAPI):
     description = "Get service resources successful."
     body = ServiceResources_GET_ResponseBodySchema(code=HTTPOk.code, description=description)
+
+
+class ServiceTypeResources_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = ServiceType_RequestPathSchema()
 
 
 class ServiceTypeResourceInfo(colander.MappingSchema):
@@ -1515,6 +1531,10 @@ class ServiceTypeResources_GET_ForbiddenResponseSchema(BaseResponseSchemaAPI):
 class ServiceTypeResources_GET_NotFoundResponseSchema(BaseResponseSchemaAPI):
     description = "Invalid 'service_type' does not exist to obtain its resource types."
     body = ErrorResponseBodySchema(code=HTTPNotFound.code, description=description)
+
+
+class ServiceTypeResourceTypes_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = ServiceType_RequestPathSchema()
 
 
 class ServiceTypeResourceTypes_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -1669,6 +1689,7 @@ class User_PATCH_RequestBodySchema(colander.MappingSchema):
 
 
 class User_PATCH_RequestSchema(BaseRequestSchemaAPI):
+    path = User_RequestPathSchema()
     body = User_PATCH_RequestBodySchema()
 
 
@@ -1690,6 +1711,10 @@ class User_PATCH_ForbiddenResponseSchema(BaseResponseSchemaAPI):
 class User_PATCH_ConflictResponseSchema(BaseResponseSchemaAPI):
     description = "New name user already exists."
     body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
+
+
+class User_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = User_RequestPathSchema()
 
 
 class User_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -1727,6 +1752,7 @@ class User_GET_NotFoundResponseSchema(BaseResponseSchemaAPI):
 
 
 class User_DELETE_RequestSchema(BaseRequestSchemaAPI):
+    path = User_RequestPathSchema()
     body = colander.MappingSchema(default={})
 
 
@@ -1740,24 +1766,8 @@ class User_DELETE_ForbiddenResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
-class UserGroup_Check_BadRequestResponseSchema(BaseResponseSchemaAPI):
-    description = "Invalid group name to associate to user."
-    body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
-
-
-class UserGroup_GET_ForbiddenResponseSchema(BaseResponseSchemaAPI):
-    description = "Group query was refused by db."
-    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
-
-
-class UserGroup_Check_NotFoundResponseSchema(BaseResponseSchemaAPI):
-    description = "Group for new user doesn't exist."
-    body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
-
-
-class UserGroup_Check_ForbiddenResponseSchema(BaseResponseSchemaAPI):
-    description = "Failed to add user-group to db."
-    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
+class UserGroups_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = User_RequestPathSchema()
 
 
 class UserGroups_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -1834,6 +1844,26 @@ class UserGroups_POST_ConflictResponseSchema(BaseResponseSchemaAPI):
     body = UserGroups_POST_ConflictResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
+class UserGroup_Check_BadRequestResponseSchema(BaseResponseSchemaAPI):
+    description = "Invalid group name to associate to user."
+    body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
+
+
+class UserGroup_GET_ForbiddenResponseSchema(BaseResponseSchemaAPI):
+    description = "Group query was refused by db."
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
+
+
+class UserGroup_Check_NotFoundResponseSchema(BaseResponseSchemaAPI):
+    description = "Group for new user doesn't exist."
+    body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
+
+
+class UserGroup_Check_ForbiddenResponseSchema(BaseResponseSchemaAPI):
+    description = "Failed to add user-group to db."
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
+
+
 class UserGroup_DELETE_RequestSchema(BaseRequestSchemaAPI):
     body = colander.MappingSchema(default={})
 
@@ -1860,6 +1890,7 @@ class UserResources_GET_QuerySchema(QueryRequestSchemaAPI):
 
 
 class UserResources_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = User_RequestPathSchema()
     querystring = UserResources_GET_QuerySchema()
 
 
@@ -1904,6 +1935,7 @@ class UserResourcePermissions_GET_QuerySchema(QueryRequestSchemaAPI):
 
 
 class UserResourcePermissions_GET_RequestSchema(BaseRequestSchemaAPI):
+    path = UserResource_RequestPathSchema()
     querystring = UserResourcePermissions_GET_QuerySchema()
 
 

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -1,10 +1,13 @@
 import math
 from typing import TYPE_CHECKING
 
+import datetime
 import sqlalchemy as sa
+import uuid
 from pyramid.httpexceptions import HTTPInternalServerError
 from pyramid.security import ALL_PERMISSIONS, Allow, Authenticated, Everyone
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from ziggurat_foundations import ziggurat_model_init
 from ziggurat_foundations.models.base import BaseModel, get_db_session
@@ -24,13 +27,17 @@ from ziggurat_foundations.models.user_permission import UserPermissionMixin
 from ziggurat_foundations.models.user_resource_permission import UserResourcePermissionMixin
 from ziggurat_foundations.permissions import permission_to_pyramid_acls
 
-from magpie.api.exception import evaluate_call
+from magpie.api import exception as ax
+from magpie.api import schemas as s
 from magpie.constants import get_constant
 from magpie.permissions import Permission
+from magpie.utils import get_magpie_url
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Dict, Type
+    from typing import Dict, Optional, Type, Union
+
+    from sqlalchemy.orm.session import Session
 
     from magpie.typedefs import AccessControlListType, GroupPriority, Str
 
@@ -414,6 +421,37 @@ class RemoteResourceTreeServicePostgresSQL(ResourceTreeServicePostgreSQL):
     """
 
 
+class TemporaryToken(BaseModel, Base):
+    """
+    Model that defines a token for temporary URL completion of a given pending operation.
+    """
+    __tablename__ = "tmp_tokens"
+
+    token = sa.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, unique=True)
+    operation = sa.Column(sa.Unicode(32), nullable=False)
+    created = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
+
+    user_id = sa.Column(sa.Integer,
+                        sa.ForeignKey("users.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=True)
+    user = relationship("User", foreign_keys=[user_id])
+    group_id = sa.Column(sa.Integer(),
+                         sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=True)
+    group = relationship("Group", foreign_keys=[group_id])
+
+    def url(self, settings=None):
+        return get_magpie_url(settings) + s.TemporaryUrlAPI.path.format(token=self.token)
+
+    def expired(self):
+        expire = get_constant("MAGPIE_TOKEN_EXPIRE", raise_missing=False, raise_not_set=False, default_value=86400)
+        return (datetime.datetime.utcnow() - self.created) <= datetime.timedelta(seconds=expire)
+
+    @staticmethod
+    def by_token(token, db_session=None):
+        # type: (Union[Str, UUID], Optional[Session]) -> Optional[TemporaryToken]
+        db_session = get_db_session(db_session)
+        return db_session.query(TemporaryToken).filter(TemporaryToken.token == token).first()
+
+
 ziggurat_model_init(User, Group, UserGroup, GroupPermission, UserPermission,
                     UserResourcePermission, GroupResourcePermission, Resource,
                     ExternalIdentity, passwordmanager=None)
@@ -429,13 +467,13 @@ for res in [Service, Directory, File, Workspace, Route, Process]:
 
 
 def resource_factory(**kwargs):
-    resource_type = evaluate_call(lambda: kwargs["resource_type"], http_error=HTTPInternalServerError,
-                                  msg_on_fail="kwargs do not contain required 'resource_type'",
-                                  content={"kwargs": repr(kwargs)})
-    return evaluate_call(lambda: RESOURCE_TYPE_DICT[resource_type](**kwargs),  # noqa
-                         http_error=HTTPInternalServerError,
-                         msg_on_fail="kwargs unpacking failed from specified 'resource_type' and 'RESOURCE_TYPE_DICT'",
-                         content={"kwargs": repr(kwargs), "RESOURCE_TYPE_DICT": repr(RESOURCE_TYPE_DICT)})
+    resource_type = ax.evaluate_call(lambda: kwargs["resource_type"], http_error=HTTPInternalServerError,
+                                     msg_on_fail="kwargs do not contain required 'resource_type'",
+                                     content={"kwargs": repr(kwargs)})
+    msg = "kwargs unpacking failed from specified 'resource_type' and 'RESOURCE_TYPE_DICT'"
+    return ax.evaluate_call(lambda: RESOURCE_TYPE_DICT[resource_type](**kwargs),  # noqa
+                            http_error=HTTPInternalServerError, msg_on_fail=msg,
+                            content={"kwargs": repr(kwargs), "RESOURCE_TYPE_DICT": repr(RESOURCE_TYPE_DICT)})
 
 
 def find_children_by_name(child_name, parent_id, db_session):

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -28,7 +28,6 @@ from ziggurat_foundations.models.user_resource_permission import UserResourcePer
 from ziggurat_foundations.permissions import permission_to_pyramid_acls
 
 from magpie.api import exception as ax
-from magpie.api import schemas as s
 from magpie.constants import get_constant
 from magpie.permissions import Permission
 from magpie.utils import get_magpie_url
@@ -439,6 +438,7 @@ class TemporaryToken(BaseModel, Base):
     group = relationship("Group", foreign_keys=[group_id])
 
     def url(self, settings=None):
+        from magpie.api import schemas as s
         return get_magpie_url(settings) + s.TemporaryUrlAPI.path.format(token=self.token)
 
     def expired(self):

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -198,7 +198,6 @@ class PermissionSet(object):
 
                 # not equivalent to raw sorting
                 list(sorted(permission_strings))
-
         """
         if not isinstance(other, PermissionSet):
             other = PermissionSet(other)

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -18,7 +18,6 @@ from magpie.owsrequest import ows_parser_factory
 from magpie.permissions import (
     PERMISSION_REASON_ADMIN,
     PERMISSION_REASON_DEFAULT,
-    PERMISSION_REASON_MULTIPLE,
     Access,
     Permission,
     PermissionSet,
@@ -28,7 +27,7 @@ from magpie.permissions import (
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Collection, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
+    from typing import Collection, Dict, List, Optional, Set, Tuple, Type, Union
 
     from pyramid.request import Request
     from ziggurat_foundations.permissions import PermissionTuple  # noqa
@@ -306,7 +305,7 @@ class ServiceInterface(object):
             for perm_name in requested_perms:
                 if full_break:
                     break
-                for i, perm_tup in enumerate(cur_res_perms):
+                for perm_tup in cur_res_perms:
                     perm_set = PermissionSet(perm_tup)
 
                     # if user is owner (directly or via groups), all permissions are set,
@@ -328,7 +327,7 @@ class ServiceInterface(object):
                         full_break = True
                         break
                     # skip if the current permission must not be processed (at all or for the moment until next 'name')
-                    elif perm_set.name not in requested_perms or perm_set.name != perm_name:
+                    if perm_set.name not in requested_perms or perm_set.name != perm_name:
                         continue
                     # only first resource can use match (if even enabled with found one), parents are recursive-only
                     if not allow_match and perm_set.scope == Scope.MATCH:
@@ -347,7 +346,7 @@ class ServiceInterface(object):
                         # - reset resolution scope of previous permission attributed to group as it takes precedence
                         # - since there can't be more than one user permission-name per resource on a given level,
                         #   scope resolution is done after applying this *closest* permission, ignore higher level ones
-                        if prev_perm.type == PermissionType.INHERITED or not scope_level:  #######################perm_set.access == Access.DENY:
+                        if prev_perm.type == PermissionType.INHERITED or not scope_level:
                             effective_perms[perm_name] = perm_set
                             effective_level[perm_name] = current_level
                         continue  # final decision for this user, skip any group permissions
@@ -355,7 +354,7 @@ class ServiceInterface(object):
                     # resolve prioritized permission according to ALLOW/DENY, scope and group priority
                     # (see 'PermissionSet.resolve' method for extensive details)
                     # skip if last permission is not on group to avoid redundant USER > GROUP check processed before
-                    elif prev_perm.type == PermissionType.INHERITED:
+                    if prev_perm.type == PermissionType.INHERITED:
                         # - If new permission to process is done against the previous permission from *same* tree-level,
                         #   there is a possibility to combine equal priority groups. In such case, reason is 'MULTIPLE'.
                         # - If not of equal priority, the appropriate permission is selected and reason is overridden

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2061,8 +2061,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
     @runner.MAGPIE_TEST_FUNCTIONAL
     def test_GetUserResourcePermissions_MultipleGroupPermissions(self):
         """
-        Validate the merging strategy that produces ``inherited``, ``resolved`` and ``effective`` permissions with
-        query parameters considering user is member of *multiple groups* which each can have conflicting permission
+        Validate the merging strategy that produces ``inherited``, ``resolved`` and ``effective`` permissions with query
+        parameters considering user is member of *multiple groups* which each can have conflicting permission
         specifications on a corresponding resource.
 
         .. seealso::
@@ -2272,8 +2272,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
     @runner.MAGPIE_TEST_FUNCTIONAL
     def test_GetUserResourcePermissions_PermissionsHierarchyResolution(self):
         """
-        Extensive test validating combined resolution against user, *normal* group, and *special* group  priorities,
-        and considering that each combination has multi-level permission defined to resolve inheritance, as well as
+        Extensive test validating combined resolution against user, *normal* group, and *special* group  priorities, and
+        considering that each combination has multi-level permission defined to resolve inheritance, as well as
         Allow/Deny modifiers permutations applied on different level in the resources hierarchy.
 
         The hierarchy is defined for each case as::
@@ -2326,7 +2326,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         # order is not really important for actual test, but they are somewhat placed by least to more specific,
         # and by least to more restrictive, for 1st/2nd resource, to help lookup during debug in case of problem
         combinations = [
-            # pylint: disable=E501
+            # pylint: disable=C0301
             #                +------------------------------------------------+-------------+ matching single-entry
             #                |                                                |             | (inherited/resolved)
             #      +---------c------+-------------+ matching single-entry     |             |
@@ -2334,15 +2334,15 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
             #      v         v      v             v                           v             v
             #  items to create  |     expected permissions on service     |     expected permissions on resource    |  test
             #  (applied perms)  | inherited     resolved      effective   | inherited     resolved      effective   |  case
-            (a_n, p_A, a_n, p_A, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)]),  #  1
-            (a_n, p_A, a_n, p_D, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)]),  #  2
-            (a_n, p_D, a_n, p_A, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)]),  #  3
-            (a_n, p_D, a_n, p_D, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)]),  #  4
-            (a_n, p_A, g_n, p_A, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, g_r)], [(p_A, g_r)], [(p_A, g_r)]),  #  5
-            (a_n, p_A, g_n, p_D, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_D, g_r)], [(p_D, g_r)], [(p_D, g_r)]),  #  6
-            (a_n, p_D, g_n, p_A, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_A, g_r)], [(p_A, g_r)], [(p_A, g_r)]),  #  7
-            (a_n, p_D, g_n, p_D, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, g_r)], [(p_D, g_r)], [(p_D, g_r)]),  #  8
-            (a_n, p_A, u_n, p_A, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, u_r)], [(p_A, u_r)], [(p_A, u_r)]),  #  9
+            (a_n, p_A, a_n, p_A, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)]),  # 01
+            (a_n, p_A, a_n, p_D, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)]),  # 02
+            (a_n, p_D, a_n, p_A, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)]),  # 03
+            (a_n, p_D, a_n, p_D, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)]),  # 04
+            (a_n, p_A, g_n, p_A, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, g_r)], [(p_A, g_r)], [(p_A, g_r)]),  # 05
+            (a_n, p_A, g_n, p_D, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_D, g_r)], [(p_D, g_r)], [(p_D, g_r)]),  # 06
+            (a_n, p_D, g_n, p_A, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_A, g_r)], [(p_A, g_r)], [(p_A, g_r)]),  # 07
+            (a_n, p_D, g_n, p_D, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, g_r)], [(p_D, g_r)], [(p_D, g_r)]),  # 08
+            (a_n, p_A, u_n, p_A, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_A, u_r)], [(p_A, u_r)], [(p_A, u_r)]),  # 09
             (a_n, p_A, u_n, p_D, [(p_A, a_r)], [(p_A, a_r)], [(p_A, a_r)], [(p_D, u_r)], [(p_D, u_r)], [(p_D, u_r)]),  # 10
             (a_n, p_D, u_n, p_A, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_A, u_r)], [(p_A, u_r)], [(p_A, u_r)]),  # 11
             (a_n, p_D, u_n, p_D, [(p_D, a_r)], [(p_D, a_r)], [(p_D, a_r)], [(p_D, u_r)], [(p_D, u_r)], [(p_D, u_r)]),  # 12
@@ -2535,8 +2535,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
     @runner.MAGPIE_TEST_FUNCTIONAL
     def test_GetUserResourcePermissions_EffectivePermissions_MatchWithinRecursiveResolution(self):
         """
-        Validates that :term:`Effective Resolution` works when :term:`Permission` with :attr:`Scope.MATCH` is defined
-        *within* a scope where a :term:`Permission` with :attr:`Scope.RECURSIVE` exists
+        Validates resolution of :term:`Effective Resolution` works when :term:`Permission` with :attr:`Scope.MATCH` is
+        defined *within* a scope where a :term:`Permission` with :attr:`Scope.RECURSIVE` exists
 
         Legend::
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1342,6 +1342,7 @@ class TestSetup(object):
                                    ):                               # type: (...) -> JSON
         """
         Creates a two-level tree with the test resource nested *immediately* under the test service.
+
         Test service gets created if it did not exist beforehand, but its information are not returned.
 
         .. seealso::


### PR DESCRIPTION
* adds tmp URL endpoint to receive token and attempt resolution of the appropriate `TokenOperation`.
* adds a table of `TemporaryToken` for pending operations mapped to tmp URL endpoint to "complete" it
* adds basic setup of "terms and conditions" validation via tmp URL (relates to [DAC-119](https://www.crim.ca/jira/browse/DAC-119))
  still requires: 
  - actual T&C field in group and corresponding API & UI group create updates
  - email with rendered T&C and embedded accept tmp-URL
* adds basic setup of "password reset" operation
  still requires:
  - actual handling to complete reset procedure (see [DAC-117](https://www.crim.ca/jira/browse/DAC-117)) 
  - sending emails for various use cases and handling responses from endpoints formatted within these emails

* includes also minor fixes of path parameter generation in OpenAPI schemas
