### PR TITLE
MAGPIE_USER_REGISTRATION_ENABLED default to false when omitted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,15 @@ Changes
 
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
-* Nothing new for the moment.
+
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* N/A
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix lookup error of setting ``MAGPIE_USER_REGISTRATION_ENABLED`` when omitted from configuration during
+  user email update (fixes `#459 <https://github.com/Ouranosinc/Magpie/issues/459>`_).
 
 `3.14.0 <https://github.com/Ouranosinc/Magpie/tree/3.14.0>`_ (2021-07-14)
 ------------------------------------------------------------------------------------

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -194,8 +194,10 @@ def update_user(user, request, new_user_name=None, new_password=None, new_email=
     # FIXME: disable email edit when self-registration is enabled to avoid not having any confirmation of new email
     #   (see https://github.com/Ouranosinc/Magpie/issues/436)
     update_email_admin_only = False
-    if update_email and asbool(get_constant("MAGPIE_USER_REGISTRATION_ENABLED", request)):
-        update_email_admin_only = True
+    if update_email:
+        update_email_admin_only = asbool(get_constant("MAGPIE_USER_REGISTRATION_ENABLED", request,
+                                                      default_value=False, print_missing=True,
+                                                      raise_missing=False, raise_not_set=False))
 
     # user name/status change is admin-only operation
     if update_username or update_status or update_email_admin_only:

--- a/magpie/ui/user/views.py
+++ b/magpie/ui/user/views.py
@@ -78,7 +78,9 @@ class UserViews(BaseViews):
         user_info["groups"] = public_groups
         # FIXME: disable email edit when self-registration is enabled to avoid not having any confirmation of new email
         #   (see https://github.com/Ouranosinc/Magpie/issues/436)
-        user_info["user_edit_email"] = not asbool(get_constant("MAGPIE_USER_REGISTRATION_ENABLED", self.request))
+        user_info["user_edit_email"] = not asbool(get_constant("MAGPIE_USER_REGISTRATION_ENABLED", self.request,
+                                                               default_value=False, print_missing=True,
+                                                               raise_missing=False, raise_not_set=False))
         user_info["user_with_error"] = schemas.UserStatuses.get(user_info["status"]) != schemas.UserStatuses.OK
         # reset error messages/flags
         user_info["error_message"] = ""


### PR DESCRIPTION
fix resolution of missing MAGPIE_USER_REGISTRATION_ENABLED setting during user email update (fixes #459)

tested manually by removing the setting from config and checking that update worked + warning was printed indicating that default (false) was used because setting was not found.