### PR TITLE
Adapter cache service

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -70,6 +70,7 @@ disable=C0111,missing-docstring,
         E0401,import-error,
         R0201,no-self-use
         R0205,useless-object-inheritance,
+        R0801,duplicate-code,
         R0904,too-many-public-methods,
         R0912,too-many-branches,
         R0914,too-many-locals,
@@ -77,6 +78,7 @@ disable=C0111,missing-docstring,
         R1710,inconsistent-return-statements,
         R1721,unnecessary-comprehension,
         R1725,super-with-arguments,
+        R1729,use-a-generator,
         W0108,unnecessary-lambda,
         W0143,comparison-with-callable,
         W0232,no-init,
@@ -228,7 +230,7 @@ dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.
-init-import=no
+init-import=yes
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
@@ -437,10 +439,10 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=10
 
 
 [CLASSES]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Features / Changes
 * Apply cache invalidation when it can be resolved upon changes to instances that should be reflected immediately.
 * Update performance docs and INI related to caching.
 
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix broken link to remote authentication provider in documentation.
+
 `3.6.0 <https://github.com/Ouranosinc/Magpie/tree/3.6.0>`_ (2021-02-09)
 ------------------------------------------------------------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,12 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Introduce caching of ``Service`` definitions using ``beaker``, which can be use in conjunction with ``ACL`` caching
+  to improve performance of `Twitcher` requests.
+* Apply cache invalidation when it can be resolved upon changes to instances that should be reflected immediately.
+* Update performance docs and INI related to caching.
 
 `3.6.0 <https://github.com/Ouranosinc/Magpie/tree/3.6.0>`_ (2021-02-09)
 ------------------------------------------------------------------------------------

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -29,16 +29,20 @@ pyramid.includes =
 magpie.port = 2001
 magpie.url = http://localhost:2001
 magpie.max_restart = 5
-# This secret should be the same in Twitcher !
+# WARNING:
+#   Secret should be the same in Twitcher INI
+#   Otherwise, they cannot resolve same user references
 magpie.secret =
 magpie.push_phoenix = true
 # magpie.config_path =
 
 # caching settings refer to the Performance section in the documentation
-cache.regions = adapter, acl
+# WARNING:
+#   Caching settings should also be defined in Twitcher INI as it is its application that will
+#   receive most requests and actually ask Magpie to resolve ACL for it to allow/deny proxied service
+cache.regions = acl
 # cache.type = memory
-# cache.adapter.expire = 5
-cache.adapter.enabled = false
+# cache.acl.expire = 30
 cache.acl.enabled = false
 
 # ziggurat

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -39,11 +39,15 @@ magpie.push_phoenix = true
 # caching settings refer to the Performance section in the documentation
 # WARNING:
 #   Caching settings should also be defined in Twitcher INI as it is its application that will
-#   receive most requests and actually ask Magpie to resolve ACL for it to allow/deny proxied service
-cache.regions = acl
-# cache.type = memory
-# cache.acl.expire = 30
+#   receive most requests and actually ask Magpie to resolve ACL/Services for it to allow/deny access
+cache.regions = acl, service
+cache.type = memory
+# controls cache of user effective permission resolution by Access Control Lists
 cache.acl.enabled = false
+# cache.acl.expire = 30
+# controls cache of service retrieval operations
+cache.service.enable = false
+# cache.service.expire = 10
 
 # ziggurat
 ziggurat_foundations.model_locations.User = magpie.models:User

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -5,24 +5,42 @@
 Performance
 *************
 
-Requesting permissions for a specific user and service can be demanding if a lot of
-requests are done rapidly. `PostgreSQL`_ and `SQLAlchemy`_ are usually fast enough, but
+Requesting permissions for a specific :term:`User` and :term:`Service` can be demanding if a lot of
+requests are execute in rapid succession. `PostgreSQL`_ and `SQLAlchemy`_ are usually fast enough, but
 when more than a couple requests per second are needed, some solutions are possible to
-improve the performance of these requests.
+improve the performance of these requests by avoiding unnecessary reload of static data.
 
-We can take advantage of the fact that permission are not susceptible to change often
-and cache the results of these permission queries.
+We can take advantage of the fact that individual :temr:`Permission` and :term:`Service` definitions are not
+susceptible to change often and cache the results of these queries.
 
-While not activated by default, it's possible to cache the access control lists (ACLs)
-for all services, and give it an expiration timeout::
+While not activated by default, it's possible to cache the :term:`Access Control Lists` (ACLs) and :term:`Service`
+retrieval operations for all services, and give it an expiration timeout::
 
   # example Paste Deploy configuration
   cache.regions = acl
   cache.type = memory
   cache.acl.expire = 5  # seconds
 
-For a particular request that queries a user's ACL
-for a specific service, the response will be cached for 5 seconds. The consequence of this
-caching is that any permission change will take 5 seconds to be effective. Depending on the
-use case, this can be perfectly acceptable and the performance improvement is not negligible.
-You should test and profile for your particular environment.
+.. warning::
+    Take into consideration that settings must be applied to `Twitcher`_ INI file such that incoming proxy requests
+    will be effective in its web application, in turn using the :class:`magpie.adapter.MagpieAdapter`. Caching settings
+    defined in `Magpie` INI file will be employed only when requesting :term:`Effective Permissions` resolution using
+    `Magpie`'s API endpoints.
+
+
+In the above example, for a particular request that queries a :term:`Logged User`'s ACL for a specific :term:`Service`,
+the response will be cached for 5 seconds. The consequence of this caching is that any change to that specific
+:term:`Permission` will take 5 seconds to be effective. Depending on the use case, this can be perfectly acceptable
+and the performance improvement is not negligible. You should test and profile for your particular environment.
+
+.. versionadded:: 3.7
+
+    As of this version, additional handling of cache invalidation is introduced in some cases where it can be resolved.
+    For example, calling a :term:`Service` update will invalidate the corresponding caches and should make the next
+    request fetch the real definitions from database instead of cached ones.
+
+.. warning::
+    Take into consideration that caching on `Twitcher`_ side will still not affect `Magpie` side caching as they run on
+    two separate web applications. Therefore, `Twitcher`_ could still indicate a different result than `Magpie` if the
+    :term:`Service` definition was recently updated (cache is invalidated only in `Magpie`), but still not effective
+    from `Twitcher`_ side (proxy requests).

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -22,7 +22,7 @@
 
 .. external providers
 .. _OpenID: https://openid.net/
-.. _ESGF: https://esgf.llnl.gov/
+.. _ESGF: https://esgf-node.llnl.gov
 .. _DKRZ: https://esgf-data.dkrz.de
 .. _IPSL: https://www.ipsl.fr/
 .. _BADC: http://data.ceda.ac.uk/badc

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -64,7 +64,8 @@ class MagpieOWSSecurity(OWSSecurityInterface):
         """
         service = evaluate_call(lambda: Service.by_service_name(service_name, db_session=self.request.db),
                                 http_error=HTTPForbidden, msg_on_fail="Service query by name refused by db.")
-        verify_param(service, not_none=True, http_error=HTTPNotFound, msg_on_fail="Service name not found.")
+        verify_param(service, not_none=True, param_name="service_name",
+                     http_error=HTTPNotFound, msg_on_fail="Service name not found.")
         # return a specific type of service (eg: ServiceWPS with all the ACL loaded according to the service impl.)
         service_impl = service_factory(service, self.request)
         service_data = service.get_appstruct()

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -68,7 +68,7 @@ class MagpieOWSSecurity(OWSSecurityInterface):
                      http_error=HTTPNotFound, msg_on_fail="Service name not found.")
         # return a specific type of service (eg: ServiceWPS with all the ACL loaded according to the service impl.)
         service_impl = service_factory(service, self.request)
-        service_data = service.get_appstruct()
+        service_data = dict(service.get_appstruct())
         return service_impl, service_data
 
     def get_service(self, request):

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -46,7 +46,7 @@ class MagpieOWSSecurity(OWSSecurityInterface):
         self.twitcher_ssl_verify = asbool(self.settings.get("twitcher.ows_proxy_ssl_verify", True))
         self.twitcher_protected_path = self.settings.get("twitcher.ows_proxy_protected_path", "/ows")
 
-    @cache_region("acl")
+    @cache_region("service")
     def _get_service_cached(self, service_name):
         # type: (Str) -> Tuple[ServiceInterface, Dict[str, AnyValue]]
         """
@@ -81,9 +81,9 @@ class MagpieOWSSecurity(OWSSecurityInterface):
 
         # make sure the cache is invalidated to retrieve 'fresh' service from database if requested or cache disabled
         self.request = request
-        if "acl" not in cache_regions:
-            cache_regions["acl"] = {"enabled": False}
         service_name = parse_service_name(request.path, self.twitcher_protected_path)
+        if "service" not in cache_regions:
+            cache_regions["service"] = {"enabled": False}
         if self.request.headers.get("Cache-Control") == "no-cache":
             invalidate_service(service_name)
 

--- a/magpie/adapter/magpieservice.py
+++ b/magpie/adapter/magpieservice.py
@@ -4,6 +4,7 @@ Store adapters to read data from magpie.
 from typing import TYPE_CHECKING
 
 import requests
+from beaker.cache import cache_region
 from pyramid.httpexceptions import HTTPOk
 from pyramid.settings import asbool
 
@@ -15,12 +16,14 @@ from magpie.utils import CONTENT_TYPE_JSON, get_admin_cookies, get_logger, get_m
 #   Twitcher available only when this module is imported from it.
 #   It is installed during tests for evaluation.
 #   Module 'magpie.adapter' should not be imported from 'magpie' package.
-from twitcher.datatype import Service  # noqa
+from twitcher.datatype import Service as TwithcerService  # noqa
 from twitcher.exceptions import ServiceNotFound  # noqa
 from twitcher.store import ServiceStoreInterface  # noqa
 
 if TYPE_CHECKING:
     from pyramid.request import Request
+
+    from magpie.typedefs import Str
 
 LOGGER = get_logger("TWITCHER")
 
@@ -68,14 +71,49 @@ class MagpieServiceStore(ServiceStoreInterface):
         json_body = resp.json()
         for service_type in json_body["services"]:
             for service in json_body["services"][service_type].values():
-                services.append(Service(url=service["service_url"],
-                                        name=service["service_name"],
-                                        type=service["service_type"]))
+                services.append(TwithcerService(url=service["service_url"],
+                                                name=service["service_name"],
+                                                type=service["service_type"]))
         return services
 
-    def fetch_by_name(self, name, visibility=None, request=None):  # noqa: F811
+    @cache_region("acl")
+    def _fetch_by_name_cached(self, service_name):
+        # type: (Str) -> TwithcerService
         """
-        Gets service for given ``name`` from magpie.
+        Cache this method with :py:mod:`beaker` based on the provided caching key parameters.
+
+        If the cache is not hit (expired timeout or new key entry), calls :meth:`fetch_by_name` to retrieve the actual
+        :class:`twitcher.datatype.Service` definition. Otherwise, returns the cached item to avoid SQL queries.
+
+        .. note::
+            Function arguments are required to generate caching keys by which cached elements will be retrieved.
+
+        .. note::
+            Method :meth:`fetch_by_name` gets triggered by :meth:`twitcher.owsproxy.owsproxy_view` after successful
+            validation of granted access for :term:`Logged User` to the service / resources following call to
+            :meth:`magpie.adapter.magpieowssecurity.MagpieOWSSecurity.check_request` in order to send and retrieve
+            the actual response of that proxied service and forward it back to the requesting user.
+            Caching helps greatly reduce recurrent SQL queries to convert `Twitcher` to `Magpie` service.
+
+        .. seealso::
+            - :meth:`magpie.adapter.magpieowssecurity.MagpieOWSSecurity.get_service`
+            - :meth:`magpie.adapter.magpieservice.MagpieServiceStore.fetch_by_name`
+        """
+
+
+
+
+        service = evaluate_call(lambda: Service.by_service_name(service_name, db_session=self.request.db),
+                                http_error=HTTPForbidden, msg_on_fail="Service query by name refused by db.")
+        verify_param(service, not_none=True, http_error=HTTPNotFound, msg_on_fail="Service name not found.")
+        # return a specific type of service (eg: ServiceWPS with all the ACL loaded according to the service impl.)
+        service_impl = service_factory(service, self.request)
+        service_data = service.get_appstruct()
+        return service_impl, service_data
+
+    def fetch_by_name(self, name):
+        """
+        Gets :class:`twitcher.datatype.Service` corresponding to :class:`magpie.models.Service` by ``name``.
         """
 
         session = self.session_factory()
@@ -85,10 +123,10 @@ class MagpieServiceStore(ServiceStoreInterface):
             if service is None:
                 raise ServiceNotFound("Service name not found.")
 
-            return Service(url=service.url,
-                           name=service.resource_name,
-                           type=service.type,
-                           verify=self.twitcher_ssl_verify)
+            return TwithcerService(url=service.url,
+                                   name=service.resource_name,
+                                   type=service.type,
+                                   verify=self.twitcher_ssl_verify)
         finally:
             session.close()
 

--- a/magpie/adapter/magpieservice.py
+++ b/magpie/adapter/magpieservice.py
@@ -17,7 +17,7 @@ from magpie.utils import CONTENT_TYPE_JSON, get_admin_cookies, get_logger, get_m
 #   Twitcher available only when this module is imported from it.
 #   It is installed during tests for evaluation.
 #   Module 'magpie.adapter' should not be imported from 'magpie' package.
-from twitcher.datatype import Service as TwithcerService  # noqa
+from twitcher.datatype import Service as TwitcherService  # noqa
 from twitcher.exceptions import ServiceNotFound  # noqa
 from twitcher.store import ServiceStoreInterface  # noqa
 
@@ -72,14 +72,14 @@ class MagpieServiceStore(ServiceStoreInterface):
         json_body = resp.json()
         for service_type in json_body["services"]:
             for service in json_body["services"][service_type].values():
-                services.append(TwithcerService(url=service["service_url"],
+                services.append(TwitcherService(url=service["service_url"],
                                                 name=service["service_name"],
                                                 type=service["service_type"]))
         return services
 
     @cache_region("service")
     def _fetch_by_name_cached(self, service_name):
-        # type: (Str) -> TwithcerService
+        # type: (Str) -> TwitcherService
         """
         Cache this method with :py:mod:`beaker` based on the provided caching key parameters.
 
@@ -107,7 +107,7 @@ class MagpieServiceStore(ServiceStoreInterface):
             if service is None:
                 raise ServiceNotFound("Service name not found.")
 
-            return TwithcerService(url=service.url,
+            return TwitcherService(url=service.url,
                                    name=service.resource_name,
                                    type=service.type,
                                    verify=self.twitcher_ssl_verify)
@@ -115,7 +115,7 @@ class MagpieServiceStore(ServiceStoreInterface):
             session.close()
 
     def fetch_by_name(self, name):
-        # type: (Str) -> TwithcerService
+        # type: (Str) -> TwitcherService
         """
         Gets :class:`twitcher.datatype.Service` corresponding to :class:`magpie.models.Service` by ``name``.
         """

--- a/magpie/api/management/service/service_utils.py
+++ b/magpie/api/management/service/service_utils.py
@@ -114,4 +114,4 @@ def add_service_getcapabilities_perms(service, db_session, group_name=None):
         perm = ResourceService.perm_by_group_and_perm_name(service.resource_id, group.id,
                                                            Permission.GET_CAPABILITIES.value, db_session)
         if perm is None:  # not set, create it
-            create_group_resource_permission_response(group, service, Permission.GET_CAPABILITIES, db_session)
+            create_group_resource_permission_response(group, service, Permission.GET_CAPABILITIES.value, db_session)

--- a/magpie/cli/register_defaults.py
+++ b/magpie/cli/register_defaults.py
@@ -20,7 +20,7 @@ from magpie.utils import get_logger, print_log, raise_log
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Any, AnyStr, Optional, Sequence
+    from typing import Any, Optional, Sequence
 
     from magpie.typedefs import AnySettingsContainer, Str
 
@@ -146,7 +146,7 @@ def init_users_group(db_session, settings=None):
 
 
 def register_defaults(db_session=None, settings=None, ini_file_path=None):
-    # type: (Optional[Session], Optional[AnySettingsContainer], Optional[AnyStr]) -> None
+    # type: (Optional[Session], Optional[AnySettingsContainer], Optional[Str]) -> None
     """
     Registers into database every undefined default users and groups matching following variables:
 
@@ -178,7 +178,7 @@ def make_parser():
 
 
 def main(args=None, parser=None, namespace=None):
-    # type: (Optional[Sequence[AnyStr]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
+    # type: (Optional[Sequence[Str]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
     if not parser:
         parser = make_parser()
     args = parser.parse_args(args=args, namespace=namespace)

--- a/magpie/cli/register_providers.py
+++ b/magpie/cli/register_providers.py
@@ -12,7 +12,9 @@ from magpie.register import magpie_register_services_from_config
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Any, AnyStr, Optional, Sequence
+    from typing import Any, Optional, Sequence
+
+    from magpie.typedefs import Str
 
 
 def make_parser():
@@ -35,7 +37,7 @@ def make_parser():
 
 
 def main(args=None, parser=None, namespace=None):
-    # type: (Optional[Sequence[AnyStr]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
+    # type: (Optional[Sequence[Str]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
     if not parser:
         parser = make_parser()
     args = parser.parse_args(args=args, namespace=namespace)

--- a/magpie/cli/run_db_migration.py
+++ b/magpie/cli/run_db_migration.py
@@ -11,7 +11,9 @@ from magpie.db import run_database_migration
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Any, AnyStr, Optional, Sequence
+    from typing import Any, Optional, Sequence
+
+    from magpie.typedefs import Str
 
 
 def make_parser():
@@ -25,7 +27,7 @@ def make_parser():
 
 
 def main(args=None, parser=None, namespace=None):
-    # type: (Optional[Sequence[AnyStr]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
+    # type: (Optional[Sequence[Str]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
     if not parser:
         parser = make_parser()
     args = parser.parse_args(args=args, namespace=namespace)

--- a/magpie/cli/sync_resources.py
+++ b/magpie/cli/sync_resources.py
@@ -26,9 +26,11 @@ from magpie.utils import get_logger
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Any, AnyStr, Optional, Sequence, Union
+    from typing import Any, Optional, Sequence, Union
 
     from sqlalchemy.orm.session import Session
+
+    from magpie.typedefs import Str
 
 LOGGER = get_logger(__name__)
 
@@ -309,7 +311,7 @@ def fetch(settings=None):
 
 
 def setup_cron_logger(log_level=logging.INFO):
-    # type: (Union[AnyStr, int]) -> None
+    # type: (Union[Str, int]) -> None
 
     if not isinstance(log_level, int):
         log_level = logging.getLevelName(log_level)
@@ -345,7 +347,7 @@ def make_parser():
 
 
 def main(args=None, parser=None, namespace=None):
-    # type: (Optional[Sequence[AnyStr]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
+    # type: (Optional[Sequence[Str]], Optional[argparse.ArgumentParser], Optional[argparse.Namespace]) -> Any
     """
     Main entry point for cron service.
     """

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
         AccessControlEntryType,
         AnyPermissionType,
         GroupPriority,
-        PermissionObject,
+        PermissionDict,
         ResolvablePermissionType,
         Str
     )
@@ -242,7 +242,7 @@ class PermissionSet(object):
         return self.name == other.name
 
     def json(self):
-        # type: () -> PermissionObject
+        # type: () -> PermissionDict
         """
         Obtains the JSON representation of this :class:`PermissionSet`.
         """
@@ -543,7 +543,7 @@ class PermissionSet(object):
 def format_permissions(permissions,             # type: Optional[Collection[AnyPermissionType]]
                        permission_type=None,    # type: Optional[PermissionType]
                        force_unique=True,       # type: bool
-                       ):                       # type: (...) -> Dict[Str, Union[List[Str], PermissionObject, Str]]
+                       ):                       # type: (...) -> Dict[Str, Union[List[Str], PermissionDict, Str]]
     """
     Obtains the formatted permission representations after validation that each of their name is a known member of
     :class:`Permission` enum, and optionally with modifiers as defined by :class:`PermissionSet`.

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -853,9 +853,11 @@ def invalidate_service(service_name):
         # could fail if twitcher was not installed
         from magpie.adapter.magpieowssecurity import MagpieOWSSecurity  # noqa
 
-        if "acl" in cache_regions:
-            region_invalidate(MagpieOWSSecurity._get_service_cached, "acl", service_name)  # noqa
+        if "service" in cache_regions:
+            region_invalidate(MagpieOWSSecurity._get_service_cached, "service", service_name)  # noqa
     except ImportError:
-        LOGGER.warning("Could not invalidate ACL of service: [%s]", service_name)
-    cache_keys = (service_name, )
-    region_invalidate(ServiceInterface._get_acl_cached, "acl", *cache_keys)  # noqa
+        LOGGER.warning("Could not invalidate cache of service: [%s]", service_name)
+
+    if "acl" in cache_regions:
+        cache_keys = (service_name, )  # (service_name, request_method, request_path, user_id)
+        region_invalidate(ServiceInterface._get_acl_cached, "acl", *cache_keys)  # noqa

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -849,6 +849,7 @@ def invalidate_service(service_name):
     """
     Invalidates any caching reference to the specified service name.
     """
+    # pylint: disable=W0212,protected-access
     try:
         # could fail if twitcher was not installed
         from magpie.adapter.magpieowssecurity import MagpieOWSSecurity  # noqa

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -592,8 +592,10 @@ class ServiceGeoserverWMS(ServiceBaseWMS):
     }
 
     def resource_requested(self):
-        permission = self.permission_requested()
         path_parts = self._get_request_path_parts()
+        if not path_parts:
+            return self.service, False
+        permission = self.permission_requested()
         parts_lower = [part.lower() for part in path_parts]
         if parts_lower and parts_lower[0] == "":
             path_parts = path_parts[1:]

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -162,7 +162,7 @@ class ServiceInterface(object):
         if "acl" not in cache_regions:
             cache_regions["acl"] = {"enabled": False}
         user_id = None if self.request.user is None else self.request.user.id
-        cache_keys = (self.request.method, self.request.path_qs, user_id, self.service.resource_name)
+        cache_keys = (self.service.resource_name, self.request.method, self.request.path_qs, user_id)
         if self.request.headers.get("Cache-Control") == "no-cache":
             region_invalidate(self._get_acl_cached, "acl", *cache_keys)
         return self._get_acl_cached(*cache_keys)

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -752,6 +752,7 @@ class ServiceTHREDDS(ServiceInterface):
         return self._config
 
     def get_path_parts(self):
+        # type: () -> Optional[List[Str]]
         cfg = self.get_config()
         path_parts = self._get_request_path_parts()
         skip_prefix = cfg["skip_prefix"]
@@ -767,7 +768,7 @@ class ServiceTHREDDS(ServiceInterface):
         path_parts = self.get_path_parts()
 
         # handle optional prefix as targeting the service directly
-        if len(path_parts) < 2:
+        if not path_parts or len(path_parts) < 2:
             return self.service, True
         path_parts = path_parts[1:]
         cfg = self.get_config()

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import math
+    import typing
     from typing import Any
     from typing import AnyStr
     from typing import Dict, Iterable, List, Optional, Tuple, Type, Union
@@ -27,6 +28,11 @@ if TYPE_CHECKING:
 
     from magpie import models
     from magpie.permissions import Permission, PermissionSet
+
+    if hasattr(typing, "TypedDict"):
+        from typing import TypedDict  # pylint: disable=E0611,no-name-in-module
+    else:
+        from typing_extensions import TypedDict  # noqa
 
     # pylint: disable=W0611,unused-import  # following definitions provided to be employed elsewhere in the code
 
@@ -62,7 +68,9 @@ if TYPE_CHECKING:
     GroupPriority = Union[int, Type[math.inf]]
     UserServicesType = Union[Dict[Str, Dict[Str, Any]], List[Dict[Str, Any]]]
     ServiceOrResourceType = Union[models.Service, models.Resource]
-    PermissionObject = Dict[Str, Optional[Str]]
+    PermissionDict = TypedDict("PermissionDict",
+                               {"name": Str, "access": Optional[Str], "scope": Optional[Str],
+                                "type": Optional[Str], "reason": Optional[Str]}, total=False)
     AnyZigguratPermissionType = Union[
         models.GroupPermission,
         models.UserPermission,
@@ -70,7 +78,7 @@ if TYPE_CHECKING:
         models.UserResourcePermission,
         PermissionTuple,
     ]
-    AnyPermissionType = Union[Permission, PermissionSet, PermissionObject, AnyZigguratPermissionType, Str]
+    AnyPermissionType = Union[Permission, PermissionSet, PermissionDict, AnyZigguratPermissionType, Str]
     ResolvablePermissionType = Union[PermissionSet, AnyZigguratPermissionType]
     AnyAccessPrincipalType = Union[Str, Iterable[Str]]
     AccessControlEntryType = Union[Tuple[Str, Str, Str], Str]

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import math
     from typing import Any
-    from typing import AnyStr as _AnyStr
+    from typing import AnyStr
     from typing import Dict, Iterable, List, Optional, Tuple, Type, Union
 
     import six
@@ -32,10 +32,9 @@ if TYPE_CHECKING:
 
     if six.PY2:
         # pylint: disable=E0602,undefined-variable  # unicode not recognized by python 3
-        Str = Union[_AnyStr, unicode]  # noqa: E0602,F405,F821
+        Str = Union[AnyStr, unicode]  # noqa: E0602,F405,F821
     else:
-        Str = _AnyStr
-    AnyStr = Str    # pylint: disable=C0103,invalid-name
+        Str = str
 
     Number = Union[int, float]
     SettingValue = Union[Str, Number, bool, None]

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import inspect
 import json
 import logging
 import os
@@ -7,7 +8,6 @@ import sys
 import types
 from distutils.dir_util import mkpath
 from enum import Enum
-from inspect import isfunction
 from typing import TYPE_CHECKING
 
 import requests
@@ -172,6 +172,16 @@ def isclass(obj):
     Evaluate an object for :class:`class` type (ie: class definition, not an instance nor any other type).
     """
     return isinstance(obj, (type, six.class_types))
+
+
+def ismethod(obj):
+    # type: (Any) -> bool
+    """
+    Evaluate an object for :class:`method` type (ie: class method reference.
+    """
+    if six.PY2:
+        return inspect.ismethod(obj)
+    return inspect.isroutine(obj) and "." in obj.__qualname__
 
 
 # alternative to 'makedirs' with 'exists_ok' parameter only available for python>3.5
@@ -408,7 +418,13 @@ def fully_qualified_name(obj):
     """
     Obtains the ``'<module>.<name>'`` full path definition of the object to allow finding and importing it.
     """
-    cls = obj if isclass(obj) or isfunction(obj) else type(obj)
+    # pylint: disable=no-member
+    if ismethod(obj):
+        if six.PY2:
+            cls = obj.im_class
+            return ".".join([cls.__module__, cls.__name__, obj.__name__])
+        return ".".join([obj.__module__, obj.__qualname__])
+    cls = obj if isclass(obj) or inspect.isfunction(obj) else type(obj)
     return ".".join([obj.__module__, cls.__name__])
 
 

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -392,7 +392,7 @@ def is_magpie_ui_path(request):
     # remove any additional hostname and known /magpie prefix to get only the final magpie-specific path
     magpie_url = get_magpie_url(request)
     magpie_url = request.url.replace(magpie_url, "")
-    magpie_path = urlparse(magpie_url).path
+    magpie_path = str(urlparse(magpie_url).path)
     magpie_path = magpie_path.split("/magpie/", 1)[-1]  # make sure we don't split a /magpie(.*) element by mistake
     magpie_path = "/" + magpie_path if not magpie_path.startswith("/") else magpie_path
     magpie_ui_home = get_constant("MAGPIE_UI_ENABLED", request) and magpie_path in ("", "/")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ isort; python_version < "3.6"
 isort>5; python_version >= "3.6"
 mock
 pylint; python_version < "3.6"
-pylint>=2.5; python_version >= "3.6"
+pylint>=2.7,<2.8; python_version >= "3.6"
 pylint-quotes
 # bird-house/twticher, must match version in Dockerfile.adapater
 pyramid-twitcher==0.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,8 @@ threddsclient==0.4.1; python_version < "3"
 threddsclient>=0.4.1; python_version >= "3"
 transaction
 typing; python_version < "3"
+# typing extension required for TypedDict
+typing_extensions; python_version < "3.8"
 wheel
 webob
 ziggurat-foundations>=0.8.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,15 +17,15 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-replace = 
+replace =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-	
+
 	* Nothing yet.
-	
+
 	`{new_version} <https://github.com/Ouranosinc/Magpie/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	------------------------------------------------------------------------------------
 
@@ -39,7 +39,7 @@ ignore-path = docs/_build,docs/autoapi
 [flake8]
 ignore = E501,W291,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	.git,
 	__pycache__,
 	build,
@@ -70,7 +70,7 @@ combine_as_imports = false
 branch = true
 source = ./
 include = magpie/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
@@ -78,10 +78,10 @@ omit =
 	magpie/typedefs.py
 
 [tool:pytest]
-addopts = 
-	--strict
+addopts =
+	--strict-markers
 	--tb=native
-markers = 
+markers =
 	adapter: magpie adapter functional operations
 	defaults: magpie default users, providers and views
 	register: magpie methods employed in 'register' module

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -46,19 +46,9 @@ if TYPE_CHECKING:
     from magpie.typedefs import JSON, CookiesType, HeadersType, PermissionDict, Str
 
 
-@six.add_metaclass(ABCMeta)
-class BaseTestCase(unittest.TestCase):
+class ConfigTestCase(object):
     """
-    Base definition for all other `Test Case` interfaces.
-
-    The implementers must provide :meth:`setUpClass` which prepares the various test parameters, session cookies and
-    the local application or remote Magpie URL configuration to evaluate test cases on.
-
-    The implementing `Test Case` must also set :attr:`__test__` to ``True`` so that tests are picked up as executable.
-
-    .. note::
-        Attribute attr:`__test__` is employed to avoid duplicate runs of this base class or other derived classes that
-        must not be considered as the *final implementer* `Test Case`.
+    Various test configuration fields that can be employed across test case implementations.
     """
     # pylint: disable=C0103,invalid-name
 
@@ -90,6 +80,23 @@ class BaseTestCase(unittest.TestCase):
     extra_group_names = set()       # type: Set[Str]
     extra_resource_ids = set()      # type: Set[int]
     extra_service_names = set()     # type: Set[Str]
+
+
+@six.add_metaclass(ABCMeta)
+class BaseTestCase(ConfigTestCase, unittest.TestCase):
+    """
+    Base definition for all other `Test Case` interfaces.
+
+    The implementers must provide :meth:`setUpClass` which prepares the various test parameters, session cookies and
+    the local application or remote Magpie URL configuration to evaluate test cases on.
+
+    The implementing `Test Case` must also set :attr:`__test__` to ``True`` so that tests are picked up as executable.
+
+    .. note::
+        Attribute attr:`__test__` is employed to avoid duplicate runs of this base class or other derived classes that
+        must not be considered as the *final implementer* `Test Case`.
+    """
+    # pylint: disable=C0103,invalid-name
 
     # NOTE: don't forget to override this, or your specialized test-suite will not run
     __test__ = False    # won't run this as a test case, only its derived classes that overrides to True
@@ -5484,7 +5491,7 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.TestSetup.check_UpStatus(self, method="POST", path=path, expected_type=CONTENT_TYPE_HTML)
 
 
-class SetupMagpieAdapter(object):
+class SetupMagpieAdapter(ConfigTestCase):
     """
     Configures all required :class:`MagpieAdapter` components to simulate how it would be loaded by `Twitcher` instance.
 
@@ -5492,29 +5499,42 @@ class SetupMagpieAdapter(object):
     to the ones that would be received by the proxy. This allows to test handling of the requests be the various
     components defined in the adapter.
     """
-    session = None  # type: Optional[Session]
+    session = None          # type: Optional[Session]
+    cache_enabled = False   # type: bool
+    cache_expire = None     # type: Optional[int]
 
     @classmethod
     def setup_adapter(cls):
         test_app = utils.get_app_or_url(cls)
         settings = test_app.app.registry.settings
-        utils.setup_cache_settings(settings)
+        utils.setup_cache_settings(settings, enabled=cls.cache_enabled, expire=cls.cache_expire)
         adapter = MagpieAdapter(settings)
         config = adapter.configurator_factory(settings)
         # making the app triggers creation of class instances from registry (eg: AuthN/AuthZ Policies)
         config.make_wsgi_app()
         settings = config.registry.settings
         cls.ows = adapter.owssecurity_factory(settings)
+        cls.adapter = adapter
 
-    @classmethod
-    def mock_request(cls, *args, **kwargs):
+    @utils.mock_get_settings
+    def mock_request(self, *args, **kwargs):
         """
         Set getters that are normally defined when running the full application.
         """
-        kwargs.setdefault("headers", {})
-        kwargs["headers"]["Cache-Control"] = "no-cache"
+        # apply test app session cookies and default headers, but override with explicit params given as input
+        param_cookies = kwargs.pop("cookies", {})
+        param_headers = kwargs.pop("headers", {})
+        test_cookies = self.test_cookies or {}
+        test_headers = self.test_headers or {}
+        test_cookies.update(param_cookies)
+        test_headers.update(param_headers)
+        if not self.cache_enabled:
+            test_headers["Cache-Control"] = "no-cache"
+        kwargs.update({"cookies": test_cookies, "headers": test_headers})
+
+        # generate mocked request and getter methods
         request = utils.mock_request(*args, **kwargs)
-        test_app = utils.get_app_or_url(cls)
+        test_app = utils.get_app_or_url(self)
         registry = test_app.app.registry
         request.registry = registry
         settings = kwargs.get("settings")
@@ -5528,9 +5548,9 @@ class SetupMagpieAdapter(object):
         for meth, reify in methods:
             # handle DB session manually, otherwise it gets duplicated and QueuePool limit gets reached
             if meth == "db":
-                if not cls.session:
-                    cls.session = reify.wrapped(request)
-                setattr(request, meth, cls.session)
+                if not self.session:
+                    self.session = reify.wrapped(request)
+                setattr(request, meth, self.session)
             else:
                 setattr(request, meth, reify.wrapped(request))
         return request

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -5511,6 +5511,8 @@ class SetupMagpieAdapter(object):
         """
         Set getters that are normally defined when running the full application.
         """
+        kwargs.setdefault("headers", {})
+        kwargs["headers"]["Cache-Control"] = "no-cache"
         request = utils.mock_request(*args, **kwargs)
         test_app = utils.get_app_or_url(cls)
         registry = test_app.app.registry

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -2,7 +2,6 @@ from pyramid.httpexceptions import HTTPNotFound
 
 from magpie import __meta__
 from magpie.adapter.magpieowssecurity import MagpieOWSSecurity, OWSAccessForbidden
-from magpie.adapter.magpieservice import MagpieServiceStore
 from magpie.constants import get_constant
 from magpie.services import ServiceAPI
 from tests import interfaces as ti, runner, utils

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,69 +1,103 @@
-import pytest
-import unittest
+from pyramid.httpexceptions import HTTPNotFound
 
 from magpie import __meta__
+from magpie.adapter.magpieowssecurity import MagpieOWSSecurity, OWSAccessForbidden
+from magpie.adapter.magpieservice import MagpieServiceStore
 from magpie.constants import get_constant
+from magpie.services import ServiceAPI
 from tests import interfaces as ti, runner, utils
 
 
 @runner.MAGPIE_TEST_LOCAL
 @runner.MAGPIE_TEST_ADAPTER
 @runner.MAGPIE_TEST_FUNCTIONAL
-class TestServices(ti.SetupMagpieAdapter, ti.AdminTestCase, ti.BaseTestCase):
+class TestAdapter(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
+    """
+    Validation of general :class:`magpie.adapter.MagpieAdapter` operations and its underlying service/security handling.
+    """
+
     __test__ = True
 
     @classmethod
     @utils.mock_get_settings
     def setUpClass(cls):
         cls.version = __meta__.__version__
-        cls.app = utils.get_test_magpie_app(cls.settings)
+        cls.app = utils.get_test_magpie_app()
         cls.grp = get_constant("MAGPIE_ADMIN_GROUP")
         cls.usr = get_constant("MAGPIE_TEST_ADMIN_USERNAME")
         cls.pwd = get_constant("MAGPIE_TEST_ADMIN_PASSWORD")
         cls.settings = cls.app.app.registry.settings
-        cls.setup_adapter()
-
-        cls.cookies = None
-        cls.version = utils.TestSetup.get_Version(cls)
-        cls.setup_admin()
-        cls.headers, cls.cookies = utils.check_or_try_login_user(cls.app, cls.usr, cls.pwd, use_ui_form_submit=True)
-        cls.require = "cannot run tests without logged in user with '{}' permissions".format(cls.grp)
-        cls.login_admin()
 
         # following will be wiped on setup
-        cls.test_user_name = "unittest-service-user"
-        cls.test_group_name = "unittest-service-group"
+        cls.test_user_name = "unittest-adapter-user"
+        cls.test_group_name = "unittest-adapter-group"
+        cls.test_service_name = "unittest-adapter-service"
+        cls.test_service_type = ServiceAPI.service_type
+        cls.test_resource_name = "test"
+        cls.test_resource_type = "route"
 
-    def mock_request(self, *args, **kwargs):
-        kwargs.update({"cookies": self.test_cookies, "headers": self.test_headers})
-        return super(TestServices, self).mock_request(*args, **kwargs)
+        cls.setup_adapter()
+        cls.setup_admin()
+        cls.login_admin()
 
-    @unittest.skip("impl")
-    @pytest.mark.skip
+    def setUp(self):
+        ti.UserTestCase.setUp(self)
+        info = utils.TestSetup.create_TestService(self)
+        utils.TestSetup.create_TestUserResourcePermission(self, resource_info=info, override_permission="read")
+        utils.TestSetup.create_TestUserResourcePermission(self, resource_info=info, override_permission="write")
+        info = utils.TestSetup.create_TestServiceResource(self)
+        utils.TestSetup.create_TestUserResourcePermission(self, resource_info=info, override_permission="read")
+        utils.TestSetup.create_TestUserResourcePermission(self, resource_info=info, override_permission="write")
+        self.login_test_user()
+
+    @utils.mock_get_settings
     def test_unauthenticated_service_blocked(self):
         """
         Validate missing authentication token blocks access to the service if not publicly accessible.
         """
-        raise NotImplementedError  # FIXME
+        utils.check_or_try_logout_user(self)
+        self.test_headers = None
+        self.test_cookies = None
 
-    @unittest.skip("impl")
-    @pytest.mark.skip
+        path = "/ows/proxy/{}".format(self.test_service_name)
+        req = self.mock_request(path, method="GET")
+        utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden, msg="Using [GET, {}]".format(path))
+        req = self.mock_request(path, method="POST")
+        utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden, msg="Using [POST, {}]".format(path))
+
+    @utils.mock_get_settings
     def test_unauthenticated_resource_allowed(self):
         """
         Validate granted access to a resource specified as publicly accessible even without any authentication token.
         """
-        raise NotImplementedError  # FIXME
+        utils.check_or_try_logout_user(self)
+        self.test_headers = None
+        self.test_cookies = None
 
-    @unittest.skip("impl")
-    @pytest.mark.skip
+        path = "/ows/proxy/{}/{}".format(self.test_service_name, self.test_resource_name)
+        req = self.mock_request(path, method="GET")
+        utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden, msg="Using [GET, {}]".format(path))
+        req = self.mock_request(path, method="POST")
+        utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden, msg="Using [POST, {}]".format(path))
+
+    @utils.mock_get_settings
     def test_unknown_service(self):
         """
         Validate that unknown service-name is handled correctly.
         """
-        raise NotImplementedError  # FIXME
+        self.login_test_user()
 
-    @unittest.skip("impl")
-    @pytest.mark.skip
+        # validate it works correctly for known service
+        path = "/ows/proxy/{}".format(self.test_service_name)
+        req = self.mock_request(path, method="GET")
+        utils.check_no_raise(lambda: self.ows.check_request(req), msg="Using [GET, {}]".format(path))
+
+        # when service is unknown, Magpie cannot resolve it and directly raises not found
+        path = "/ows/proxy/unittest-unknown-service"
+        req = self.mock_request(path, method="GET")
+        utils.check_raises(lambda: self.ows.check_request(req), HTTPNotFound, msg="Using [GET, {}]".format(path))
+
+    @utils.mock_get_settings
     def test_unknown_resource_under_service(self):
         """
         Evaluate use-case where requested resource when parsing the request corresponds to non-existing element.
@@ -73,4 +107,98 @@ class TestServices(ti.SetupMagpieAdapter, ti.AdminTestCase, ti.BaseTestCase):
 
         If the closest parent permission permission is either Match-scoped or explicit Deny, access should be refused.
         """
-        raise NotImplementedError  # FIXME
+        self.login_test_user()
+
+        # validate it works correctly for known Magpie resource
+        path = "/ows/proxy/{}/{}".format(self.test_service_name, self.test_resource_name)
+        req = self.mock_request(path, method="GET")
+        utils.check_no_raise(lambda: self.ows.check_request(req), msg="Using [GET, {}]".format(path))
+
+        # resource is unknown, but user permission grants access to whatever 'resource' is supposedly located there
+        # up to underlying service to return whichever status is appropriate, but request is forwarded as considered
+        # resolved for Magpie/Twitcher roles
+        path = "/ows/proxy/{}/{}".format(self.test_service_name, "unittest-unknown-resource")
+        req = self.mock_request(path, method="GET")
+        utils.check_no_raise(lambda: self.ows.check_request(req), msg="Using [GET, {}]".format(path))
+
+
+@runner.MAGPIE_TEST_LOCAL
+@runner.MAGPIE_TEST_ADAPTER
+@runner.MAGPIE_TEST_FUNCTIONAL
+class TestAdapterCaching(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
+    """
+    Test request parsing and :term:`ACL` resolution when caching is enabled.
+    """
+    # pylint: disable=C0103,invalid-name
+    __test__ = True
+    test_headers = None
+    test_cookies = None
+    cache_expire = 10
+    cache_enabled = True
+    cache_reset_headers = {"Cache-Control": "no-cache"}
+
+    @classmethod
+    @utils.mock_get_settings
+    def setUpClass(cls):
+        cls.version = __meta__.__version__
+        cls.settings = {}
+        utils.setup_cache_settings(cls.settings, enabled=cls.cache_enabled, expire=cls.cache_expire)
+        cls.app = utils.get_test_magpie_app(settings=cls.settings, setup_cache=False)
+        cls.grp = get_constant("MAGPIE_ADMIN_GROUP")
+        cls.usr = get_constant("MAGPIE_TEST_ADMIN_USERNAME")
+        cls.pwd = get_constant("MAGPIE_TEST_ADMIN_PASSWORD")
+
+        # following will be wiped on setup
+        cls.test_user_name = "unittest-adapter-cache-user"
+        cls.test_group_name = "unittest-adapter-cache-group"
+        cls.test_service_name = "unittest-adapter-service"
+        cls.test_service_type = ServiceAPI.service_type
+
+        cls.setup_adapter()
+        cls.setup_admin()
+
+    @utils.mock_get_settings
+    def setUp(self):
+        ti.UserTestCase.setUp(self)
+        self.setup_adapter()
+        self.cookies = None
+        self.headers, self.cookies = utils.check_or_try_login_user(self, self.usr, self.pwd, use_ui_form_submit=True)
+        self.require = "cannot run tests without logged in user with '{}' permissions".format(self.grp)
+        self.login_admin()
+        utils.TestSetup.create_TestService(self)
+
+    @utils.mock_get_settings
+    def test_access_cached_service(self):
+        """
+        Verify caching operation of adapter to retrieve the requested service.
+
+        Caching limits retrieval of service implementation from database service definition matched by service name.
+        """
+        number_calls = 10
+        admin_headers = self.headers.copy()
+        admin_cookies = self.cookies.copy()
+        admin_no_cache = self.cache_reset_headers.copy()
+        admin_no_cache.update(admin_headers)
+
+        # wrap 'get_service' which calls the cached method, which in turn calls 'service_factory'
+        # when caching takes effect, 'service_factory' does not get called as the cached service is returned directly
+        with utils.wrapped_call(MagpieOWSSecurity, "get_service", self.ows) as mock_cached:
+            with utils.wrapped_call("magpie.adapter.magpieowssecurity.service_factory") as mock_service:
+
+                # initial request to ensure functions get cached once from scratch
+                path = "/ows/proxy/{}".format(self.test_service_name)
+                req = self.mock_request(path, method="GET", headers=admin_no_cache, cookies=admin_cookies)
+                utils.check_no_raise(lambda: self.ows.check_request(req), msg="Using [GET, {}]".format(path))
+
+                # run many requests which should directly return the previously cached result
+                req = self.mock_request(path, method="GET", headers=admin_headers, cookies=admin_cookies)
+                msg = "Using [GET, {}]".format(path)
+                for _ in range(number_calls):
+                    utils.check_no_raise(lambda: self.ows.check_request(req), msg=msg)
+
+        utils.check_val_equal(mock_cached.call_count, number_calls + 1, msg="Cached call expected for each request")
+        utils.check_val_equal(mock_service.call_count, 1, msg="Real call expected only on first run before caching")
+
+    @utils.mock_get_settings
+    def test_access_cached_service_by_other_user(self):
+        pass

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,9 +1,11 @@
+import random
+
 from pyramid.httpexceptions import HTTPNotFound
 
 from magpie import __meta__
 from magpie.adapter.magpieowssecurity import MagpieOWSSecurity, OWSAccessForbidden
 from magpie.constants import get_constant
-from magpie.services import ServiceAPI
+from magpie.services import ServiceAPI, ServiceInterface
 from tests import interfaces as ti, runner, utils
 
 
@@ -137,7 +139,7 @@ class TestAdapterCaching(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase
     __test__ = True
     test_headers = None
     test_cookies = None
-    cache_expire = 10
+    cache_expire = 600
     cache_enabled = True
     cache_reset_headers = {"Cache-Control": "no-cache"}
 
@@ -157,6 +159,7 @@ class TestAdapterCaching(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase
         cls.test_group_name = "unittest-adapter-cache-group"
         cls.test_service_name = "unittest-adapter-service"
         cls.test_service_type = ServiceAPI.service_type
+        cls.test_resource_type = "route"
 
         cls.setup_adapter()
         cls.setup_admin()
@@ -242,3 +245,115 @@ class TestAdapterCaching(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase
 
         utils.check_val_equal(wrapped_cached.call_count, 1, msg="Real call expected only on first run before caching")
         utils.check_val_equal(wrapped_service.call_count, 3, msg="Service call expected for each request")
+
+    @utils.mock_get_settings
+    def test_retrieve_cached_acl(self):
+        """
+        Validate caching of :term:`ACL` resolution against repeated combinations of caching arguments.
+
+        Caching method takes as inputs combinations of (:term:`User`, :term:`Resource`, :term:`Permission`).
+
+        Verify that the caching takes effect, but also that it is properly managed between distinct consecutive
+        requests. Multiple combinations of :term:`ACL` resolution requests are sent in random order to ensure they
+        don't invalidate other caches (of other combinations), while still producing valid results for the relevant
+        :term:`Resource` the :term:`User` attempts to obtain :term:`Permission` access.
+
+        When :term:`ACL` caching is applied properly, the complete computation of the access result should only be
+        accomplished on the first call of each combination, and all following ones (within the caching timeout) will
+        resolve from the cache.
+        """
+        # create some test resources under the service with permission for the user
+        # service not allowed access, resource allowed
+        res1_name = "test1"
+        res2_name = "test2"
+        res1_path = "/ows/proxy/{}/{}".format(self.test_service_name, res1_name)
+        res2_path = "/ows/proxy/{}/{}".format(self.test_service_name, res2_name)
+        info = utils.TestSetup.create_TestServiceResource(self, override_resource_name=res1_name)
+        utils.TestSetup.create_TestUserResourcePermission(self, resource_info=info, override_permission="read")
+        info = utils.TestSetup.create_TestServiceResource(self, override_resource_name=res2_name)
+        utils.TestSetup.create_TestUserResourcePermission(self, resource_info=info, override_permission="write")
+
+        no_cache_header = self.cache_reset_headers.copy()
+        admin_cookies = self.cookies.copy()
+        admin_headers = self.headers.copy()
+        self.login_test_user()
+        user_cookies = self.test_cookies.copy()
+        user_headers = self.test_headers.copy()
+        utils.check_or_try_logout_user(self)
+        self.test_headers = None
+        self.test_cookies = None
+
+        test_requests = [
+            # allowed because admin
+            (True, self.mock_request(res1_path, method="GET", headers=admin_headers, cookies=admin_cookies)),
+            (True, self.mock_request(res1_path, method="POST", headers=admin_headers, cookies=admin_cookies)),
+            (True, self.mock_request(res2_path, method="GET", headers=admin_headers, cookies=admin_cookies)),
+            (True, self.mock_request(res2_path, method="POST", headers=admin_headers, cookies=admin_cookies)),
+            # allowed/denied based on (user, resource, permission) combination
+            (True, self.mock_request(res1_path, method="GET", headers=user_headers, cookies=user_cookies)),
+            (False, self.mock_request(res1_path, method="POST", headers=user_headers, cookies=user_cookies)),
+            (False, self.mock_request(res2_path, method="GET", headers=user_headers, cookies=user_cookies)),
+            (True, self.mock_request(res2_path, method="POST", headers=user_headers, cookies=user_cookies)),
+        ]
+        number_duplicate_call_cached = 20
+        cache_requests = test_requests * number_duplicate_call_cached
+        random.shuffle(cache_requests)
+
+        # each method targets a different Permission, each path a different Resource, and each cookies a different user
+        token = get_constant("MAGPIE_COOKIE_NAME")
+        unique_calls = set((req.method, req.path, req.cookies[token]) for _, req in test_requests + cache_requests)
+
+        def run_check(test_requests_set, cached):
+            _cached = " (cached)" if cached else ""
+            for _allowed, _request in test_requests_set:
+                _cookie = _request.cookies[token]
+                _user = self.test_user_name if _cookie == user_cookies[token] else "admin"
+                _msg = "Using [{}, {}]{} with user [{}]".format(_request.method, _request.path, _cached, _user)
+                if not cached:
+                    _request.headers.update(no_cache_header)
+                else:
+                    _request.headers.pop("Cache-Control", None)
+                if _allowed:
+                    utils.check_no_raise(lambda: self.ows.check_request(_request), msg=_msg)
+                else:
+                    utils.check_raises(lambda: self.ows.check_request(_request), OWSAccessForbidden, msg=_msg)
+
+        # obtain a reference to the 'service' that should be returned by 'service_factory' such that we can
+        # prepare wrapped mock references to its '__acl__' and '_get_acl' methods
+        tmp_req = test_requests[0][1]
+        service = self.ows.get_service(tmp_req)
+
+        def mocked_service_factory(__test_service, test_request):
+            service.request = test_request
+            return service
+
+        # WARNING:
+        #  In both cases below, we cannot mock the cached method directly since it needs to do caching retrieval.
+        #  Instead, mock a function before each cached method call and another within to compare call-counts.
+
+        # wrap 'get_service' which calls the cached method '_get_service_cached', which in turn calls 'service_factory'
+        # when caching takes effect, 'service_factory' does not get called as the cached service is returned directly
+        with utils.wrapped_call(MagpieOWSSecurity, "get_service", self.ows) as mock_service_cached:
+            with utils.wrapped_call("magpie.adapter.magpieowssecurity.service_factory",
+                                    side_effect=mocked_service_factory) as mock_service:
+                # wrap '__acl__' which calls '_get_acl_cached', that in turns calls '_get_acl' when computing real ACL
+                with utils.wrapped_call(ServiceInterface, "__acl__", service) as mock_acl_cached:
+                    with utils.wrapped_call(ServiceInterface, "_get_acl", service) as mock_acl:
+
+                        # run all requests with caching disabled to initialize their expire duration
+                        run_check(test_requests, False)
+                        # then, do exactly the same but with caches enabled for requests in random order
+                        # all caches should remain active for the whole duration and not conflict with each other
+                        run_check(cache_requests, True)
+
+        # there should be as many service resolution as there are requests, but only first ones without cache fetches it
+        # for ACL resolution, there should also be as many as there are requests, but actual computation will be limited
+        # to the number of combinations without caching, and all others only return the precomputed cache result
+        total_cached = len(cache_requests)
+        total_no_cache = len(test_requests)
+        total_calls = total_cached + total_no_cache
+        total_acl_cached = len(unique_calls)
+        utils.check_val_equal(mock_service_cached.call_count, total_calls, msg="Service call expected for each request")
+        utils.check_val_equal(mock_acl_cached.call_count, total_calls, msg="ACL resolution expected for each request")
+        utils.check_val_equal(mock_service.call_count, total_no_cache, msg="Real service expected only on first ones")
+        utils.check_val_equal(mock_acl.call_count, total_acl_cached, msg="Real ACL call expected only on first unique")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -75,7 +75,7 @@ class TestOWSParser(unittest.TestCase):
         assert parser.params["test"] == "something"
 
         body = '{"test": "something"}'  # pylint: disable=C4001
-        parser = make_ows_parser(method="POST", content_type=CONTENT_TYPE_PLAIN, params=None, body=body)
+        parser = make_ows_parser(method="POST", content_type=CONTENT_TYPE_JSON, params=None, body=body)
         parser.parse(["test"])
         assert isinstance(parser, owsrequest.MultiFormatParser)
         assert parser.params["test"] == "something"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -21,7 +21,7 @@ from magpie.adapter.magpieowssecurity import OWSAccessForbidden
 from magpie.constants import get_constant
 from magpie.permissions import Access, Permission, PermissionSet, Scope
 from magpie.services import ServiceAccess, ServiceAPI, ServiceGeoserverWMS, ServiceTHREDDS, ServiceWPS
-from magpie.utils import CONTENT_TYPE_FORM, CONTENT_TYPE_JSON, CONTENT_TYPE_PLAIN, CONTENT_TYPE_TXT_XML
+from magpie.utils import CONTENT_TYPE_FORM, CONTENT_TYPE_JSON, CONTENT_TYPE_TXT_XML
 from tests import interfaces as ti, runner, utils
 
 if TYPE_CHECKING:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -552,8 +552,6 @@ def mock_request(request_path_query="",     # type: Str
     return request  # noqa  # fake type of what is normally expected just to avoid many 'noqa'
 
 
-
-
 def wrapped_call(target, method=None, instance=None):
     # type: (Union[Type, Str], Optional[Str], Optional[Any]) -> mock.MagicMock
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -257,6 +257,10 @@ def get_test_magpie_app(settings=None):
     config.registry.settings["magpie.url"] = "http://localhost:80"
     if settings:
         config.registry.settings.update(settings)
+    # enforce no caching for tests
+    for region in ["acl", "service"]:
+        config.registry.settings["cache.{}.enable".format(region)] = "false"
+        config.registry.settings.pop("cache.{}.expire".format(region), None)
     # create the test application
     magpie_app = TestApp(app.main({}, **config.registry.settings))
     return magpie_app


### PR DESCRIPTION
helps resolve bird-house/twitcher#97 
based on finding from https://github.com/bird-house/birdhouse-deploy/compare/cache-settings
and https://github.com/bird-house/twitcher/issues/97#issuecomment-780747482 

settings should be defined in `Twitcher` 's INI with something like: 

```
# caching settings for specific sections/functions
cache.regions = acl, service
cache.type = memory
cache.acl.expire = 60
cache.acl.enabled = true
cache.service.expire = 10
cache.service.enabled = true
```

