### PR TITLE
pin sqlalchemy & related packages to avoid issue in ziggurat_foundations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,13 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Pin ``sqlalchemy``, ``sqlalchemy_utils``, ``zope.sqlalchemy`` and ``ziggurat_foundations`` to specific package
+  versions to avoid underlying issues when combining dependencies with `Twitcher` (in ``Docker.adapter``).
+  Some definitions at lower level in ``ziggurat_foundations`` cause an issue when moving to ``sqlalchemy>=1.4``,
+  which was allowed since `Twitcher` ``v0.5.5``.
+
 `3.15.0 <https://github.com/Ouranosinc/Magpie/tree/3.15.0>`_ (2021-08-11)
 ------------------------------------------------------------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,11 @@ Bug Fixes
 * Pin ``sqlalchemy``, ``sqlalchemy_utils``, ``zope.sqlalchemy`` and ``ziggurat_foundations`` to specific package
   versions to avoid underlying issues when combining dependencies with `Twitcher` (in ``Docker.adapter``).
   Some definitions at lower level in ``ziggurat_foundations`` cause an issue when moving to ``sqlalchemy>=1.4``,
-  which was allowed since `Twitcher` ``v0.5.5``.
+  which was allowed since `Twitcher` ``v0.5.5``
+  (see `ergo/ziggurat_foundations#71 <https://github.com/ergo/ziggurat_foundations/issues/71>`_).
+  It is temporarily addressed by reducing requirements of `Twitcher`
+  (see `bird-house/twitcher#108 <https://github.com/bird-house/twitcher/pull/108>`_) and referencing its associated
+  release ``v0.5.6`` in the ``Docker.adapter``, which downgrades needed packages when extending it with `Magpie`.
 
 `3.15.0 <https://github.com/Ouranosinc/Magpie/tree/3.15.0>`_ (2021-08-11)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug Fixes
   It is temporarily addressed by reducing requirements of `Twitcher`
   (see `bird-house/twitcher#108 <https://github.com/bird-house/twitcher/pull/108>`_) and referencing its associated
   release ``v0.5.6`` in the ``Docker.adapter``, which downgrades needed packages when extending it with `Magpie`.
+* Use ``pip`` legacy and faster resolver as per
+  `pypa/pip#9187 (comment) <https://github.com/pypa/pip/issues/9187#issuecomment-853091201>`_
+  since current one is endlessly failing to resolve development packages (linting tools from ``check`` targets).
 
 `3.15.0 <https://github.com/Ouranosinc/Magpie/tree/3.15.0>`_ (2021-08-11)
 ------------------------------------------------------------------------------------

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -3,7 +3,7 @@
 #   docker run will need to override ini file with mounted volume
 #   using config 'twitcher.adapter = magpie.adapter.MagpieAdapter'
 #
-FROM birdhouse/twitcher:v0.5.5
+FROM birdhouse/twitcher:v0.5.6
 LABEL Description="Configures MagpieAdapter on top of Twitcher application."
 LABEL Maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL Vendor="CRIM"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,9 @@ linkcheck_ignore = [
     "CHANGES.rst",
     r"docs/\w+.rst",
     "https://pcmdi.llnl.gov/",  # works, but very often causes false-positive 'broken' links
-    r"github.com/*#issuecomment*"  # issue comment anchors not resolved
+]
+linkcheck_anchors_ignore = [
+    r".*issuecomment.*"   # github issue comment anchors not resolved
 ]
 linkcheck_timeout = 20
 linkcheck_retries = 5

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,7 @@ linkcheck_ignore = [
     "CHANGES.rst",
     r"docs/\w+.rst",
     "https://pcmdi.llnl.gov/",  # works, but very often causes false-positive 'broken' links
+    r"github.com/*#issuecomment*"  # issue comment anchors not resolved
 ]
 linkcheck_timeout = 20
 linkcheck_retries = 5

--- a/magpie/alembic/versions/2021-04-16_dea413e13a8a_pending_users_and_statuses.py
+++ b/magpie/alembic/versions/2021-04-16_dea413e13a8a_pending_users_and_statuses.py
@@ -1,5 +1,5 @@
 """
-Pending Users and statuses
+Pending Users and statuses.
 
 Create table for pending users, and update existing user statuses '0' to '2' for WebhookError
 

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -112,6 +112,8 @@ class ManagementViews(AdminRequests, BaseViews):
     @view_config(route_name="edit_user", renderer="templates/edit_user.mako")
     def edit_user(self):
         """
+        Edit the fields of any referenced user profile by an administrator.
+
         .. seealso::
             - :meth:`magpie.ui.user.views.UserViews.edit_current_user` for corresponding operation by user self-update
         """

--- a/magpie/ui/user/views.py
+++ b/magpie/ui/user/views.py
@@ -67,6 +67,8 @@ class UserViews(BaseViews):
     @view_config(route_name="edit_current_user", renderer="templates/edit_current_user.mako", permission=Authenticated)
     def edit_current_user(self):
         """
+        Edit the own fields of the current user profile (self-update information).
+
         .. seealso::
             - :meth:`magpie.ui.management.views.ManagementViews.edit_user` for corresponding operation by administrator
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,17 +1,21 @@
 -r requirements-doc.txt
-autopep8
+autopep8; python_version < "3"
+autopep8>=1.5.4; python_version >= "3.6"
 backports.tempfile; python_version < "3"
 bandit==1.6.2
-bump2version
-codacy-coverage
+bump2version==1.0.0
+codacy-coverage>=1.3.11
 coverage==5.5; python_version < "3"
-coverage; python_version >= "3"
-doc8
+coverage==5.5,<5.6; python_version >= "3"
+doc8; python_version < "3.6"
+doc8>=0.8; python_version >= "3.6"
 docformatter==1.4
-flake8
+flake8; python_version < "3.6"
+flake8>=3.8.3,<3.9; python_version >= "3.6"
 isort; python_version < "3.6"
-isort>5; python_version >= "3.6"
-mock
+isort>5.5; python_version >= "3.6"
+mock; python_version < "3.6"
+mock>4; python_version >= "3.6"
 pylint<2.7; python_version < "3.6"  # pyup: ignore
 # skip pylint 2.7.3 (issue https://github.com/PyCQA/pylint/issues/4265)
 pylint>=2.7,!=2.7.3,<2.8; python_version >= "3.6"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ codacy-coverage
 coverage==5.5; python_version < "3"
 coverage; python_version >= "3"
 doc8
-docformatter
+docformatter==1.4
 flake8
 isort; python_version < "3.6"
 isort>5; python_version >= "3.6"

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,7 +1,7 @@
 # these are doc-only requirements
 # we actually need to install all requirements during docs build because of OpenAPI generation
 # (see 'docs/conf.py')
-pycodestyle
+pycodestyle==2.6.0; python_version >= "3.6"
 # sphinx-autoapi dropped 3.5 support at 1.3.0
 # latest to fullfil requirements, but that is not the main doc builder version
 sphinx-autoapi; python_version < "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,13 @@
-alembic>=1.3.0,<1.5
 aenum; python_version < "3.6"
+alembic>=1.3.0,<1.5
+# TODO: remove when merged
+#   until fix merged and deployed (https://github.com/authomatic/authomatic/pull/195)
+#   old variants:
+#       -e git+https://github.com/fmigneault/authomatic.git@httplib-port#egg=Authomatic
+#       https://github.com/fmigneault/authomatic/archive/httplib-port.zip#egg=Authomatic-1.0.1
+#   new authomatic handles openid install correctly
+#   leave http port until merged:
+authomatic[OpenID] @ https://github.com/fmigneault/authomatic/archive/httplib-port.zip
 bcrypt>=3.1.6
 beaker
 colander
@@ -36,9 +44,11 @@ six>=1.12.0
 # 'sqlalchemy_utils' with 'Python>=3.7' could use 'sqlalchemy==1.4' when patched:
 #   https://github.com/kvesteri/sqlalchemy-utils/issues/474
 #   https://github.com/kvesteri/sqlalchemy-utils/issues/505
-sqlalchemy<1.4
+#sqlalchemy<1.4
+sqlalchemy==1.3.22
 sqlalchemy_utils<0.36.4; python_version < "3"
-sqlalchemy_utils!=0.36.8; python_version >= "3"
+#sqlalchemy_utils!=0.36.8; python_version >= "3"
+sqlalchemy_utils==0.37.8; python_version >= "3"
 threddsclient==0.4.1; python_version < "3"
 threddsclient>=0.4.1; python_version >= "3"
 transaction
@@ -47,15 +57,7 @@ typing; python_version < "3"
 typing_extensions; python_version < "3.8"
 wheel
 webob
-ziggurat-foundations>=0.8.3
+ziggurat_foundations==0.8.4
 zope.interface>=4.7.2,<5
 zope.sqlalchemy<1.2; python_version < "3.7"
-zope.sqlalchemy; python_version >= "3.7"
-# TODO: remove when merged
-#   until fix merged and deployed (https://github.com/authomatic/authomatic/pull/195)
-#   old variants:
-#       -e git+https://github.com/fmigneault/authomatic.git@httplib-port#egg=Authomatic
-#       https://github.com/fmigneault/authomatic/archive/httplib-port.zip#egg=Authomatic-1.0.1
-#   new authomatic handles openid install correctly
-#   leave http port until merged:
-authomatic[OpenID] @ https://github.com/fmigneault/authomatic/archive/httplib-port.zip
+zope.sqlalchemy==1.3; python_version >= "3.7"


### PR DESCRIPTION
When combining Magpie and Twitcher in the docker adapter image, Twitcher's more recent dependencies about `sqlalchmy` (https://github.com/bird-house/twitcher/blob/202377532a921940143af1d360bc0e51d938dad2/requirements.txt), which forces `SQLAlchemy>=1.4` causes a mismatch with expected versions in Mapgie, which where tested with `SQLAlchemy==1.3`. 

More specifically, package `ziggurat_foundations` causes the following error : 
```
>Textual column expression 'depth' should be explicitly declared with text('depth'), or use column('depth') for more specificity
```

when reaching the following code `ziggurat_foundations.models.services.resource_tree_postgres.ResourceTreeServicePostgreSQL.from_parent_deeper`
```python
query = db_session.query(cls.model, "depth", "sorting", "path")
```

Depends on https://github.com/ergo/ziggurat_foundations/issues/71 to move back to `SQLAlchemy==1.4`. 
