### PR TITLE
bump twitcher 0.5.4 -> 0.5.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bug Fixes
 * Fix rendering of path parameter details within OpenAPI schemas.
 * Fix ``alembic`` migration failing due to new version updates of package
   (see `diff 1.4.3 => 1.5.2 <https://github.com/sqlalchemy/alembic/compare/rel_1_4_3..rel_1_5_2>`_).
+* Bump version of ``Twitcher`` to ``v0.5.5`` to obtain its Docker dependency fixes
+  (see PR `bird-house/twitcher#99 <https://github.com/bird-house/twitcher/pull/99>`_).
 
 `3.5.0 <https://github.com/Ouranosinc/Magpie/tree/3.5.0>`_ (2021-01-06)
 ------------------------------------------------------------------------------------

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -3,7 +3,7 @@
 #   docker run will need to override ini file with mounted volume
 #   using config 'twitcher.adapter = magpie.adapter.MagpieAdapter'
 #
-FROM birdhouse/twitcher:v0.5.4
+FROM birdhouse/twitcher:v0.5.5
 LABEL Description="Configures MagpieAdapter on top of Twitcher application."
 LABEL Maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL Vendor="CRIM"


### PR DESCRIPTION
include fix of incorrect `python3-dev` from Twitcher's docker employed for the adapter image
https://github.com/bird-house/twitcher/pull/99