### PR TITLE
Finish the missing tmp_url part for the webhooks

### DIFF
--- a/magpie/api/management/register/register_utils.py
+++ b/magpie/api/management/register/register_utils.py
@@ -24,7 +24,7 @@ class TokenOperation(ExtendedEnum):
     """
     GROUP_ACCEPT_TERMS = "group-accept-terms"
     USER_PASSWORD_RESET = "user-password-reset"  # nosec: B105
-    WEBHOOK_ERROR = "webhook-error"
+    WEBHOOK_CREATE_USER_ERROR = "webhook-create-user-error"
 
 
 def handle_temporary_token(tmp_token, db_session):
@@ -49,7 +49,7 @@ def handle_temporary_token(tmp_token, db_session):
                         http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
         # TODO: reset procedure
         ax.raise_http(HTTPNotImplemented, detail="Not Implemented")
-    if tmp_token.operation == TokenOperation.WEBHOOK_ERROR.value:
+    if tmp_token.operation == TokenOperation.WEBHOOK_CREATE_USER_ERROR.value:
         ax.verify_param(tmp_token.user, not_none=True,
                         http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
         webhook_update_error_status(tmp_token.user.user_name)

--- a/magpie/api/management/register/register_utils.py
+++ b/magpie/api/management/register/register_utils.py
@@ -7,6 +7,7 @@ from magpie.api import exception as ax
 from magpie.api import schemas as s
 from magpie.api.management.user import user_utils as uu
 from magpie import models
+from magpie.api.webhooks import webhook_update_error_status
 from magpie.utils import CONTENT_TYPE_JSON, ExtendedEnum
 
 if TYPE_CHECKING:
@@ -23,6 +24,7 @@ class TokenOperation(ExtendedEnum):
     """
     GROUP_ACCEPT_TERMS = "group-accept-terms"
     USER_PASSWORD_RESET = "user-password-reset"  # nosec: B105
+    WEBHOOK_ERROR = "webhook-error"
 
 
 def handle_temporary_token(tmp_token, db_session):
@@ -36,17 +38,21 @@ def handle_temporary_token(tmp_token, db_session):
         ax.raise_http(HTTPGone, content={"token": str_token}, detail=s.TemporaryURL_GET_GoneResponseSchema.description)
     ax.verify_param(tmp_token.operation, is_in=True, param_compare=TokenOperation.values(),
                     param_name="token", http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
-    if tmp_token.operation == TokenOperation.GROUP_ACCEPT_TERMS:
+    if tmp_token.operation == TokenOperation.GROUP_ACCEPT_TERMS.value:
         ax.verify_param(tmp_token.group, not_none=True,
                         http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
         ax.verify_param(tmp_token.user, not_none=True,
                         http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
         uu.assign_user_group(tmp_token.user, tmp_token.group, db_session)
-    if tmp_token.operation == TokenOperation.USER_PASSWORD_RESET:
+    if tmp_token.operation == TokenOperation.USER_PASSWORD_RESET.value:
         ax.verify_param(tmp_token.user, not_none=True,
                         http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
         # TODO: reset procedure
         ax.raise_http(HTTPNotImplemented, detail="Not Implemented")
+    if tmp_token.operation == TokenOperation.WEBHOOK_ERROR.value:
+        ax.verify_param(tmp_token.user, not_none=True,
+                        http_error=HTTPInternalServerError, msg_on_fail="Invalid token.")
+        webhook_update_error_status(tmp_token.user.user_name)
     db_session.delete(tmp_token)
 
 

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -135,7 +135,7 @@ def create_user(user_name, password, email, group_name, db_session):
     # Force commit before sending the webhook requests, so that the user's status is editable if a webhook error occurs
     transaction.commit()
 
-    process_webhook_requests(WebhookAction.WEBHOOK_CREATE_USER_ACTION,
+    process_webhook_requests(WebhookAction.CREATE_USER,
                              {"user_name": user_name, "tmp_url": tmp_url}, True)
 
     return ax.valid_http(http_success=HTTPCreated, detail=s.Users_POST_CreatedResponseSchema.description,

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -24,7 +24,7 @@ from magpie.api.management.register.register_utils import TokenOperation
 from magpie.api.management.resource import resource_utils as ru
 from magpie.api.management.service.service_formats import format_service
 from magpie.api.management.user import user_formats as uf
-from magpie.api.webhooks import process_webhook_requests, WEBHOOK_CREATE_USER_ACTION
+from magpie.api.webhooks import process_webhook_requests, WebhookAction
 from magpie.constants import get_constant
 from magpie.permissions import PermissionSet, PermissionType, format_permissions
 from magpie.services import service_factory
@@ -135,7 +135,8 @@ def create_user(user_name, password, email, group_name, db_session):
     # Force commit before sending the webhook requests, so that the user's status is editable if a webhook error occurs
     transaction.commit()
 
-    process_webhook_requests(WEBHOOK_CREATE_USER_ACTION, {"user_name": user_name, "tmp_url": tmp_url}, True)
+    process_webhook_requests(WebhookAction.WEBHOOK_CREATE_USER_ACTION,
+                             {"user_name": user_name, "tmp_url": tmp_url}, True)
 
     return ax.valid_http(http_success=HTTPCreated, detail=s.Users_POST_CreatedResponseSchema.description,
                          content={"user": user_content})

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -125,7 +125,7 @@ def create_user(user_name, password, email, group_name, db_session):
     token_id = uuid.uuid4()
     webhook_token = models.TemporaryToken(
         token=token_id,
-        operation=TokenOperation.WEBHOOK_ERROR.value,
+        operation=TokenOperation.WEBHOOK_CREATE_USER_ERROR.value,
         user_id=new_user.id,
         group_id=_get_group(group_name).id)
     ax.evaluate_call(lambda: db_session.add(webhook_token), fallback=lambda: db_session.rollback(),

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -140,7 +140,7 @@ def delete_user_view(request):
                      http_error=HTTPForbidden, msg_on_fail=s.User_DELETE_ForbiddenResponseSchema.description)
 
     # Process any webhook requests
-    process_webhook_requests(WebhookAction.WEBHOOK_DELETE_USER_ACTION,
+    process_webhook_requests(WebhookAction.DELETE_USER,
                              {"user_name": user.user_name})
 
     return ax.valid_http(http_success=HTTPOk, detail=s.User_DELETE_OkResponseSchema.description)

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -16,7 +16,7 @@ from magpie.api import schemas as s
 from magpie.api.management.service.service_formats import format_service_resources
 from magpie.api.management.user import user_formats as uf
 from magpie.api.management.user import user_utils as uu
-from magpie.api.webhooks import process_webhook_requests, WEBHOOK_DELETE_USER_ACTION
+from magpie.api.webhooks import process_webhook_requests, WebhookAction
 from magpie.constants import MAGPIE_CONTEXT_PERMISSION, MAGPIE_LOGGED_PERMISSION, get_constant
 from magpie.permissions import PermissionType, format_permissions
 from magpie.services import SERVICE_TYPE_DICT
@@ -140,7 +140,8 @@ def delete_user_view(request):
                      http_error=HTTPForbidden, msg_on_fail=s.User_DELETE_ForbiddenResponseSchema.description)
 
     # Process any webhook requests
-    process_webhook_requests(WEBHOOK_DELETE_USER_ACTION, {"user_name": user.user_name})
+    process_webhook_requests(WebhookAction.WEBHOOK_DELETE_USER_ACTION,
+                             {"user_name": user.user_name})
 
     return ax.valid_http(http_success=HTTPOk, detail=s.User_DELETE_OkResponseSchema.description)
 

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -2745,6 +2745,11 @@ class TemporaryURL_GET_GoneResponseSchema(BaseResponseSchemaAPI):
     body = BaseResponseBodySchema(code=HTTPGone.code, description=description)
 
 
+class TemporaryToken_POST_ForbiddenResponseSchema(BaseResponseSchemaAPI):
+    description = "Failed to add token to db."
+    body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
+
+
 class Session_GET_ResponseBodySchema(BaseResponseBodySchema):
     user = UserBodySchema(missing=colander.drop)
     authenticated = colander.SchemaNode(

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -31,8 +31,8 @@ class WebhookAction(ExtendedEnum):
     """
     Actions supported by webhooks.
     """
-    WEBHOOK_CREATE_USER_ACTION = "create_user"
-    WEBHOOK_DELETE_USER_ACTION = "delete_user"
+    CREATE_USER = "create_user"
+    DELETE_USER = "delete_user"
 
 
 def process_webhook_requests(action, params, update_user_status_on_error=False):

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -8,7 +8,7 @@ from magpie.api.schemas import UserWebhookErrorStatus
 from magpie.constants import MAGPIE_INI_FILE_PATH
 from magpie.db import get_db_session_from_config_ini
 from magpie import models
-from magpie.utils import get_logger, get_settings
+from magpie.utils import get_logger, get_settings, ExtendedEnum
 
 # List of keys that should be found for a single webhook item in the config
 WEBHOOK_KEYS = {
@@ -19,20 +19,20 @@ WEBHOOK_KEYS = {
     "payload"
 }
 
-# List of possible actions associated with a webhook
-WEBHOOK_CREATE_USER_ACTION = "create_user"
-WEBHOOK_DELETE_USER_ACTION = "delete_user"
-WEBHOOK_ACTIONS = [
-    WEBHOOK_CREATE_USER_ACTION,
-    WEBHOOK_DELETE_USER_ACTION
-]
-
 # These are the parameters permitted to use the template form in the webhook payload.
 WEBHOOK_TEMPLATE_PARAMS = ["user_name", "tmp_url"]
 
 HTTP_METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"]
 
 LOGGER = get_logger(__name__)
+
+
+class WebhookAction(ExtendedEnum):
+    """
+    Actions supported by webhooks
+    """
+    WEBHOOK_CREATE_USER_ACTION = "create_user"
+    WEBHOOK_DELETE_USER_ACTION = "delete_user"
 
 
 def process_webhook_requests(action, params, update_user_status_on_error=False):
@@ -45,7 +45,7 @@ def process_webhook_requests(action, params, update_user_status_on_error=False):
     :param update_user_status_on_error: update the user status or not in case of a webhook error
     """
     # Check for webhook requests
-    webhooks = get_settings(get_current_registry())["webhooks"][action]
+    webhooks = get_settings(get_current_registry())["webhooks"][action.value]
     if len(webhooks) > 0:
         # Execute all webhook requests
         pool = multiprocessing.Pool(processes=len(webhooks))

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -29,7 +29,7 @@ LOGGER = get_logger(__name__)
 
 class WebhookAction(ExtendedEnum):
     """
-    Actions supported by webhooks
+    Actions supported by webhooks.
     """
     WEBHOOK_CREATE_USER_ACTION = "create_user"
     WEBHOOK_DELETE_USER_ACTION = "delete_user"

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from pyramid.settings import asbool
 from pyramid_beaker import set_cache_regions_from_settings
 
-from magpie.api.webhooks import HTTP_METHODS, WEBHOOK_ACTIONS, WEBHOOK_KEYS
+from magpie.api.webhooks import HTTP_METHODS, WebhookAction, WEBHOOK_KEYS
 from magpie.cli.register_defaults import register_defaults
 from magpie.constants import get_constant
 from magpie.db import get_db_session_from_config_ini, run_database_migration_when_ready, set_sqlalchemy_log_level
@@ -89,7 +89,7 @@ def main(global_config=None, **settings):  # noqa: F811
                 if webhook.keys() != WEBHOOK_KEYS:
                     raise ValueError("Missing or invalid key found in a webhook config " +
                                      "from the config file {}".format(combined_config))
-                if webhook["action"] not in WEBHOOK_ACTIONS:
+                if webhook["action"] not in WebhookAction.values():
                     raise ValueError("Invalid action {} found in a webhook config ".format(webhook["action"]) +
                                      "from the config file {}".format(combined_config))
                 if webhook["method"] not in HTTP_METHODS:

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -5,7 +5,7 @@
 Magpie is a service for AuthN and AuthZ based on Ziggurat-Foundations.
 """
 from collections import defaultdict
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 
 from pyramid.settings import asbool
 from pyramid_beaker import set_cache_regions_from_settings

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -443,7 +443,7 @@ class TemporaryToken(BaseModel, Base):
 
     def expired(self):
         expire = get_constant("MAGPIE_TOKEN_EXPIRE", raise_missing=False, raise_not_set=False, default_value=86400)
-        return (datetime.datetime.utcnow() - self.created) <= datetime.timedelta(seconds=expire)
+        return (datetime.datetime.utcnow() - self.created) > datetime.timedelta(seconds=expire)
 
     @staticmethod
     def by_token(token, db_session=None):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -98,14 +98,14 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
+                    "action": WebhookAction.CREATE_USER.value,
                     "method": "POST",
                     "url": create_webhook_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}
                 },
                 {
                     "name": "test_webhook_2",
-                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
+                    "action": WebhookAction.CREATE_USER.value,
                     "method": "POST",
                     "url": create_webhook_url,
                     # Test with a more complex payload, that includes different types and nested arrays / dicts
@@ -190,7 +190,7 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
+                    "action": WebhookAction.CREATE_USER.value,
                     "method": "POST",
                     "url": webhook_fail_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}
@@ -238,7 +238,7 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
+                    "action": WebhookAction.CREATE_USER.value,
                     "method": "POST",
                     "url": webhook_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}
@@ -276,14 +276,14 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WebhookAction.WEBHOOK_DELETE_USER_ACTION.value,
+                    "action": WebhookAction.DELETE_USER.value,
                     "method": "POST",
                     "url": delete_webhook_url,
                     "payload": {"user_name": "{user_name}"}
                 },
                 {
                     "name": "test_webhook_2",
-                    "action": WebhookAction.WEBHOOK_DELETE_USER_ACTION.value,
+                    "action": WebhookAction.DELETE_USER.value,
                     "method": "POST",
                     "url": delete_webhook_url,
                     "payload": {"user_name": "{user_name}"}
@@ -367,7 +367,7 @@ class TestFailingWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook_app",
-                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
+                    "action": WebhookAction.CREATE_USER.value,
                     "method": "POST",
                     "url": create_webhook_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -17,7 +17,7 @@ import yaml
 import requests
 
 from magpie.api.schemas import UserOKStatus, UserWebhookErrorStatus
-from magpie.api.webhooks import WEBHOOK_CREATE_USER_ACTION, WEBHOOK_DELETE_USER_ACTION
+from magpie.api.webhooks import WebhookAction
 from magpie.constants import get_constant
 from magpie.utils import CONTENT_TYPE_JSON, CONTENT_TYPE_HTML
 from tests import runner, utils
@@ -98,14 +98,14 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WEBHOOK_CREATE_USER_ACTION,
+                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
                     "method": "POST",
                     "url": create_webhook_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}
                 },
                 {
                     "name": "test_webhook_2",
-                    "action": WEBHOOK_CREATE_USER_ACTION,
+                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
                     "method": "POST",
                     "url": create_webhook_url,
                     # Test with a more complex payload, that includes different types and nested arrays / dicts
@@ -190,7 +190,7 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WEBHOOK_CREATE_USER_ACTION,
+                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
                     "method": "POST",
                     "url": webhook_fail_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}
@@ -238,7 +238,7 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WEBHOOK_CREATE_USER_ACTION,
+                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
                     "method": "POST",
                     "url": webhook_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}
@@ -276,14 +276,14 @@ class TestWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook",
-                    "action": WEBHOOK_DELETE_USER_ACTION,
+                    "action": WebhookAction.WEBHOOK_DELETE_USER_ACTION.value,
                     "method": "POST",
                     "url": delete_webhook_url,
                     "payload": {"user_name": "{user_name}"}
                 },
                 {
                     "name": "test_webhook_2",
-                    "action": WEBHOOK_DELETE_USER_ACTION,
+                    "action": WebhookAction.WEBHOOK_DELETE_USER_ACTION.value,
                     "method": "POST",
                     "url": delete_webhook_url,
                     "payload": {"user_name": "{user_name}"}
@@ -367,7 +367,7 @@ class TestFailingWebhooks(unittest.TestCase):
             "webhooks": [
                 {
                     "name": "test_webhook_app",
-                    "action": WEBHOOK_CREATE_USER_ACTION,
+                    "action": WebhookAction.WEBHOOK_CREATE_USER_ACTION.value,
                     "method": "POST",
                     "url": create_webhook_url,
                     "payload": {"user_name": "{user_name}", "tmp_url": "{tmp_url}"}

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -10,7 +10,7 @@ Tests for the webhooks implementation
 import tempfile
 import unittest
 from time import sleep
-from urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse
 
 import yaml
 
@@ -222,7 +222,7 @@ class TestWebhooks(unittest.TestCase):
 
             # Retrieve the tmp_url and send the request to the magpie app
             resp = requests.get(BASE_WEBHOOK_URL + "/get_tmp_url")
-            assert resp.text
+            utils.check_response_basic_info(resp, 200, expected_method="GET", expected_type=CONTENT_TYPE_HTML)
             utils.test_request(self, "GET", urlparse(resp.text).path)
 
             # Check if the user's status is set to 0

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -10,6 +10,8 @@ Tests for the webhooks implementation
 import tempfile
 import unittest
 from time import sleep
+from urllib.parse import urlparse
+
 import yaml
 
 import requests
@@ -176,8 +178,6 @@ class TestWebhooks(unittest.TestCase):
             utils.check_val_is_in(self.test_user_name, users, msg="Test user should exist.")
             self.checkTestUserStatus(UserOKStatus)
 
-    # Skip this test, until tmp_url is implemented
-    @unittest.skip("implement tmp_url")
     def test_Webhook_CreateUser_FailingWebhook(self):
         """
         Test creating a user where the webhook receives an internal error.
@@ -216,6 +216,14 @@ class TestWebhooks(unittest.TestCase):
             # Check if user creation was successful even if the webhook resulted in failure
             users = utils.TestSetup.get_RegisteredUsersList(self)
             utils.check_val_is_in(self.test_user_name, users, msg="Test user should exist.")
+
+            # Check if the user's status is still set to 1, since the tmp_url has not been called yet
+            self.checkTestUserStatus(UserOKStatus)
+
+            # Retrieve the tmp_url and send the request to the magpie app
+            resp = requests.get(BASE_WEBHOOK_URL + "/get_tmp_url")
+            assert resp.text
+            utils.test_request(self, "GET", urlparse(resp.text).path)
 
             # Check if the user's status is set to 0
             self.checkTestUserStatus(UserWebhookErrorStatus)


### PR DESCRIPTION
I completed the missing part for the tmp_url with Francis' new code, and completed the FailingWebhook test case.

Note that I couldn't call the tmp_url directly from the webhook app, or at least, it would have been complicated, so instead, I just save the tmp_url value in the webhook_app, and retrieve it from the test case where I have easy access to the local Magpie app to call the tmp_url. I think this is fine as it still tests the tmp_url feature and tests the validity of the TemporaryToken id.

Let me know what you guys think!