### PR TITLE
Webhook config multi

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Bug Fixes
   Empty ``{}``, ``""``, ``null`` payloads, or even omitting the parameter itself, will now be allowed since this
   can be valid use cases when sending requests without any body.
 * Fix ``url`` parameter of `Webhooks` not allowing empty string for path portion of the URL.
+* Fix incorrect documentation of ``name`` parameter handling for `Webhooks` in configurations files (single or multiple)
+  with respect to the code. Duplicate entries are not enforced, but will be warned in logs.
 
 `3.11.0 <https://github.com/Ouranosinc/Magpie/tree/3.11.0>`_ (2021-05-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@ Features / Changes
 * Add explicit typing definitions of configuration files and resolved settings to facilitate discovery of invalid
   handling of formats or parameters during parsing and startup registration.
 * Apply many documentation updates in both configuration sections and the corresponding configuration example headers.
+* Add ``MAGPIE_WEBHOOKS_CONFIG_PATH`` configuration setting / environment variable that allows potentially using
+  multiple configuration files for `Webhooks`. This parameter is notably important for developers that where using the
+  ``MAGPIE_PROVIDERS_CONFIG_PATH`` or ``MAGPIE_PERMISSIONS_CONFIG_PATH`` settings to load multiple files, as they
+  cannot be combined with single configuration provided by ``MAGPIE_CONFIG_PATH``, which was the only supported way to
+  provide `Webhooks` definitions.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
@@ -19,6 +24,10 @@ Bug Fixes
   definitions occur. They will respect alphabetical file name order and later ones remain.
 * Fix ``users`` and ``groups`` registration configurations not correctly parsed when multiple files where employed
   (fixes `#429 <https://github.com/Ouranosinc/Magpie/issues/429>`_).
+* Fix inappropriate validation of ``payload`` field when loading `Webhooks`.
+  Empty ``{}``, ``""``, ``null`` payloads, or even omitting the parameter itself, will now be allowed since this
+  can be valid use cases when sending requests without any body.
+* Fix ``url`` parameter of `Webhooks` not allowing empty string for path portion of the URL.
 
 `3.11.0 <https://github.com/Ouranosinc/Magpie/tree/3.11.0>`_ (2021-05-06)
 ------------------------------------------------------------------------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -188,6 +188,10 @@ field.
     The ``webhook`` section allows to define external connectors to which `Magpie` should send requests following
     certain events. These are described in further details in :ref:`config_webhook` section.
 
+.. versionadded:: 3.12
+    Variable :envvar:`MAGPIE_WEBHOOKS_CONFIG_PATH` was added and will act in a similar fashion as their providers and
+    permissions counterparts, to load definitions from multiple configuration files.
+
 
 .. _config_constants:
 
@@ -236,6 +240,9 @@ These settings can be used to specify where to find other settings through custo
     Setting this variable will only look for files named *exactly* as above, unless the more explicit definitions
     of ``MAGPIE_<type>_CONFIG_PATH`` variables are also provided.
 
+    .. warning::
+        This setting is ignored if :envvar:`MAGPIE_CONFIG_PATH` is specified.
+
 .. envvar:: MAGPIE_PROVIDERS_CONFIG_PATH
 
     (Default: ``${MAGPIE_CONFIG_DIR}/providers.cfg``)
@@ -254,6 +261,9 @@ These settings can be used to specify where to find other settings through custo
         Loading order of multiple files was **NOT** guaranteed prior to this version.
 
         This could lead to some entries to be loaded in inconsistent order.
+
+    .. warning::
+        This setting is ignored if :envvar:`MAGPIE_CONFIG_PATH` is specified.
 
 .. envvar:: MAGPIE_PERMISSIONS_CONFIG_PATH
 
@@ -277,6 +287,24 @@ These settings can be used to specify where to find other settings through custo
         and these conflicts will be correctly handled according to configuration loading methodology.
         Later versions are safe to assume alphabetical loading order.
 
+    .. warning::
+        This setting is ignored if :envvar:`MAGPIE_CONFIG_PATH` is specified.
+
+.. envvar:: MAGPIE_WEBHOOKS_CONFIG_PATH
+
+    (Default: ``None``)
+
+    .. versionadded:: 3.12
+
+    Path where to find a file or a directory of multiple configuration files where ``webhooks`` section(s) that
+    provide definitions for :ref:`config_webhook` can be loaded from.
+
+    Examples of such configuration section is presented in the example :ref:`config_file`.
+    When multiple files are available from a directory path, they are loaded by name alphabetically.
+
+    .. warning::
+        This setting is ignored if :envvar:`MAGPIE_CONFIG_PATH` is specified.
+
 .. envvar:: MAGPIE_CONFIG_PATH
 
     Path where to find a combined YAML configuration file which can include ``providers``, ``permissions``, ``users``
@@ -290,9 +318,10 @@ These settings can be used to specify where to find other settings through custo
 
     .. warning::
         When this setting is defined, all other combinations of :envvar:`MAGPIE_CONFIG_DIR`,
-        :envvar:`MAGPIE_PERMISSIONS_CONFIG_PATH` and :envvar:`MAGPIE_PROVIDERS_CONFIG_PATH` are effectively
-        ignored in favour of definitions in this file. It is not possible to employ the :ref:`config_file` at
-        the same time as multi-configuration loading from a directory.
+        :envvar:`MAGPIE_PERMISSIONS_CONFIG_PATH`, :envvar:`MAGPIE_PROVIDERS_CONFIG_PATH` and
+        :envvar:`MAGPIE_WEBHOOKS_CONFIG_PATH` are effectively ignored in favour of definitions in this file.
+        It is not possible to employ the single :ref:`config_file` at the same time as multi-configuration file
+        loading strategy from a directory.
 
 .. envvar:: MAGPIE_INI_FILE_PATH
 
@@ -950,7 +979,7 @@ instance URL. For this reason, the values of :envvar:`MAGPIE_URL`, :envvar:`MAGP
 be considered.
 
 .. seealso::
-    Refer to :ref:`auth_requests` and :ref:`auth_providers` for details.
+    Refer to :ref:`authn_requests` and :ref:`authn_providers` for details.
 
 .. _config_auth_wso2:
 
@@ -966,10 +995,10 @@ To use `WSO2`_ authentication provider, following variables must be set:
 - :envvar:`WSO2_SSL_VERIFY`
 
 To configure your `Magpie` instance as a trusted application for ``WSO2`` (and therefore retrieve values of above
-parameters), please refer to `WSO2_doc`_.
+parameters), please refer to |WSO2_doc|_.
 
 .. seealso::
-    Refer to :ref:`auth_requests` and :ref:`auth_providers` for details.
+    Refer to :ref:`authn_requests` and :ref:`authn_providers` for details.
 
 
 .. _config_webhook:
@@ -1045,9 +1074,13 @@ Configuration parameters are all required unless explicitly indicated to have a 
 .. |webhook_param_payload| replace:: ``payload``
 
 - | |webhook_param_payload|_
+  | (Default: ``None``)
 
-  Format of the payload that will be sent in the request body of the triggered :term:`Webhook`.
+  Structure of the payload that will be sent in the request body of the triggered :term:`Webhook`.
   The payload can be anything between a literal string or a JSON/YAML formatted structure.
+
+  .. versionchanged:: 3.12
+    If the field is undefined or resolved as ``None``, it will be accepted for request with an empty body.
 
   .. note::
     The payload can employ parameters that contain template variables using brace characters ``{{<variable>}}``.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1034,7 +1034,10 @@ Configuration parameters are all required unless explicitly indicated to have a 
 
 - | |webhook_param_name|_
 
-  The name of the :term:`Webhook` for reference. Must be unique.
+  The name of the :term:`Webhook` for reference.
+
+  It is not required for this name to be unique, but it is recommended for reporting and reference purposes.
+  If duplicates are found, a warning will be emitted, but all entries will still be registered.
 
 .. _webhook_param_action:
 .. |webhook_param_action| replace:: ``action``

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -288,7 +288,7 @@ def setup_webhooks(config_path, settings):
     if not config_path:
         LOGGER.info("No configuration file provided to load webhook definitions.")
     else:
-        LOGGER.info("Loading provided configuration file to setup webhook definitions.")
+        LOGGER.info("Loading provided configuration files to setup webhook definitions.")
         webhook_configs = get_all_configs(config_path, "webhooks", allow_missing=True)
 
         for cfg in webhook_configs:

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -42,11 +42,11 @@ WEBHOOK_KEYS_REQUIRED = {
     "name",
     "action",
     "method",
-    "url",
-    "payload"
+    "url"
 }
 WEBHOOK_KEYS_OPTIONAL = {
-    "format"
+    "format",
+    "payload"
 }
 WEBHOOK_KEYS = WEBHOOK_KEYS_REQUIRED | WEBHOOK_KEYS_OPTIONAL
 
@@ -280,7 +280,22 @@ def webhook_update_error_status(user_name):
 def setup_webhooks(config_path, settings):
     # type: (Optional[Str], SettingsType) -> None
     """
-    Prepares the webhook settings for the application based on definitions retrieved from the configuration file.
+    Prepares and validates :term:`Webhook` settings for the application based on definitions in configuration file(s).
+
+    Following execution, all validated :term:`Webhook` configurations will have every parameters defined in
+    :py:data:`WEBHOOK_KEYS`, whether optional or mandatory. Required parameters in :py:data:`WEBHOOK_KEYS_REQUIRED`
+    are explicitly validated for defined value and raise if missing. Parameters from :py:data:`WEBHOOK_KEYS_OPTIONAL`
+    are defaulted to ``None`` if missing.
+
+    Any :term:`Webhook` failing validation will raise the whole configuration and not apply any changes to
+    the :paramref:`settings`. Format validation is applied to some specific parameters to anticipate and raise
+    definitions guaranteed to be erroneous to avoid waiting until runtime for them to fail upon their trigger event.
+
+    .. seealso::
+        Documentation in :ref:`config_webhook`.
+
+    :param config_path: a single file or directory path where configuration file(s) with ``webhook`` section.
+    :param settings: modified settings in-place with added valid webhooks.
     """
 
     settings["webhooks"] = defaultdict(lambda: [])
@@ -300,7 +315,9 @@ def setup_webhooks(config_path, settings):
                         exception=ValueError, logger=LOGGER
                     )
                 LOGGER.debug("Validating webhook: %s", webhook.get("name", "<undefined-name>"))
-                if set(webhook) != WEBHOOK_KEYS_REQUIRED or not all(value for value in webhook.values()):
+                param_missing = any(not value for key, value in webhook.items() if key in WEBHOOK_KEYS_REQUIRED)
+                param_required = set(webhook) - WEBHOOK_KEYS_OPTIONAL
+                if param_required != WEBHOOK_KEYS_REQUIRED or param_missing:
                     raise_log(
                         "Missing or invalid key/value in webhook config from the config file {}".format(config_path),
                         exception=ValueError, logger=LOGGER
@@ -316,11 +333,13 @@ def setup_webhooks(config_path, settings):
                         exception=ValueError, logger=LOGGER
                     )
                 url_parsed = urlparse(webhook["url"])
-                if not all([url_parsed.scheme, url_parsed.netloc, url_parsed.path]):
+                if not all([url_parsed.scheme, url_parsed.netloc, url_parsed.path or url_parsed.path == ""]):
                     raise_log(
                         "Invalid URL {} found in webhook from config file {}".format(webhook["url"], config_path),
                         exception=ValueError, logger=LOGGER
                     )
+                for option in WEBHOOK_KEYS_OPTIONAL:
+                    webhook.setdefault(option, None)
 
                 # Regroup webhooks by action key
                 webhook_cfg = {k: webhook[k] for k in WEBHOOK_KEYS if k in webhook}  # noqa # ignore optional fields

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -305,7 +305,7 @@ def setup_webhooks(config_path, settings):
     else:
         LOGGER.info("Loading provided configuration files to setup webhook definitions.")
         webhook_configs = get_all_configs(config_path, "webhooks", allow_missing=True)
-
+        webhook_names = set()  # allow duplicate names, but warn about them because of ambiguity
         for cfg in webhook_configs:
             for webhook in cfg:
                 # Validate the webhook config
@@ -340,6 +340,12 @@ def setup_webhooks(config_path, settings):
                     )
                 for option in WEBHOOK_KEYS_OPTIONAL:
                     webhook.setdefault(option, None)
+
+                if webhook["name"] in webhook_names:
+                    LOGGER.warning("Detected duplicate names in webhooks configurations [%s]. "
+                                   "All will still be registered, but references by name could lead to confusion.",
+                                   webhook["name"])
+                webhook_names.add(webhook["name"])
 
                 # Regroup webhooks by action key
                 webhook_cfg = {k: webhook[k] for k in WEBHOOK_KEYS if k in webhook}  # noqa # ignore optional fields

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -75,7 +75,9 @@ def main(global_config=None, **settings):  # noqa: F811
     magpie_register_permissions_from_config(perm_cfg, db_session=db_session)
 
     print_log("Register webhook configurations...", LOGGER)
-    setup_webhooks(combined_config, settings)
+    webhook_cfg = combined_config or get_constant("MAGPIE_WEBHOOKS_CONFIG_PATH", settings, default_value="",
+                                                  raise_missing=False, raise_not_set=False, print_missing=True)
+    setup_webhooks(webhook_cfg, settings)
 
     print_log("Running configurations setup...", LOGGER)
     patch_magpie_url(settings)

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -4,6 +4,8 @@
 """
 Magpie is a service for AuthN and AuthZ based on Ziggurat-Foundations.
 """
+import logging
+
 from pyramid.settings import asbool
 from pyramid_beaker import set_cache_regions_from_settings
 
@@ -62,6 +64,12 @@ def main(global_config=None, **settings):  # noqa: F811
     print_log("Register service providers...", logger=LOGGER)
     combined_config = get_constant("MAGPIE_CONFIG_PATH", settings, default_value=None,
                                    raise_missing=False, raise_not_set=False, print_missing=True)
+    if combined_config:
+        print_log("Setting 'MAGPIE_CONFIG_PATH' detected for single file configuration, "
+                  "following settings for multi-file configuration will be ignored: "
+                  "[MAGPIE_PROVIDERS_CONFIG_PATH, MAGPIE_PERMISSIONS_CONFIG_PATH, MAGPIE_WEBHOOKS_CONFIG_PATH]",
+                  logger=LOGGER, level=logging.WARNING)
+
     push_phoenix = asbool(get_constant("PHOENIX_PUSH", settings, settings_name="phoenix.push", default_value=False,
                                        raise_missing=False, raise_not_set=False, print_missing=True))
     prov_cfg = combined_config or get_constant("MAGPIE_PROVIDERS_CONFIG_PATH", settings, default_value="",

--- a/magpie/constants.py
+++ b/magpie/constants.py
@@ -37,6 +37,7 @@ MAGPIE_PROVIDERS_CONFIG_PATH = os.getenv(
     "MAGPIE_PROVIDERS_CONFIG_PATH", "{}/providers.cfg".format(MAGPIE_CONFIG_DIR))
 MAGPIE_PERMISSIONS_CONFIG_PATH = os.getenv(
     "MAGPIE_PERMISSIONS_CONFIG_PATH", "{}/permissions.cfg".format(MAGPIE_CONFIG_DIR))
+MAGPIE_WEBHOOKS_CONFIG_PATH = os.getenv("MAGPIE_WEBHOOKS_CONFIG_PATH")
 MAGPIE_CONFIG_PATH = os.getenv("MAGPIE_CONFIG_PATH")  # default None, require explicit specification
 MAGPIE_INI_FILE_PATH = os.getenv(
     "MAGPIE_INI_FILE_PATH", "{}/magpie.ini".format(MAGPIE_CONFIG_DIR))

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -540,3 +540,31 @@ def test_register_process_permissions_from_multiple_files():
     assert perms == cfg2["permissions"]
     assert users == expect_users
     assert groups == expect_groups
+
+
+@runner.MAGPIE_TEST_LOCAL
+@runner.MAGPIE_TEST_REGISTER
+def test_multiple_webhook_files():
+    cfg1 = {
+        "webhooks": [
+            {
+                "name": "test_webhook_1",
+                "action": WebhookAction.DELETE_GROUP_PERMISSION.value,
+                "method": "POST",
+                "url": update_webhook_url,
+                "payload": {"data": group_payload, "action": WebhookAction.DELETE_GROUP_PERMISSION.value}
+            }
+        ]
+    }
+
+    with utils.wrapped_call("magpie.register._process_permissions") as mock_process_perms:
+
+
+
+        with tempfile2.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "cfg1.json"), "w") as cfg1_file:
+                json.dump(cfg1, cfg1_file)
+            with open(os.path.join(tmpdir, "cfg2.json"), "w") as cfg2_file:
+                json.dump(cfg2, cfg2_file)
+            with utils.wrapped_call("magpie.register.get_admin_cookies", side_effect=lambda *_, **__: {}):
+                register.magpie_register_permissions_from_config(tmpdir, "http://dontcare.com")

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -540,31 +540,3 @@ def test_register_process_permissions_from_multiple_files():
     assert perms == cfg2["permissions"]
     assert users == expect_users
     assert groups == expect_groups
-
-
-@runner.MAGPIE_TEST_LOCAL
-@runner.MAGPIE_TEST_REGISTER
-def test_multiple_webhook_files():
-    cfg1 = {
-        "webhooks": [
-            {
-                "name": "test_webhook_1",
-                "action": WebhookAction.DELETE_GROUP_PERMISSION.value,
-                "method": "POST",
-                "url": update_webhook_url,
-                "payload": {"data": group_payload, "action": WebhookAction.DELETE_GROUP_PERMISSION.value}
-            }
-        ]
-    }
-
-    with utils.wrapped_call("magpie.register._process_permissions") as mock_process_perms:
-
-
-
-        with tempfile2.TemporaryDirectory() as tmpdir:
-            with open(os.path.join(tmpdir, "cfg1.json"), "w") as cfg1_file:
-                json.dump(cfg1, cfg1_file)
-            with open(os.path.join(tmpdir, "cfg2.json"), "w") as cfg2_file:
-                json.dump(cfg2, cfg2_file)
-            with utils.wrapped_call("magpie.register.get_admin_cookies", side_effect=lambda *_, **__: {}):
-                register.magpie_register_permissions_from_config(tmpdir, "http://dontcare.com")


### PR DESCRIPTION
Identified while working on #430 

This will be of good interest when integrating with `cowbird`. 

## main change
* Add ``MAGPIE_WEBHOOKS_CONFIG_PATH`` configuration setting / environment variable that allows potentially using
  multiple configuration files for `Webhooks`. This parameter is notably important for developers that where using the
  ``MAGPIE_PROVIDERS_CONFIG_PATH`` or ``MAGPIE_PERMISSIONS_CONFIG_PATH`` settings to load multiple files, as they
  cannot be combined with single configuration provided by ``MAGPIE_CONFIG_PATH``, which was the only supported way to
  provide `Webhooks` definitions.

Other updates are related to above.
