### PR TITLE
Gunicorn update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Features / Changes
   | **NOTE**:
   | Because ``gunicorn`` changed how its CLI handles INI files, ``pserve`` should be employed instead to ensure the
     configured web application port is properly applied with the provided ``magpie.ini`` configuration file.
+    Furthermore, the (``host``, ``port``) or ``bind`` should be updated to employ ``0.0.0.0:2001`` instead of
+    ``localhost:2001``, or any other combination of desired port to serve the application.
 
 `3.9.0 <https://github.com/Ouranosinc/Magpie/tree/3.9.0>`_ (2021-04-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,13 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* | Update ``gunicorn>=20.x`` to receive latest security fixes.
+  |
+  | **NOTE**:
+  | Because ``gunicorn`` changed how its CLI handles INI files, ``pserve`` should be employed instead to ensure the
+    configured web application port is properly applied with the provided ``magpie.ini`` configuration file.
 
 `3.9.0 <https://github.com/Ouranosinc/Magpie/tree/3.9.0>`_ (2021-04-06)
 ------------------------------------------------------------------------------------
@@ -461,9 +467,11 @@ Bug Fixes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* When using logging level ``DEBUG``, `Magpie` requests will log additional details.
-
-  **WARNING**: these log entries will potentially also include sensible information such as authentication cookies.
+* | When using logging level ``DEBUG``, `Magpie` requests will log additional details.
+  |
+  | **WARNING**:
+  | Log entries with ``DEBUG`` level will potentially also include sensible information such as authentication cookies.
+  | This level **SHOULD NOT** be used in production environments.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Features / Changes
 * | Update ``gunicorn>=20.x`` to receive latest security patches
     (fixes `#410 <https://github.com/Ouranosinc/Magpie/issues/410>`_).
   |
-  | **NOTE**:
+  | **IMPORTANT**:
   | Because ``gunicorn`` changed how its CLI handles INI files, ``pserve`` should be employed instead to ensure the
     configured web application port is properly applied with the provided ``magpie.ini`` configuration file.
     Furthermore, the (``host``, ``port``) or ``bind`` should be updated to employ ``0.0.0.0:2001`` instead of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* | Update ``gunicorn>=20.x`` to receive latest security fixes.
+* | Update ``gunicorn>=20.x`` to receive latest security patches
+    (fixes `#410 <https://github.com/Ouranosinc/Magpie/issues/410>`_).
   |
   | **NOTE**:
   | Because ``gunicorn`` changed how its CLI handles INI files, ``pserve`` should be employed instead to ensure the

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,5 @@ COPY ./magpie $MAGPIE_DIR/magpie/
 RUN pip install --no-dependencies -e $MAGPIE_DIR
 
 # equivalent of `make cron start` without conda env
-CMD crond -c $CRON_DIR && gunicorn -b 0.0.0.0:2001 --paste $MAGPIE_CONFIG_DIR/magpie.ini --workers 10 --preload
+# bind to '0.0.0.0' such that any IP employed by the server will retrieve the application endpoint by default
+CMD crond -c $CRON_DIR && pserve $MAGPIE_CONFIG_DIR/magpie.ini bind=0.0.0.0:2001

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN apk update \
     && apk --purge del .build-deps
 
 # install app package source, avoid copying the rest
-COPY ./bin $MAGPIE_DIR/bin/
 COPY ./config/magpie.ini $MAGPIE_CONFIG_DIR/magpie.ini
 COPY ./env/*.env.example $MAGPIE_ENV_DIR/
 COPY ./magpie $MAGPIE_DIR/magpie/

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN pip install --no-dependencies -e $MAGPIE_DIR
 
 # equivalent of `make cron start` without conda env
 # bind to '0.0.0.0' such that any IP employed by the server will retrieve the application endpoint by default
-CMD crond -c $CRON_DIR && pserve $MAGPIE_CONFIG_DIR/magpie.ini bind=0.0.0.0:2001
+CMD crond -c $CRON_DIR && pserve "$MAGPIE_CONFIG_DIR/magpie.ini"

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ start: install start-app  ## start application instance with gunicorn after inst
 .PHONY: start-app
 start-app: stop		## start application instance with gunicorn
 	@echo "Starting $(APP_NAME)..."
-	@bash -c '$(CONDA_CMD) exec gunicorn -b 0.0.0.0:2001 --paste "$(APP_INI)" --preload &'
+	@bash -c '$(CONDA_CMD) pserve "$(APP_INI)" "bind=127.0.0.1:2001" --reload &'
 	@sleep 5
 	@curl -H "Accept: application/json" "http://localhost:2001/version" | grep '"code": 200'
 

--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,10 @@ docker-test: docker-build-magpie	## execute a smoke test of the built image for 
 	curl localhost:2001 | grep "Magpie Administration"
 	docker-compose $(DOCKER_TEST_COMPOSES) stop
 
+.PHONY: docker-test-stop
+docker-test-stop:  ## explicitly stop any running instance that could remain from 'docker-test' target
+	docker-compose $(DOCKER_TEST_COMPOSES) stop
+
 .PHONY: docker-clean
 docker-clean: 	## remove any leftover images from docker target operations
 	docker rmi $(docker images -f "reference=$(MAGPIE_DOCKER_REPO)" -q)

--- a/bin/gunicorn
+++ b/bin/gunicorn
@@ -1,6 +1,0 @@
-import sys
-import gunicorn.app.wsgiapp
-
-
-if __name__ == '__main__':
-    sys.exit(gunicorn.app.wsgiapp.run())

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -84,7 +84,7 @@ prefix = /magpie
 
 [server:main]
 use = egg:gunicorn#main
-host = localhost
+host = 0.0.0.0
 port = 2001
 timeout = 10
 workers = 3

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -26,6 +26,9 @@ pyramid.includes =
 
 ## magpie
 # see all options in 'https://pavics-magpie.readthedocs.io/en/latest/configuration.html'
+# NOTE:
+#   below port definitions must be aligned with the value employed in [server:main] section if running locally
+#   when running within a server architecture, they should be updated accordingly to the desired server endpoint
 magpie.port = 2001
 magpie.url = http://localhost:2001
 
@@ -41,6 +44,7 @@ magpie.secret =
 # magpie.cookie_expire =    # value in seconds, never expire by default
 
 # --- temporary token definition --- (defaults below if omitted)
+# note: token here refers to uuids employed in temporary URL endpoints, not security auth tokens
 magpie.token_expire = 86400
 
 # --- phoenix ---
@@ -49,7 +53,7 @@ magpie.push_phoenix = true
 # --- caching settings ---
 # refer to 'https://pavics-magpie.readthedocs.io/en/latest/performance.html'
 # WARNING:
-#   Caching settings should also be defined in Twitcher INI as it is its application that will
+#   Caching settings should also be defined in Twitcher INI as it is that application that will
 #   receive most requests and actually ask Magpie to resolve ACL/Services for it to allow/deny access
 cache.regions = acl, service
 cache.type = memory
@@ -82,12 +86,19 @@ prefix = /magpie
 # wsgi server configuration
 ###
 
+# NOTE:
+#   Below host/port (or bind) are the parameters that define where the wsgi app will be running locally.
+#   These usually must remain as such even when running within docker in a server architecture, as those
+#   values can be mapped to anything else outside.
+#   When running the web app locally (e.g.: development, debugging, testing) definitions should be aligned
+#   with the values employed in [app:magpie_app] section to make it easier finding the application endpoint.
+#   Setting fewer threads/workers can also be useful when debugging to avoid too many parallel processes.
 [server:main]
 use = egg:gunicorn#main
 host = 0.0.0.0
 port = 2001
 timeout = 10
-workers = 3
+workers = 10
 threads = 4
 
 # used by magpie/alembic for database migration

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -323,6 +323,15 @@ at the start of the :ref:`Configuration` section.
         as possible from the individual parts. The result of these parts (potential using corresponding defaults) will
         have the following format: ``"${MAGPIE_SCHEME}//:${MAGPIE_HOST}:${MAGPIE_PORT}"``.
 
+    .. note::
+        The definition of :envvar:`MAGPIE_URL` or any of its parts to reconstruct it must not be confused with
+        parameters defined in the ``[server:main]`` section of the provided `magpie.ini`_ configuration. The purpose
+        of variable :envvar:`MAGPIE_URL` is to define where the *exposed* application is located, often representing
+        the server endpoint for which the `Magpie` instance is employed. The values of ``host`` and ``port``, or
+        ``bind`` defined in ``[server:main]`` instead correspond to how the WSGI application is exposed (e.g.: through
+        `Gunicorn`_), and so represents a *local* web application that must be mapped one way or another to the server
+        when running within the :ref:`usage_docker`.
+
 .. envvar:: MAGPIE_SCHEME
 
     (Default: ``"http"``)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -790,9 +790,9 @@ Following settings define parameters required by `Twitcher`_ (OWS Security Proxy
 
 Please note that although `Twitcher`_ URL references are needed to configure interactive parameters with `Magpie`, the
 employed `Twitcher`_ instance will also need to have access to `Magpie`'s database in order to allow proper
-:term:`Service` resolution with `magpie.adapter.magpieservice.MagpieServiceStore`. Appropriate database credentials
-must therefore be shared between the two services, as well as :envvar:`MAGPIE_SECRET` value in order for successful
-completion of the handshake during :term:`Authentication` procedure of the request :term:`User` token.
+:term:`Service` resolution with :class:`magpie.adapter.magpieservice.MagpieServiceStore`. Appropriate database
+credentials must therefore be shared between the two services, as well as :envvar:`MAGPIE_SECRET` value in order for
+successful completion of the handshake during :term:`Authentication` procedure of the request :term:`User` token.
 
 
 .. _config_postgres_settings:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,23 +4,32 @@
 Installation
 =============
 
-At the command line::
+At the command line:
+
+.. code-block:: console
 
     pip install magpie
 
-Or, if you have conda installed::
+
+Or, if you have conda installed:
+
+.. code-block:: console
 
     conda create -n magpie
     conda activate magpie
     pip install magpie
 
 
-All above is done automatically with::
+All above is done automatically with:
+
+.. code-block:: console
 
     make install-pkg
 
 
-If you want the full setup for development (including dependencies for test execution), use::
+If you want the full setup for development (including dependencies for test execution), use:
+
+.. code-block:: console
 
     make install-dev
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -14,12 +14,14 @@ We can take advantage of the fact that individual :temr:`Permission` and :term:`
 susceptible to change often and cache the results of these queries.
 
 While not activated by default, it's possible to cache the :term:`Access Control Lists` (ACLs) and :term:`Service`
-retrieval operations for all services, and give it an expiration timeout::
+retrieval operations for all services, and give it an expiration timeout.
 
-  # example Paste Deploy configuration
-  cache.regions = acl
-  cache.type = memory
-  cache.acl.expire = 5  # seconds
+.. code-block:: ini
+
+    # example Paste Deploy configuration
+    cache.regions = acl
+    cache.type = memory
+    cache.acl.expire = 5  # seconds
 
 .. warning::
     Take into consideration that settings must be applied to `Twitcher`_ INI file such that incoming proxy requests

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -9,6 +9,7 @@
 .. _Magpie Docker Images: https://hub.docker.com/r/pavics/magpie/tags
 .. _Magpie REST API: https://pavics-magpie.readthedocs.io/en/latest/api.html
 .. _ncWMS2: https://github.com/Reading-eScience-Centre/ncwms
+.. _Nginx: https://www.nginx.com/
 .. _Ouranosinc/requests-magpie: https://github.com/Ouranosinc/requests-magpie
 .. _Phoenix: https://github.com/bird-house/pyramid-phoenix
 .. _PostgreSQL: https://www.postgresql.org/

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -39,6 +39,7 @@
 
 .. file/source references
 .. _constants.py: https://github.com/Ouranosinc/Magpie/tree/master/magpie/constants.py
+.. _Dockerfile: https://github.com/Ouranosinc/Magpie/tree/master/Dockerfile
 .. _docker-compose.yml.example: https://github.com/Ouranosinc/Magpie/tree/master/docker-compose.yml.example
 .. _magpie-cron: https://github.com/Ouranosinc/Magpie/tree/master/magpie-cron
 .. _magpie.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/magpie.env.example

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -114,7 +114,7 @@ Two `Docker` images are provided for very version released.
 The first, simply named ``pavics/magpie``, is to execute `Magpie` itself as a :ref:`usage_webapp`.
 This simultaneously offers both :ref:`usage_api` and :ref:`usage_ui` interfaces accessible from the configured endpoint.
 Using the same image and an override of the ``CMD``, it is also possible to run any of the :ref:`usage_cli` operations
-with all preinstalled package dependencies. This image is a good reference to understand how to run the
+with all preinstalled package dependencies. This image's `Dockerfile`_ is a good reference to understand how to run the
 :ref:`usage_webapp` locally if desired.
 
 The second `Docker` image consists of `Twitcher`_ code base with integrated :class:`magpie.adapter.MagpieAdapter` such
@@ -122,8 +122,8 @@ that they can communicate between each other. Each tagged `Magpie` version will 
 corresponding `Twitcher`_ image tag as ``pavics/twitcher:magpie-<version>``.
 
 Usually, both images are employed in tandem with a `PostgreSQL`_ database connexion within a ``docker-compose.yml``
-configuration, similar to the following. It is recommended to keep the versions in sync to ensure their
-inter-compatibility. Both images must share some configurations, such as but not limited to, the same
+configuration, similar to the following example. It is recommended to keep the versions in sync to ensure their
+interoperability. Both images must also share some configurations, such as but not limited to, the same
 :envvar:`MAGPIE_SECRET` in order to resolve operations in the same manner. See :ref:`config_twitcher` for
 further details.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -155,6 +155,12 @@ further details.
         - <data-persistence-dir>:/var/lib/postgresql/data/pgdata
 
 
+.. note::
+    Exposing the web application endpoints and ports to the outside world is left to the discretion of the developer
+    maintaining the server. This can be accomplished with basic mapping of ports using ``expose`` keyword, but can
+    also be more securely achieved with ``links`` and specific `Nginx`_ configurations to route locations as desired.
+
+
 .. _usage_tests:
 
 Testing

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,7 +12,9 @@ To use `Magpie` in a project, first you need to install it. To do so, you can do
 For more details or other installation variants and environment preparation, see :ref:`installation` and
 :ref:`configuration` procedures.
 
-After this, you should be able to import the Python package to validate it is installed properly using::
+After this, you should be able to import the Python package to validate it is installed properly using:
+
+.. code-block:: python
 
     import magpie
 
@@ -24,7 +26,9 @@ Web Application
 
 In most situation, you will want to run `Magpie` as a Web Application in combination with some Web Proxy
 (e.g.: `Twitcher`_) that can interrogate `Magpie` about applicable user authentication and permission authorization
-from the HTTP request session. To start the application, you can simply run the following command::
+from the HTTP request session. To start the application, you can simply run the following command.
+
+.. code-block:: console
 
     make start
 
@@ -33,11 +37,10 @@ start a basic Web Application on ``localhost:2001`` with default configurations.
 `PostgreSQL`_ database connection configured prior to running `Magpie` for it to operate (refer to :ref:`Configuration`
 for details).
 
-For running the application, multiple
-`WSGI HTTP Servers` can be employed (e.g.: `Gunicorn`_, `Waitress`_, etc.). They usually all support as input an INI
-configuration file for specific settings. `Magpie` also employs such INI file to customize its behaviour.
-See `Configuration`_ for further details, and please refer to the employed `WSGI` application documentation of your
-liking for their respective setup requirements.
+For running the application, multiple `WSGI HTTP Servers` can be employed (e.g.: `Gunicorn`_, `Waitress`_, etc.).
+They usually all support as input an INI configuration file for specific settings. `Magpie` also employs such INI file
+to customize its behaviour. See `Configuration`_ for further details, and please refer to the employed `WSGI`
+application documentation of your liking for their respective setup requirements.
 
 
 .. _usage_api:
@@ -101,6 +104,57 @@ administrator permissions.
     using the ``Account`` button from the main entrypoint of the `Magpie` UI.
 
 
+.. _usage_docker:
+
+Docker Application
+-----------------------
+
+Two `Docker` images are provided for very version released.
+
+The first, simply named ``pavics/magpie``, is to execute `Magpie` itself as a :ref:`usage_webapp`.
+This simultaneously offers both :ref:`usage_api` and :ref:`usage_ui` interfaces accessible from the configured endpoint.
+Using the same image and an override of the ``CMD``, it is also possible to run any of the :ref:`usage_cli` operations
+with all preinstalled package dependencies. This image is a good reference to understand how to run the
+:ref:`usage_webapp` locally if desired.
+
+The second `Docker` image consists of `Twitcher`_ code base with integrated :class:`magpie.adapter.MagpieAdapter` such
+that they can communicate between each other. Each tagged `Magpie` version will have an automatically deployed and
+corresponding `Twitcher`_ image tag as ``pavics/twitcher:magpie-<version>``.
+
+Usually, both images are employed in tandem with a `PostgreSQL`_ database connexion within a ``docker-compose.yml``
+configuration, similar to the following. It is recommended to keep the versions in sync to ensure their
+inter-compatibility. Both images must share some configurations, such as but not limited to, the same
+:envvar:`MAGPIE_SECRET` in order to resolve operations in the same manner. See :ref:`config_twitcher` for
+further details.
+
+
+.. code-block:: YAML
+
+    magpie:
+      image: pavics/magpie:<version>
+      # ... other Magpie configs ...
+      links:
+        - postgres
+      volumes:
+        - <some-path>/magpie.ini:/opt/local/src/magpie/config/magpie.ini
+
+    twitcher:
+      image: pavics/twitcher:magpie-<version>
+      # ... other Twitcher configs ...
+      links:
+        - postgres
+      volumes:
+        - <some-path>/twitcher.ini:/opt/birdhouse/src/twitcher/twitcher.ini
+
+    postgres:
+      image: postgres:9.6
+      # ... other PostgreSQL configs ...
+      environment:
+        PGDATA: /var/lib/postgresql/data/pgdata
+      volumes:
+        - <data-persistence-dir>:/var/lib/postgresql/data/pgdata
+
+
 .. _usage_tests:
 
 Testing
@@ -123,12 +177,16 @@ are intended to validate older or pre-deployed servers, although with slightly m
 A basic `Magpie` instance can also be initialized by using the `docker-compose.yml.example`_ file.
 Note that the environment variables :envvar:`MAGPIE_TEST_REMOTE_SERVER_URL` and :envvar:`HOST_FQDN`
 must first be defined for the `remote` tests.
-For example, these default values should work with ``docker-compose``::
+For example, these default values should work with ``docker-compose``:
+
+.. code-block:: console
 
     export MAGPIE_TEST_REMOTE_SERVER_URL=http://localhost:2001
     export HOST_FQDN=localhost
 
-To start the tests, you can simply run one of the following command::
+To start the tests, you can simply run one of the following command:
+
+.. code-block:: console
 
     make test
     make test-local
@@ -145,7 +203,9 @@ Customizing Tests
 
 Specific tests can be enabled or disabled by *category*, using variables in ``magpie.env``
 (copy of `magpie.env.example`_). Tests marked with the corresponding variables will be executed or not if they were
-marked as matching that category. Alternatively, you can also provide the conditions directly using::
+marked as matching that category. Alternatively, you can also provide the conditions directly using:
+
+.. code-block:: console
 
     make test-custom SPEC="utils and local"
     make test-custom SPEC="not remote"

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -24,7 +24,7 @@ def main(global_config=None, **settings):  # noqa: F811
     """
     import magpie.constants  # pylint: disable=C0415  # avoid circular import
 
-    # override magpie ini if provided with --paste to gunicorn, otherwise use environment variable
+    # override magpie ini if provided with --paste to gunicorn (or pserve), otherwise use environment variable
     config_env = get_constant("MAGPIE_INI_FILE_PATH", settings, raise_missing=True)
     config_ini = (global_config or {}).get("__file__", config_env)
     if config_ini != config_env:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,12 +12,12 @@ flake8
 isort; python_version < "3.6"
 isort>5; python_version >= "3.6"
 mock
-pylint<2.7; python_version < "3.6"
+pylint<2.7; python_version < "3.6"  # pyup: ignore
 # skip pylint 2.7.3 (issue https://github.com/PyCQA/pylint/issues/4265)
 pylint>=2.7,!=2.7.3,<2.8; python_version >= "3.6"
 pylint-quotes
 # bird-house/twticher, must match version in Dockerfile.adapater
-pyramid-twitcher==0.5.3
+pyramid-twitcher==0.5.3  # pyup: ignore
 pytest
 python2-secrets; python_version <= "3.5"
 tox>=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,9 @@ cornice_swagger>=0.7.0
 dicttoxml
 # futures is required for gunicorn threads
 futures; python_version < "3"
-# flag --paste breaks for >20 unless using pserve
-gunicorn<20
+# flag --paste breaks for >20, must use pserve instead
+gunicorn<20; python_version < "3.5"
+gunicorn>=20; python_version >= "3"
 humanize
 lxml>=3.7
 paste

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ dicttoxml
 # futures is required for gunicorn threads
 futures; python_version < "3"
 # flag --paste breaks for >20, must use pserve instead
-gunicorn<20; python_version < "3.5"
+gunicorn<20; python_version < "3.5"  # pyup: ignore
 gunicorn>=20; python_version >= "3"
 humanize
 lxml>=3.7

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ def _split_requirement(requirement, version=False, python=False, merge=False):
     if python and "python_version" not in requirement:
         return ("", "") if version and not merge else ""
     requirement = requirement.split("python_version")[idx_pyv].replace(";", "").replace("\"", "")
+    requirement = requirement.split(" #")[0]    # ignore comments, space important because 'pkg#egg=' is valid
     op_str = ""
     pkg_name = requirement
     for operator in [">=", ">", "<=", "<", "!=", "==", "="]:


### PR DESCRIPTION
- Update to most recent gunicorn version such that security fixes and performance improvements are integrated (resolve #410)
- General docs updates.

**important** 
needs to be properly updated in daccs/pavics, as the necessary binding changes using `pserve`
config INI with `host = localhost` does not work 
relates to https://github.com/bird-house/birdhouse-deploy/pull/143

