### PR TITLE
fix and improve handling of parameter update of service API request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,12 +9,18 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* N/A
+* Improve API update operation of ``Service`` for allowed fields in order to accept body containing only the
+  new value for the custom ``configuration`` without additional parameters. It was not possible to
+  update ``configuration`` by itself, as ``service_name`` and ``service_url`` were independently validated
+  for new values beforehand.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix lookup error of setting ``MAGPIE_USER_REGISTRATION_ENABLED`` when omitted from configuration during
   user email update (fixes `#459 <https://github.com/Ouranosinc/Magpie/issues/459>`_).
+* Fix erasure value ``None`` (JSON ``null``) validation when updating ``Service`` field ``configuration`` to
+  properly distinguish explicitly provided ``None`` against default value when the field is omitted.
+* Fix incorrect OpenAPI body schema indicated in response of ``POST /services`` request.
 
 `3.14.0 <https://github.com/Ouranosinc/Magpie/tree/3.14.0>`_ (2021-07-14)
 ------------------------------------------------------------------------------------

--- a/magpie/api/management/service/service_utils.py
+++ b/magpie/api/management/service/service_utils.py
@@ -91,7 +91,7 @@ def create_service(service_name, service_type, service_url, service_push, servic
                                msg_on_fail=s.Services_POST_ForbiddenResponseSchema.description,
                                content=format_service(service, show_private_url=True))
     return ax.valid_http(http_success=HTTPCreated, detail=s.Services_POST_CreatedResponseSchema.description,
-                         content={"service": format_service(service, show_private_url=True)})
+                         content={"service": format_service(service, show_private_url=True, show_configuration=True)})
 
 
 def get_services_by_type(service_type, db_session):

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1387,9 +1387,13 @@ class Services_POST_RequestBodySchema(BaseRequestSchemaAPI):
     body = Services_POST_BodySchema()
 
 
+class Services_POST_CreatedResponseBodySchema(BaseResponseBodySchema):
+    service = ServiceDetailSchema()
+
+
 class Services_POST_CreatedResponseSchema(BaseResponseSchemaAPI):
     description = "Service registration to db successful."
-    body = BaseResponseBodySchema(code=HTTPOk.code, description=description)
+    body = Services_POST_CreatedResponseBodySchema(code=HTTPCreated.code, description=description)
 
 
 class Services_POST_BadRequestResponseSchema(BaseResponseSchemaAPI):
@@ -1423,6 +1427,10 @@ class Services_POST_InternalServerErrorResponseSchema(BaseResponseSchemaAPI):
 
 
 class Service_PATCH_RequestBodySchema(colander.MappingSchema):
+    description = (
+        "New parameters to apply for service update. Any combination of new values can be provided. "
+        "At least one field must be provided with a different value than the current service parameters."
+    )
     service_name = colander.SchemaNode(
         colander.String(),
         description="New service name to apply to service specified in path",
@@ -1439,7 +1447,11 @@ class Service_PATCH_RequestBodySchema(colander.MappingSchema):
         validator=colander.url,
     )
     service_push = PhoenixServicePushOption()
-    configuration = ServiceConfigurationSchema()
+    configuration = ServiceConfigurationSchema(
+        description="New service configuration to be applied. "
+                    "Must be a valid JSON object definition different than the currently active configuration. "
+                    "If explicitly provided with null value, instead erase the current service configuration."
+    )
 
 
 class Service_PATCH_RequestSchema(BaseRequestSchemaAPI):


### PR DESCRIPTION
## changes 

* Improve API update operation of ``Service`` for allowed fields in order to accept body containing only the
  new value for the custom ``configuration`` without additional parameters. It was not possible to
  update ``configuration`` by itself, as ``service_name`` and ``service_url`` were independently validated
  for new values beforehand.
* Fix erasure value ``None`` (JSON ``null``) validation when updating ``Service`` field ``configuration`` to
  properly distinguish explicitly provided ``None`` against default value when the field is omitted.
* Fix incorrect OpenAPI body schema indicated in response of ``POST /services`` request.
* Updated tests for new use cases.