### PR TITLE
Fix tests

### DIFF
--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -457,20 +457,21 @@ def get_phoenix_url(container=None):
     return "https://{0}{1}".format(hostname, ":{}".format(phoenix_port) if phoenix_port else "")
 
 
-def get_twitcher_protected_service_url(magpie_service_name, hostname=None):
+def get_twitcher_url(container=None, hostname=None):
+    # type: (Optional[AnySettingsContainer], Optional[Str]) -> Str
     """
-    Obtains the protected service URL behind Twitcher Proxy based on combination of supported configuration settings.
+    Obtains the configured Twitcher URL entrypoint based on various combinations of supported configuration settings.
 
     .. seealso::
         Documentation section :ref:`config_twitcher` for available setting combinations.
 
-    :param magpie_service_name: name of the service to employ in order to form the URL path behind the proxy.
+    :param container: container that provides access to application settings.
     :param hostname: override literal hostname to generate the URL instead of resolving using settings.
-    :return: resolved Twitcher Proxy protected service URL
+    :return: resolved Twitcher URL
     """
-    twitcher_proxy_url = get_constant("TWITCHER_PROTECTED_URL", raise_not_set=False)
+    twitcher_proxy_url = get_constant("TWITCHER_PROTECTED_URL", container, raise_not_set=False)
     if not twitcher_proxy_url:
-        twitcher_proxy = get_constant("TWITCHER_PROTECTED_PATH", raise_not_set=False)
+        twitcher_proxy = get_constant("TWITCHER_PROTECTED_PATH", container, raise_not_set=False)
         if not twitcher_proxy.endswith("/"):
             twitcher_proxy = twitcher_proxy + "/"
         if not twitcher_proxy.startswith("/"):
@@ -478,12 +479,28 @@ def get_twitcher_protected_service_url(magpie_service_name, hostname=None):
         if not twitcher_proxy.startswith("/twitcher"):
             twitcher_proxy = "/twitcher" + twitcher_proxy
         hostname = (hostname or
-                    get_constant("TWITCHER_HOST", raise_not_set=False, raise_missing=False) or
-                    get_constant("HOSTNAME", raise_not_set=False, raise_missing=False))
+                    get_constant("TWITCHER_HOST", container, raise_not_set=False, raise_missing=False) or
+                    get_constant("HOSTNAME", container, raise_not_set=False, raise_missing=False))
         if not hostname:
             raise ConfigurationError("Missing or unset TWITCHER_PROTECTED_URL, TWITCHER_HOST or HOSTNAME value.")
         twitcher_proxy_url = "https://{0}{1}".format(hostname, twitcher_proxy)
     twitcher_proxy_url = twitcher_proxy_url.rstrip("/")
+    return twitcher_proxy_url
+
+
+def get_twitcher_protected_service_url(magpie_service_name, container=None, hostname=None):
+    """
+    Obtains the protected service URL behind Twitcher Proxy based on combination of supported configuration settings.
+
+    .. seealso::
+        Documentation section :ref:`config_twitcher` for available setting combinations.
+
+    :param magpie_service_name: name of the service to employ in order to form the URL path behind the proxy.
+    :param container: container that provides access to application settings.
+    :param hostname: override literal hostname to generate the URL instead of resolving using settings.
+    :return: resolved Twitcher Proxy protected service URL
+    """
+    twitcher_proxy_url = get_twitcher_url(container=container, hostname=hostname)
     return "{0}/{1}".format(twitcher_proxy_url, magpie_service_name)
 
 

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -1770,8 +1770,11 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.check_val_equal(body["code"], 401)
 
         # when logged in as non-admin to get 403
-        utils.check_or_try_login_user(self, username=self.test_user_name, password=self.test_user_name)
-        resp = utils.test_request(self, "GET", "/services", headers=self.json_headers, expect_errors=True)
+        headers, cookies = utils.check_or_try_login_user(self,
+                                                         username=self.test_user_name,
+                                                         password=self.test_user_name)
+        resp = utils.test_request(self, "GET", "/services", expect_errors=True,
+                                  headers=headers, cookies=cookies)
         body = utils.check_response_basic_info(resp, 403, expected_method="GET")
         utils.check_val_equal(body["code"], 403)
 

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -36,8 +36,7 @@ from magpie.utils import (
     CONTENT_TYPE_HTML,
     CONTENT_TYPE_JSON,
     CONTENT_TYPE_PLAIN,
-    CONTENT_TYPE_TXT_XML,
-    get_twitcher_protected_service_url
+    CONTENT_TYPE_TXT_XML
 )
 from tests import runner, utils
 from tests.utils import TestVersion

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -5037,12 +5037,12 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
             svc_name = svc["service_name"]
             if svc_name in self.test_services_info:
                 utils.check_val_equal(svc["service_type"], self.test_services_info[svc_name]["type"])
-                hostname = utils.get_hostname(self)
+                netloc = utils.get_netloc(self)
                 # private service URL should match format of Magpie (schema/host)
-                svc_url = self.test_services_info[svc_name]["url"].replace("${HOSTNAME}", hostname)
+                svc_url = self.test_services_info[svc_name]["url"].replace("${HOSTNAME}", netloc)
                 utils.check_val_equal(svc["service_url"], svc_url)
                 # public service URL should match Twitcher config, but ignore schema that depends on each server config
-                twitcher_svc_url = get_twitcher_protected_service_url(svc_name, hostname=hostname)
+                twitcher_svc_url = get_twitcher_protected_service_url(svc_name, hostname=netloc)
                 twitcher_parsed_url = urlparse(twitcher_svc_url)
                 twitcher_test_url = twitcher_parsed_url.netloc + twitcher_parsed_url.path
                 svc_parsed_url = urlparse(svc["public_url"])

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -1809,6 +1809,13 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.TestSetup.create_TestGroup(self)
         test_bad_users = []
         test_good_users = []
+        # cleanup in case of failed previous test run
+        for i in range(3):
+            user = test_users_template.format("bad", i)
+            utils.TestSetup.delete_TestUser(self, override_user_name=user)
+            user = test_users_template.format("good", i)
+            utils.TestSetup.delete_TestUser(self, override_user_name=user)
+        # create test users with statuses
         for i in range(3):
             user = test_users_template.format("bad", i)
             utils.TestSetup.create_TestUser(self, override_user_name=user)
@@ -1819,6 +1826,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
             utils.TestSetup.create_TestUser(self, override_user_name=user)
             test_good_users.append(user)
 
+        # test response results
         test_cases = [
             (test_good_users, s.UserStatuses.OK.value),
             (test_bad_users, s.UserStatuses.WebhookErrorStatus.value)

--- a/tests/test_magpie_cli.py
+++ b/tests/test_magpie_cli.py
@@ -37,7 +37,8 @@ KNOWN_HELPERS = [
 def run_and_get_output(command, trim=True):
     if isinstance(command, (list, tuple)):
         command = " ".join(command)
-    proc = subprocess.Popen(command, shell=True, universal_newlines=True, stdout=subprocess.PIPE)  # nosec
+    env = {"PATH": os.path.expandvars(os.environ["PATH"])}  # when debugging, explicit expand of install path required
+    proc = subprocess.Popen(command, shell=True, env=env, universal_newlines=True, stdout=subprocess.PIPE)  # nosec
     out, err = proc.communicate()
     assert not err, "process returned with error code {}".format(err)
     # when no output is present, it is either because CLI was not installed correctly, or caused by some other error

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -787,6 +787,8 @@ def test_request(test_item,             # type: AnyMagpieTestItemType
 
     kwargs.pop("expect_errors", None)  # remove keyword specific to TestApp
     content_type = get_header("Content-Type", headers)
+    if headers:
+        headers.pop("Content-Length", None)  # let requests recalculate to avoid mismatch against real content
     if json or content_type == CONTENT_TYPE_JSON:
         kwargs["json"] = _body
     elif data or body:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Collection, Dict, Iterable, List, Optional, Tuple, Type, Union
 
     from pyramid.request import Request
+    from six.moves.urllib.parse import ParseResult
     from webtest.forms import BeautifulSoup
 
     import tests.interfaces as ti
@@ -403,15 +404,15 @@ def get_test_webhook_app(webhook_url):
     return webhook_app_instance
 
 
-def get_netloc(test_item):
-    # type: (AnyMagpieTestItemType) -> Str
+def get_parsed_url(test_item):
+    # type: (AnyMagpieTestItemType) -> ParseResult
     """
-    Obtains stored network location including hostname and applicable port from the test class implementation.
+    Obtains the parsed URL result from the test class web application implementation.
     """
     app_or_url = get_app_or_url(test_item)
     if isinstance(app_or_url, TestApp):
         app_or_url = get_magpie_url(app_or_url.app.registry)
-    return urlparse(app_or_url).netloc
+    return urlparse(app_or_url)
 
 
 def get_headers(app_or_url, header_dict):
@@ -961,6 +962,18 @@ def check_all_equal(iter_val, iter_ref, msg=None, any_order=False):
     r_val = repr(iter_val)
     r_ref = repr(iter_ref)
     assert all_equal(iter_val, iter_ref, any_order), format_test_val_ref(r_val, r_ref, pre="All Equal Fail", msg=msg)
+
+
+def check_val_true(val, msg=None):
+    # type: (Any, Optional[Str]) -> None
+    """:raises AssertionError: if :paramref:`val` is not ``True``."""
+    assert val is True, format_test_val_ref(val, True, pre="Not True", msg=msg)
+
+
+def check_val_false(val, msg=None):
+    # type: (Any, Optional[Str]) -> None
+    """:raises AssertionError: if :paramref:`val` is not ``False``."""
+    assert val is False, format_test_val_ref(val, False, pre="Not False", msg=msg)
 
 
 def check_val_equal(val, ref, msg=None):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -403,15 +403,15 @@ def get_test_webhook_app(webhook_url):
     return webhook_app_instance
 
 
-def get_hostname(test_item):
+def get_netloc(test_item):
     # type: (AnyMagpieTestItemType) -> Str
     """
-    Obtains stored hostname in the class implementation.
+    Obtains stored network location including hostname and applicable port from the test class implementation.
     """
     app_or_url = get_app_or_url(test_item)
     if isinstance(app_or_url, TestApp):
         app_or_url = get_magpie_url(app_or_url.app.registry)
-    return urlparse(app_or_url).hostname
+    return urlparse(app_or_url).netloc
 
 
 def get_headers(app_or_url, header_dict):


### PR DESCRIPTION
fixes to tests in order to make all of them work seamlessly both for local/remote and shell/debug runs

* fix cli tests exec path when debugging
* fix missing forwarding of request cookies to evaluate forbidden access
* fix invalid netloc retrieval when twitcher url has port value
* fix failed test pre-cleanup
* fix test-remote execution for some cases with invalid content-length
