### PR TITLE
Fix config loading

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,18 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing yet.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add explicit typing definitions of configuration files and resolved settings to facilitate discovery of invalid
+  handling of formats or parameters during parsing and startup registration.
+* Apply many documentation updates in both configuration sections and the corresponding configuration example headers.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix ``users`` and ``groups`` registration configurations not respecting update method when conflicting
+  definitions occur. They will respect alphabetical file name order and later ones remain.
+* Fix ``users`` and ``groups`` registration configurations not correctly parsed when multiple files where employed
+  (fixes `#429 <https://github.com/Ouranosinc/Magpie/issues/429>`_).
 
 `3.11.0 <https://github.com/Ouranosinc/Magpie/tree/3.11.0>`_ (2021-05-06)
 ------------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ check-security-only: mkdir-reports	## run security code checks
 		1> >(tee "$(REPORTS_DIR)/check-security.txt")'
 
 .PHONY: check-docs-only
-check-docs-only: check-doc8 check-docf	## run every code documentation checks
+check-docs-only: check-doc8-only check-docf-only	## run every code documentation checks
 
 .PHONY: check-doc8-only
 check-doc8-only: mkdir-reports		## run PEP8 documentation style checks

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,8 @@
-## Combined configuration definition to setup objects at Magpie startup
-## See documentation 'Configuration'
+## Combined Configuration
+## ------------------------
+## Prepare or suppress known entity definitions at Magpie startup.
+## See documentation 'Configuration' for detail about loading method, order and other relevant information.
+## ------------------------
 
 # All following sections are optional.
 # All parameters must fulfill data validation rules as per corresponding API requests.
@@ -13,8 +16,8 @@ providers:
 permissions:
   # see full format details in 'permissions.cfg'
   # for each definition:
-  #   can refer to users and groups that will be created dynamically as needed with corresponding information
-  #   plain user or group name not matched against below entry will create it with defaults for other fields
+  #   can refer to below 'users' and 'groups' that will be created dynamically as needed with corresponding information
+  #   user or group name not matched against any extended definition will be created with defaults for other fields
 
 # extended definitions for users to create
 # default values will be used for missing optional fields
@@ -22,9 +25,9 @@ permissions:
 #   will default to only using the user name and defaults for every other field
 users:
   - username: username  # required if entry provided
-    password:           # optional
-    email:              # optional
-    group: <groupname>  # optional (either one of the groups, or plain string to generate it with defaults)
+    password:           # optional (default: random password of size MAGPIE_PASSWORD_MIN_LENGTH)
+    email:              # optional (default: <username>@mail.com)
+    group: <groupname>  # optional (one of 'groups' entry, or plain string to generate it with defaults, else anonymous)
 
 # extended definitions for groups to create
 # default values will be used for missing optional fields
@@ -32,8 +35,8 @@ users:
 #   will default to only using the group name and defaults for every other field
 groups:
   - name: <groupname>                 # required if entry provided
-    description: <some description>   # optional
-    discoverable: True                # optional
+    description: <some description>   # optional (default: empty)
+    discoverable: True                # optional (default: False)
 
 # Definitions of all the webhooks urls that will be called when creating or deleting a users.
 webhooks:

--- a/config/config.yml
+++ b/config/config.yml
@@ -27,7 +27,8 @@ users:
   - username: username  # required if entry provided
     password:           # optional (default: random password of size MAGPIE_PASSWORD_MIN_LENGTH)
     email:              # optional (default: <username>@mail.com)
-    group: <groupname>  # optional (one of 'groups' entry, or plain string to generate it with defaults, else anonymous)
+    group: <group.name> # optional (default: anonymous, otherwise one of 'groups' matched by 'name')
+                        #          (if group name doesn't exist in 'groups', other parameters use defaults)
 
 # extended definitions for groups to create
 # default values will be used for missing optional fields

--- a/config/permissions.cfg
+++ b/config/permissions.cfg
@@ -25,12 +25,18 @@
 #   Both can also be specified simultaneously to create/remove the same permission for both cases.
 #
 #   Whenever a specified user/group doesn't exist in the database for permission creation, it gets created dynamically.
-#   When this dynamic creation must occur, sections 'users' and 'groups' are looked for possible extended definitions,
-#   as presented in 'config.yml'. Otherwise, the corresponding defaults are employed when no match was found.
+#   When this dynamic creation must occur, sections 'users' and 'groups' are looked for possible extended definitions to
+#   obtain the complete set of parameters applicable for each creation.
 #
-#   The 'users' and 'groups' sections must be at the top-level of the configuration (same as 'permissions').
-#   This is to allow reuse of the same named reference multiple times across many permissions operations without
-#   needing to repeat the whole user/group parameters each time.
+#   Lookup of 'users' and 'groups' is done transversally over all loaded configuration files within the configured
+#   directory. This means that 'users' could be defined in one file, and referenced in another. Note that conflicting
+#   items will override each other according to alphabetical load order of those files.
+#   When no match can be found in any if the respective sections, default parameters of those definitions are employed.
+#
+#   The 'users' and 'groups' sections must be at the top-level of configuration files (same level as 'permissions').
+#   This is to allow reuse of the same named reference multiple times across many 'permissions' items without
+#   needing to repeat the whole set of parameters for corresponding user/group each time.
+#   Examples of such sections are presented in 'config.yml'.
 #
 # Permission:
 # -----------

--- a/config/permissions.cfg
+++ b/config/permissions.cfg
@@ -1,6 +1,7 @@
 # Creates Magpie services/resource permissions with specified configuration values on application startup.
 #
 #   This configuration is parsed after 'providers.cfg' (if found) to allow referencing existing service definitions.
+#   See documentation 'Configuration' for more detail about loading method, order and other relevant information.
 #
 #   - Default location is 'magpie/config/permissions.cfg'.
 #   - Directory location can be overridden with 'MAGPIE_CONFIG_DIR' (using filename 'permissions.cfg')
@@ -11,11 +12,25 @@
 # Parameters:
 # -----------
 #   service:              service name to receive the permission (directly on it if no 'resource' mentioned, must exist)
-#   resource (optional):  tree path of the service's resource (ex: /res1/sub-res2/sub-sub-res3)
-#   type (optional):      resource type employed in case of ambiguity between multiple choices (depends on service type)
-#   user and/or group:    user/group for which to apply the permission (create if missing, see below)
+#   resource:  (optional) tree path of the service's resource (ex: /res1/sub-res2/sub-sub-res3)
+#   type:      (optional) resource type employed in case of ambiguity between multiple choices (depends on service type)
+#   user:                 user for which to apply the modification of permission (skip if omitted or None)
+#   group:                group for which to apply the modification of permission (skip if omitted or None)
 #   permission:           name or object of the permission to be applied (see 'magpie.permissions' for supported values)
 #   action:               one of [create, remove] (default: create)
+#
+# User/Group:
+# -----------
+#   At least one of [user, group] must be provided for every permission entry specified to create/remove.
+#   Both can also be specified simultaneously to create/remove the same permission for both cases.
+#
+#   Whenever a specified user/group doesn't exist in the database for permission creation, it gets created dynamically.
+#   When this dynamic creation must occur, sections 'users' and 'groups' are looked for possible extended definitions,
+#   as presented in 'config.yml'. Otherwise, the corresponding defaults are employed when no match was found.
+#
+#   The 'users' and 'groups' sections must be at the top-level of the configuration (same as 'permissions').
+#   This is to allow reuse of the same named reference multiple times across many permissions operations without
+#   needing to repeat the whole user/group parameters each time.
 #
 # Permission:
 # -----------
@@ -30,14 +45,14 @@
 # Default behaviour:
 # ------------------
 #   - create missing resources if supported by the service (and tree automatically resolvable), then apply permissions.
-#   - create missing user/group if required (default user created: (group: anonymous, password: 12345) ).
+#   - create missing user/group dynamically if required (see above 'User/Group' section).
 #   - if applicable service, user or group is missing, corresponding permissions are ignored and not updated.
 #   - if resolved resource during 'create' action results into an ambiguity (eg: cannot infer which type to apply),
 #     the operation is skipped and the corresponding permission is not applied (use 'type' field to specify it).
 #   - unknown actions are ignored and corresponding permission are not updated.
 #   - unspecified action defaults to 'create'.
 #   - already satisfied permission configurations are left as is
-#     (ie: existing permission to create or non-existing permission to remove are passed)
+#     (ie: already existing permission to create or non-existing permission to remove are considered applied)
 #   - environment variables (formatted as `$name` or `${name}`) are expanded if they are matched in the environment.
 #
 permissions:
@@ -46,6 +61,7 @@ permissions:
     permission: read
     user: anonymous
     action: create
+
   - service: flyingpigeon
     permission: getcapabilities
     group: administrators

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -1,5 +1,7 @@
 # Creates Magpie services with specified configuration values on application startup.
 #
+#   See documentation 'Configuration' for detail about loading method, order and other relevant information.
+#
 #   - Default location is 'magpie/config/providers.cfg'.
 #   - Directory location can be overridden with 'MAGPIE_CONFIG_DIR' (using filename 'providers.cfg')
 #     or can be explicitly overridden with 'MAGPIE_PROVIDERS_CONFIG_PATH' pointing to a valid file.

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -96,7 +96,7 @@ LoggedUserBase = "/users/{}".format(_LOGGED_USER_VALUE)
 
 class UserStatuses(ExtendedEnum):
     """
-    Values for the 'status' field of Users
+    Values for the 'status' field of Users.
     """
     WebhookErrorStatus = 0
     OK = 1  # use 1 for ok since this value is set by default by ziggurat

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -31,9 +31,9 @@ if TYPE_CHECKING:
         ServiceOrResourceType,
         SettingsType,
         Str,
-        WebhookConfig,
-        WebhookConfigSettings,
+        WebhookConfigItem,
         WebhookPayload,
+        WebhookSettings,
         WebhookTemplateParameters
     )
 
@@ -165,7 +165,7 @@ def process_webhook_requests(action, params, update_user_status_on_error=False, 
     # ignore if triggered during application startup, settings not yet loaded
     if not settings:
         return
-    webhooks = settings.get("webhooks", {})  # type: WebhookConfig
+    webhooks = settings.get("webhooks", {})  # type: WebhookSettings
     if not webhooks:
         return
     action_webhooks = webhooks[action]
@@ -237,7 +237,7 @@ def replace_template(params, payload, force_str=False):
 
 
 def send_webhook_request(webhook_config, params, update_user_status_on_error=False):
-    # type: (WebhookConfigSettings, WebhookTemplateParameters, bool) -> None
+    # type: (WebhookConfigItem, WebhookTemplateParameters, bool) -> None
     """
     Sends a single webhook request using the input config.
 
@@ -284,14 +284,14 @@ def setup_webhooks(config_path, settings):
     """
 
     settings["webhooks"] = defaultdict(lambda: [])
-    webhooks_conf = settings["webhooks"]  # type: WebhookConfig
+    webhooks_conf = settings["webhooks"]  # type: WebhookSettings
     if not config_path:
         LOGGER.info("No configuration file provided to load webhook definitions.")
     else:
         LOGGER.info("Loading provided configuration file to setup webhook definitions.")
         webhook_configs = get_all_configs(config_path, "webhooks", allow_missing=True)
 
-        for cfg in webhook_configs:  # type: List[WebhookConfigSettings]
+        for cfg in webhook_configs:
             for webhook in cfg:
                 # Validate the webhook config
                 if not isinstance(webhook, dict):

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -21,7 +21,7 @@ from magpie.register import get_all_configs
 from magpie.utils import CONTENT_TYPE_JSON, FORMAT_TYPE_MAPPING, ExtendedEnum, get_logger, get_settings, raise_log
 
 if TYPE_CHECKING:
-    from typing import List, Optional, Union
+    from typing import Optional, Union
 
     from sqlalchemy.orm.session import Session
 

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -284,7 +284,7 @@ def setup_webhooks(config_path, settings):
     """
 
     settings["webhooks"] = defaultdict(lambda: [])
-    webhooks_conf = settings["webhooks"]  # type: WebhookSettings
+    webhooks_settings = settings["webhooks"]  # type: WebhookSettings
     if not config_path:
         LOGGER.info("No configuration file provided to load webhook definitions.")
     else:
@@ -325,4 +325,4 @@ def setup_webhooks(config_path, settings):
                 # Regroup webhooks by action key
                 webhook_cfg = {k: webhook[k] for k in WEBHOOK_KEYS if k in webhook}  # noqa # ignore optional fields
                 webhook_action = WebhookAction.get(webhook["action"])
-                webhooks_conf[webhook_action].append(webhook_cfg)
+                webhooks_settings[webhook_action].append(webhook_cfg)

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -436,8 +436,7 @@ class RemoteResourceTreeServicePostgresSQL(ResourceTreeServicePostgreSQL):
     @classmethod
     def build_subtree_strut(cls, result, *args, **kwargs):
         """
-        Returns a dictionary in form of
-        {node:Resource, children:{node_id: Resource}}
+        Returns a dictionary in form of ``{node:Resource, children:{node_id: Resource}}``.
 
         :param result:
         :return:

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -52,21 +52,21 @@ if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
     from magpie.typedefs import (
+        JSON,
         AnyCookiesType,
         AnyResolvedSettings,
         CombinedConfig,
         CookiesOrSessionType,
         GroupsConfig,
         GroupsSettings,
-        JSON,
         MultiConfigs,
         PermissionConfigItem,
         PermissionsConfig,
         ServicesConfig,
         ServicesSettings,
+        Str,
         UsersConfig,
-        UsersSettings,
-        Str
+        UsersSettings
     )
 
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -32,9 +32,8 @@ if TYPE_CHECKING:
     from typing import Collection, Dict, List, Optional, Set, Tuple, Type, Union
 
     from pyramid.request import Request
-    from ziggurat_foundations.permissions import PermissionTuple  # noqa
 
-    from magpie.typedefs import AccessControlListType, ConfigDict, ServiceOrResourceType, Str
+    from magpie.typedefs import AccessControlListType, ServiceConfiguration, ServiceOrResourceType, Str
 
 
 class ServiceMeta(type):
@@ -225,7 +224,7 @@ class ServiceInterface(object):
         return path_parts[svc_idx + 1:]
 
     def get_config(self):
-        # type: () -> ConfigDict
+        # type: () -> ServiceConfiguration
         """
         Obtains the custom configuration of the registered service.
         """
@@ -738,7 +737,7 @@ class ServiceTHREDDS(ServiceInterface):
         self._config = None
 
     def get_config(self):
-        # type: () -> ConfigDict
+        # type: () -> ServiceConfiguration
         if self._config is not None:
             return self._config
 

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -118,7 +118,7 @@ if TYPE_CHECKING:
         "group": Optional[Str],
     })
     # generic 'configuration' field under a service that supports it
-    ServiceConfigurationParam = Dict[Str, Union[Str, List[JSON], JSON]]
+    ServiceConfiguration = Dict[Str, Union[Str, List[JSON], JSON]]
     ServiceConfigItem = TypedDict("ServiceConfigItem", {
         "url": Str,
         "title": Str,
@@ -127,7 +127,7 @@ if TYPE_CHECKING:
         # must use 'asbool' since technically a bool-like string from config
         "public": bool,
         "c4i": bool,
-        "configuration": Optional[ServiceConfigurationParam],
+        "configuration": Optional[ServiceConfiguration],
     })
 
     # individual sections directly loaded from config files (BEFORE resolution)

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -84,6 +84,7 @@ if TYPE_CHECKING:
     AccessControlListType = List[AccessControlEntryType]
 
     # registered configurations
+    ConfigPerm = TypedDict("ConfigPerm", {""})
     ConfigItem = Dict[Str, JSON]
     ConfigList = List[ConfigItem]
     ConfigDict = Dict[Str, Union[Str, ConfigItem, ConfigList, JSON]]

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -83,17 +83,83 @@ if TYPE_CHECKING:
     AccessControlEntryType = Union[Tuple[Str, Str, Str], Str]
     AccessControlListType = List[AccessControlEntryType]
 
-    # registered configurations
-    ConfigPerm = TypedDict("ConfigPerm", {""})
-    ConfigItem = Dict[Str, JSON]
-    ConfigList = List[ConfigItem]
-    ConfigDict = Dict[Str, Union[Str, ConfigItem, ConfigList, JSON]]
+    # note:
+    #   For all following items 'Settings' suffix refer to loaded definitions AFTER resolution.
+    #   When 'Config' suffix is used, it instead refers to raw definitions BEFORE resolution.
 
     WebhookPayload = Union[JSON, Str]
+    # items that are substituted dynamically in the payload during webhook handling (eg: {{user.name}})
     WebhookTemplateParameters = TypedDict("WebhookTemplateParameters", {
         param: AnyValue for param in WEBHOOK_TEMPLATE_PARAMS
     })
-    WebhookConfigSettings = TypedDict("WebhookConfigSettings", {
+    WebhookConfigItem = TypedDict("WebhookConfigItem", {
         "name": Str, "action": Str, "method": Str, "url": Str, "format": Str, "payload": WebhookPayload
     })
-    WebhookConfig = Dict[WebhookAction, List[WebhookConfigSettings]]
+
+    # registered configurations
+    PermissionConfigItem = TypedDict("PermissionConfigItem", {
+        "service": Str,
+        "resource": Optional[Str],
+        "type": Optional[Str],
+        "user": Optional[Str],
+        "group": Optional[Str],
+        "permission": Union[Str, PermissionDict],
+        "action": Optional[Str],  # create/remove
+    })
+    GroupConfigItem = TypedDict("GroupConfigItem", {
+        "name": Str,
+        "description": Optional[Str],
+        "discoverable": bool,  # must use 'asbool' since technically a bool-like string from config
+    })
+    UserConfigItem = TypedDict("UserConfigItem", {
+        "username": Str,
+        "password": Optional[Str],
+        "email": Optional[Str],
+        "group": Optional[Str],
+    })
+    # generic 'configuration' field under a service that supports it
+    ServiceConfigurationParam = Dict[Str, Union[Str, List[JSON], JSON]]
+    ServiceConfigItem = TypedDict("ServiceConfigItem", {
+        "url": Str,
+        "title": Str,
+        "type": Str,
+        "sync_type": Optional[Str],
+        # must use 'asbool' since technically a bool-like string from config
+        "public": bool,
+        "c4i": bool,
+        "configuration": Optional[ServiceConfigurationParam],
+    })
+
+    # individual sections directly loaded from config files (BEFORE resolution)
+    ServicesConfig = Dict[Str, ServiceConfigItem]  # only section already formatted the same way as resolved settings
+    PermissionsConfig = List[PermissionConfigItem]
+    GroupsConfig = List[GroupConfigItem]
+    UsersConfig = List[UserConfigItem]
+    WebhooksConfig = List[WebhookConfigItem]
+
+    # when loaded from multiple distinct configuration files, but fetching only a specific section
+    # they are never mixed together in this case, so use distinct list per section
+    MultiConfigs = Union[  # see as 'OneOf' below list
+        List[ServicesConfig],
+        List[PermissionsConfig],
+        List[UsersConfig],
+        List[GroupsConfig],
+        List[WebhooksConfig],
+    ]
+
+    # combined configuration of respective sections above all within the same file (config.yml)
+    CombinedConfig = TypedDict("CombinedConfig", {
+        "providers": Optional[ServicesConfig],
+        "permissions": Optional[PermissionsConfig],
+        "users": Optional[UsersConfig],
+        "groups": Optional[GroupsConfig],
+        "webhooks": Optional[WebhooksConfig],
+    })
+
+    # mappings after loading of multiple files for relevant sections (AFTER resolution)
+    PermissionsSettings = Dict[Str, PermissionConfigItem]
+    ServicesSettings = Dict[Str, ServiceConfigItem]
+    GroupsSettings = Dict[Str, GroupConfigItem]
+    UsersSettings = Dict[Str, UserConfigItem]
+    WebhookSettings = Dict[WebhookAction, List[WebhookConfigItem]]  # many webhooks aggregated by action
+    AnyResolvedSettings = Union[PermissionsSettings, ServicesSettings, GroupsSettings, UsersSettings, WebhookSettings]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,15 +17,15 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-replace = 
+replace =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-	
-	* Nothing yet.
-	
+
+	* Nothing new for the moment.
+
 	`{new_version} <https://github.com/Ouranosinc/Magpie/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	------------------------------------------------------------------------------------
 
@@ -39,7 +39,7 @@ ignore-path = docs/_build,docs/autoapi
 [flake8]
 ignore = E501,W291,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	.git,
 	__pycache__,
 	build,
@@ -70,7 +70,7 @@ combine_as_imports = false
 branch = true
 source = ./
 include = magpie/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
@@ -78,7 +78,7 @@ omit =
 	magpie/typedefs.py
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise AssertionError
 	raise NotImplementedError
@@ -92,10 +92,10 @@ exclude_lines =
 	LOGGER.log
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict-markers
 	--tb=native
-markers = 
+markers =
 	adapter: magpie adapter functional operations
 	defaults: magpie default users, providers and views
 	register: magpie methods employed in 'register' module

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -1084,6 +1084,8 @@ class Interface_MagpieAPI_UsersAuth(UserTestCase, BaseTestCase):
     @runner.MAGPIE_TEST_USERS
     def test_UpdateUsers_status_Forbidden_AnyNonAdmin(self):
         """
+        Test that user status updates can only be executed by an administrator.
+
         .. seealso::
             - :meth:`Interface_MagpieAPI_AdminAuth.test_UpdateUser_status`
         """

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -491,39 +491,39 @@ def test_register_process_permissions_from_multiple_files():
     Use the *raw* format expected from loaded configuration files to validate their parsing at the same time.
     """
 
-    with utils.wrapped_call("magpie.register._process_permissions") as mock_process_perms:
-        cfg1 = {
-            "users": [
-                {"username": "usr1"},
-                {"username": "usr2", "group": "grp2"},
-                {"username": "usr3"}  # will be overridden
-            ],
-            "groups": [
-                {"name": "grp1", "discoverable": True},
-                {"name": "grp2"}
-            ],
-            "permissions": [
-                {"permission": "perm1", "action": "remove", "service": "svc", "user": "y"},
-                # applied to both user/group, default 'create' operation, group created with only string (no entry)
-                {"permission": "perm2", "user": "x", "group": "grp3", "service": "svc"},
-                # referenced group is a definition
-                {"permission": "perm3", "action": "create", "service": "svc", "group": "grp1"}
-            ]
-        }
-        cfg2 = {
-            "permissions": [
-                {"permission": "perm4", "group": "grp2"}  # referred from other file
-            ],
-            "users": [
-                {"username": "usr3", "group": "grp3"}  # should override one in first config
-            ]
-        }
+    cfg1 = {
+        "users": [
+            {"username": "usr1"},
+            {"username": "usr2", "group": "grp2"},
+            {"username": "usr3"}  # will be overridden
+        ],
+        "groups": [
+            {"name": "grp1", "discoverable": True},
+            {"name": "grp2"}
+        ],
+        "permissions": [
+            {"permission": "perm1", "action": "remove", "service": "svc", "user": "y"},
+            # applied to both user/group, default 'create' operation, group created with only string (no entry)
+            {"permission": "perm2", "user": "x", "group": "grp3", "service": "svc"},
+            # referenced group is a definition
+            {"permission": "perm3", "action": "create", "service": "svc", "group": "grp1"}
+        ]
+    }
+    cfg2 = {
+        "permissions": [
+            {"permission": "perm4", "group": "grp2"}  # referred from other file
+        ],
+        "users": [
+            {"username": "usr3", "group": "grp3"}  # should override one in first config
+        ]
+    }
 
-        with tempfile2.TemporaryDirectory() as tmpdir:
-            with open(os.path.join(tmpdir, "cfg1.json"), "w") as cfg1_file:
-                json.dump(cfg1, cfg1_file)
-            with open(os.path.join(tmpdir, "cfg2.json"), "w") as cfg2_file:
-                json.dump(cfg2, cfg2_file)
+    with tempfile2.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "cfg1.json"), "w") as cfg1_file:
+            json.dump(cfg1, cfg1_file)
+        with open(os.path.join(tmpdir, "cfg2.json"), "w") as cfg2_file:
+            json.dump(cfg2, cfg2_file)
+        with utils.wrapped_call("magpie.register._process_permissions") as mock_process_perms:
             with utils.wrapped_call("magpie.register.get_admin_cookies", side_effect=lambda *_, **__: {}):
                 register.magpie_register_permissions_from_config(tmpdir, "http://dontcare.com")
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -9,12 +9,14 @@ Tests for `magpie.register` operations.
 """
 import copy
 import json
+import os
 import shutil
 import tempfile
 import unittest
 from typing import TYPE_CHECKING
 
 import mock
+import six
 
 from magpie import register
 from magpie.constants import get_constant
@@ -24,6 +26,11 @@ from magpie.permissions import Access, Permission, PermissionSet, Scope
 from magpie.services import ServiceAPI, ServiceTHREDDS
 from magpie.utils import CONTENT_TYPE_JSON
 from tests import interfaces, runner, utils
+
+if six.PY2:
+    from backports import tempfile as tempfile2  # noqa  # Python 2
+else:
+    tempfile2 = tempfile  # pylint: disable=C0103,invalid-name
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
@@ -464,12 +471,72 @@ class TestRegister(interfaces.BaseAdminTestCase, unittest.TestCase):
 
 @runner.MAGPIE_TEST_LOCAL
 @runner.MAGPIE_TEST_REGISTER
-def test_register_make_config_registry():
+def test_register_resolve_config_registry():
     # pylint: disable=W0212
-    assert register._make_config_registry(None, "whatever") == {}
-    assert register._make_config_registry([], "whatever") == {}
-    assert register._make_config_registry([{}], "whatever") == {}
-    assert register._make_config_registry([None], "whatever") == {}  # noqa
+    assert register._resolve_config_registry(None, "whatever") == {}
+    assert register._resolve_config_registry([], "whatever") == {}
+    assert register._resolve_config_registry([{}], "whatever") == {}
+    assert register._resolve_config_registry([None], "whatever") == {}  # noqa
     config = [{"key": "val1", "name": "name1"}, {"key": "val2"}]
     mapped = {"val1": {"key": "val1", "name": "name1"}, "val2": {"key": "val2"}}
-    assert register._make_config_registry(config, "key") == mapped
+    assert register._resolve_config_registry(config, "key") == mapped
+
+
+@runner.MAGPIE_TEST_LOCAL
+@runner.MAGPIE_TEST_REGISTER
+def test_register_process_permissions_from_multiple_files():
+    """
+    Validate that resolution using multiple configuration files retrieves definition across all of them.
+
+    Use the *raw* format expected from loaded configuration files to validate their parsing at the same time.
+    """
+
+    with utils.wrapped_call("magpie.register._process_permissions") as mock_process_perms:
+        cfg1 = {
+            "users": [
+                {"username": "usr1"},
+                {"username": "usr2", "group": "grp2"},
+                {"username": "usr3"}  # will be overridden
+            ],
+            "groups": [
+                {"name": "grp1", "discoverable": True},
+                {"name": "grp2"}
+            ],
+            "permissions": [
+                {"permission": "perm1", "action": "remove", "service": "svc", "user": "y"},
+                # applied to both user/group, default 'create' operation, group created with only string (no entry)
+                {"permission": "perm2", "user": "x", "group": "grp3", "service": "svc"},
+                # referenced group is a definition
+                {"permission": "perm3", "action": "create", "service": "svc", "group": "grp1"}
+            ]
+        }
+        cfg2 = {
+            "permissions": [
+                {"permission": "perm4", "group": "grp2"}  # referred from other file
+            ],
+            "users": [
+                {"username": "usr3", "group": "grp3"}  # should override one in first config
+            ]
+        }
+
+        with tempfile2.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "cfg1.json"), "w") as cfg1_file:
+                json.dump(cfg1, cfg1_file)
+            with open(os.path.join(tmpdir, "cfg2.json"), "w") as cfg2_file:
+                json.dump(cfg2, cfg2_file)
+            with utils.wrapped_call("magpie.register.get_admin_cookies", side_effect=lambda *_, **__: {}):
+                register.magpie_register_permissions_from_config(tmpdir, "http://dontcare.com")
+
+    assert mock_process_perms.call_count == 2
+    expect_users = {"usr1": cfg1["users"][0], "usr2": cfg1["users"][1], "usr3": cfg2["users"][0]}
+    expect_groups = {"grp1": cfg1["groups"][0], "grp2": cfg1["groups"][1]}
+
+    perms, _, _, users, groups = mock_process_perms.call_args_list[0].args
+    assert perms == cfg1["permissions"]
+    assert users == expect_users
+    assert groups == expect_groups
+
+    perms, _, _, users, groups = mock_process_perms.call_args_list[1].args
+    assert perms == cfg2["permissions"]
+    assert users == expect_users
+    assert groups == expect_groups


### PR DESCRIPTION
# Features / Changes
* Add explicit typing definitions of configuration files and resolved settings to facilitate discovery of invalid
  handling of formats or parameters during parsing and startup registration.
* Apply many documentation updates in both configuration sections and the corresponding configuration example headers.

# Bug Fixes
* Fix ``users`` and ``groups`` registration configurations not respecting update method when conflicting
  definitions occur. They will respect alphabetical file name order and later ones remain.
* Fix ``users`` and ``groups`` registration configurations not correctly parsed when multiple files where employed (fixes #429).