### PR TITLE
add type query parameter to filter requested services/resource tree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,16 @@ Features / Changes
   because ``Services`` that are not required (since they are not currently being displayed by the tab-panel view) can
   be skipped entirely, removing the need to compute their underlying ``Resource`` and ``Permissions`` tree hierarchy.
 
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Replace invalid schema definitions using old ``combined`` query parameter by ``resolve`` query parameter actually
+  employed by request views.
+* Apply ``resolve=true`` query parameter to UI page sub-request when resolving inherited user/group permissions in
+  order to display the highest priority ``Permission`` for each corresponding ``Resource`` in the tree hierarchy.
+  Without this option, the first permission was displayed based on naming ordering methodology, which made it more
+  confusing for administrators to understand how effective permissions could be obtained
+  (fixes `#463 <https://github.com/Ouranosinc/Magpie/issues/463>`_).
+
 `3.15.1 <https://github.com/Ouranosinc/Magpie/tree/3.15.1>`_ (2021-09-29)
 ------------------------------------------------------------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,11 @@ Changes
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Add ``type`` query parameter to multiple requests returning ``Services`` or ``Resources`` regrouped by ``ServiceType``
-  to limit listing in responses and optimise some operations where only a subset of details are needed. Using this
-  feature, some ``Permissions`` listing in UI pages are faster because ``Services`` not required since they are not
-  being displayed are skipped entirely, removing the need to compute their underlying ``Resource`` and ``Permissions``
-  tree hierarchy.
+  for a given ``User`` or ``Group`` in order to limit listing in responses and optimise some operations where only a
+  subset of details are needed.
+* Using new ``type`` query to filter ``ServiceType``, improve ``Permissions`` listing in UI pages with faster processing
+  because ``Services`` that are not required (since they are not currently being displayed by the tab-panel view) can
+  be skipped entirely, removing the need to compute their underlying ``Resource`` and ``Permissions`` tree hierarchy.
 
 `3.15.1 <https://github.com/Ouranosinc/Magpie/tree/3.15.1>`_ (2021-09-29)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,16 +15,23 @@ Features / Changes
 * Using new ``type`` query to filter ``ServiceType``, improve ``Permissions`` listing in UI pages with faster processing
   because ``Services`` that are not required (since they are not currently being displayed by the tab-panel view) can
   be skipped entirely, removing the need to compute their underlying ``Resource`` and ``Permissions`` tree hierarchy.
+* Add various test utility improvements to parse and retrieve ``Permissions`` from HTML pages combo-boxes to facilitate
+  development and increase validation of UI functionalities.
+  This will also help for futures tests (relates to `#193 <https://github.com/Ouranosinc/Magpie/issues/193>`_).
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Replace invalid schema definitions using old ``combined`` query parameter by ``resolve`` query parameter actually
-  employed by request views.
+  employed by request views in order to properly report this query parameter in the `OpenAPI` specification.
 * Apply ``resolve=true`` query parameter to UI page sub-request when resolving inherited user/group permissions in
   order to display the highest priority ``Permission`` for each corresponding ``Resource`` in the tree hierarchy.
   Without this option, the first permission was displayed based on naming ordering methodology, which made it more
   confusing for administrators to understand how effective permissions could be obtained
   (fixes `#463 <https://github.com/Ouranosinc/Magpie/issues/463>`_).
+* Fix a situation where the response from the API for ``GET /users/{}/resources`` endpoint would not correctly
+  list `Resolved Permissions` only for the top-most ``Resource`` in the hierarchy (i.e.: ``Service``) due to different
+  resolution methodologies applied between both types. This does **NOT** affect `Effective Resolution` which has its
+  own algorithm for access resolution to ``Resources``.
 
 `3.15.1 <https://github.com/Ouranosinc/Magpie/tree/3.15.1>`_ (2021-09-29)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,14 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add ``type`` query parameter to multiple requests returning ``Services`` or ``Resources`` regrouped by ``ServiceType``
+  to limit listing in responses and optimise some operations where only a subset of details are needed. Using this
+  feature, some ``Permissions`` listing in UI pages are faster because ``Services`` not required since they are not
+  being displayed are skipped entirely, removing the need to compute their underlying ``Resource`` and ``Permissions``
+  tree hierarchy.
+
 `3.15.1 <https://github.com/Ouranosinc/Magpie/tree/3.15.1>`_ (2021-09-29)
 ------------------------------------------------------------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,15 +9,21 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* Add ``type`` query parameter to multiple requests returning ``Services`` or ``Resources`` regrouped by ``ServiceType``
-  for a given ``User`` or ``Group`` in order to limit listing in responses and optimise some operations where only a
-  subset of details are needed.
+* Add ``type`` query parameter to multiple requests returning ``Services`` or ``Resources`` regrouped
+  by ``ServiceType``, either in general or for a given ``User`` or ``Group`` in order to limit listing in responses
+  and optimise some operations where only a subset of details are needed.
+* When requesting specific ``type`` with new query parameters, the relevant sections will always be added to the
+  response content, even when no ``Service`` are to be returned when ``User`` as no `Direct` or `Inherited` permissions
+  on it. This is to better illustrate that ``type`` was properly interpreted and indicate that nothing was found.
 * Using new ``type`` query to filter ``ServiceType``, improve ``Permissions`` listing in UI pages with faster processing
   because ``Services`` that are not required (since they are not currently being displayed by the tab-panel view) can
   be skipped entirely, removing the need to compute their underlying ``Resource`` and ``Permissions`` tree hierarchy.
 * Add various test utility improvements to parse and retrieve ``Permissions`` from HTML pages combo-boxes to facilitate
   development and increase validation of UI functionalities.
   This will also help for futures tests (relates to `#193 <https://github.com/Ouranosinc/Magpie/issues/193>`_).
+* Reapply ``list`` (prior name in ``2.x`` releases) as permitted alternative query parameter name to official
+  query parameter ``flatten`` for requests that support it.
+* Sort items by type and name for better readability of returned content by the various ``Service`` endpoints.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/magpie/api/management/group/group_utils.py
+++ b/magpie/api/management/group/group_utils.py
@@ -20,7 +20,7 @@ from magpie.api import schemas as s
 from magpie.api.management.group.group_formats import format_group
 from magpie.api.management.resource.resource_formats import format_resource
 from magpie.api.management.resource.resource_utils import check_valid_service_or_resource_permission
-from magpie.api.management.service.service_formats import format_service, format_service_resources
+from magpie.api.management.service import service_formats as sf
 from magpie.api.webhooks import WebhookAction, get_permission_update_params, process_webhook_requests
 from magpie.permissions import PermissionSet, PermissionType, format_permissions
 from magpie.services import SERVICE_TYPE_DICT
@@ -46,20 +46,24 @@ def get_all_group_names(db_session):
     return group_names
 
 
-def get_group_resources(group, db_session):
-    # type: (models.Group, Session) -> JSON
+def get_group_resources(group, db_session, service_types=None):
+    # type: (models.Group, Session, Optional[List[Str]]) -> JSON
     """
     Get formatted JSON body describing all service resources the ``group`` as permissions on.
     """
     json_response = {}
+    if service_types is None:
+        service_types = list(SERVICE_TYPE_DICT)
     for svc in list(ResourceService.all(models.Service, db_session=db_session)):
+        svc_type = str(svc.type)
+        if svc_type not in service_types:
+            continue
         svc_perms = get_group_service_permissions(group=group, service=svc, db_session=db_session)
         svc_name = str(svc.resource_name)
-        svc_type = str(svc.type)
         if svc_type not in json_response:
             json_response[svc_type] = {}
         res_perm_dict = get_group_service_resources_permissions_dict(group=group, service=svc, db_session=db_session)
-        json_response[svc_type][svc_name] = format_service_resources(
+        json_response[svc_type][svc_name] = sf.format_service_resources(
             svc,
             db_session=db_session,
             service_perms=svc_perms,
@@ -274,24 +278,28 @@ def delete_group_resource_permission_response(group, resource, permission, db_se
     return ax.valid_http(http_success=HTTPOk, detail=s.GroupServicePermission_DELETE_OkResponseSchema.description)
 
 
-def get_group_services(resources_permissions_dict, db_session):
-    # type: (JSON, Session) -> JSON
+def get_group_services(resources_permissions_dict, db_session, service_types=None):
+    # type: (JSON, Session, Optional[List[Str]]) -> JSON
     """
     Nest and regroup the resource permissions under corresponding root service types.
     """
     grp_svc_dict = {}
+    if service_types is None:
+        service_types = list(SERVICE_TYPE_DICT)
     for res_id, perms in resources_permissions_dict.items():
         svc = ResourceService.by_resource_id(resource_id=res_id, db_session=db_session)
         svc_type = str(svc.type)
+        if svc_type not in service_types:
+            continue
         svc_name = str(svc.resource_name)
         if svc_type not in grp_svc_dict:
             grp_svc_dict[svc_type] = {}
-        grp_svc_dict[svc_type][svc_name] = format_service(svc, perms, show_private_url=False)
+        grp_svc_dict[svc_type][svc_name] = sf.format_service(svc, perms, show_private_url=False)
     return grp_svc_dict
 
 
-def get_group_services_response(group, db_session):
-    # type: (models.Group, Session) -> HTTPException
+def get_group_services_response(group, db_session, service_types=None):
+    # type: (models.Group, Session, Optional[List[Str]]) -> HTTPException
     """
     Get validated response of services the group has permissions on.
 
@@ -301,7 +309,7 @@ def get_group_services_response(group, db_session):
     res_perm_dict = get_group_resources_permissions_dict(group,
                                                          resource_types=[models.Service.resource_type_name],
                                                          db_session=db_session)
-    grp_svc_json = ax.evaluate_call(lambda: get_group_services(res_perm_dict, db_session),
+    grp_svc_json = ax.evaluate_call(lambda: get_group_services(res_perm_dict, db_session, service_types=service_types),
                                     http_error=HTTPInternalServerError,
                                     msg_on_fail=s.GroupServices_InternalServerErrorResponseSchema.description,
                                     content={"group": format_group(group, basic_info=True)})
@@ -343,7 +351,7 @@ def get_group_service_permissions_response(group, service, db_session):
         lambda: format_permissions(get_group_service_permissions(group, service, db_session), PermissionType.APPLIED),
         http_error=HTTPInternalServerError,
         msg_on_fail=s.GroupServicePermissions_GET_InternalServerErrorResponseSchema.description,
-        content={"group": format_group(group, basic_info=True), "service": format_service(service)})
+        content={"group": format_group(group, basic_info=True), "service": sf.format_service(service)})
     return ax.valid_http(http_success=HTTPOk, content=svc_perms_found,
                          detail=s.GroupServicePermissions_GET_OkResponseSchema.description)
 
@@ -369,7 +377,7 @@ def get_group_service_resources_response(group, service, db_session):
     """
     svc_perms = get_group_service_permissions(group=group, service=service, db_session=db_session)
     res_perms = get_group_service_resources_permissions_dict(group=group, service=service, db_session=db_session)
-    svc_res_json = format_service_resources(
+    svc_res_json = sf.format_service_resources(
         service=service,
         db_session=db_session,
         service_perms=svc_perms,

--- a/magpie/api/management/group/group_views.py
+++ b/magpie/api/management/group/group_views.py
@@ -8,6 +8,7 @@ from magpie.api import requests as ar
 from magpie.api import schemas as s
 from magpie.api.management.group import group_formats as gf
 from magpie.api.management.group import group_utils as gu
+from magpie.api.management.service import service_utils as su
 from magpie.constants import get_constant
 
 
@@ -133,7 +134,9 @@ def get_group_services_view(request):
     List all services a group has permission on.
     """
     group = ar.get_group_matchdict_checked(request)
-    return gu.get_group_services_response(group, request.db)
+    service_types = ar.get_query_param(request, ["type", "types"], default="")
+    service_types = su.filter_service_types(service_types)
+    return gu.get_group_services_response(group, request.db, service_types=service_types)
 
 
 @s.GroupServicePermissionsAPI.get(schema=s.GroupServicePermissions_GET_RequestSchema,
@@ -215,7 +218,9 @@ def get_group_resources_view(request):
     List all resources a group has permission on.
     """
     group = ar.get_group_matchdict_checked(request)
-    grp_res_json = ax.evaluate_call(lambda: gu.get_group_resources(group, request.db),
+    service_types = ar.get_query_param(request, ["type", "types"], default="")
+    service_types = su.filter_service_types(service_types)
+    grp_res_json = ax.evaluate_call(lambda: gu.get_group_resources(group, request.db, service_types=service_types),
                                     fallback=lambda: request.db.rollback(),
                                     http_error=HTTPInternalServerError, content={"group": repr(group)},
                                     msg_on_fail=s.GroupResources_GET_InternalServerErrorResponseSchema.description)

--- a/magpie/api/management/service/service_utils.py
+++ b/magpie/api/management/service/service_utils.py
@@ -25,7 +25,7 @@ from magpie.utils import get_logger
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Iterable, Optional
+    from typing import Iterable, List, Optional
 
     from pyramid.httpexceptions import HTTPException
     from sqlalchemy.orm.session import Session
@@ -120,3 +120,18 @@ def add_service_getcapabilities_perms(service, db_session, group_name=None):
                                                            Permission.GET_CAPABILITIES.value, db_session)
         if perm is None:  # not set, create it
             create_group_resource_permission_response(group, service, Permission.GET_CAPABILITIES.value, db_session)
+
+
+def filter_service_types(service_query):
+    # type: (Optional[Str]) -> List[Str]
+    """
+    Obtains all valid case-insensitive service-type names from a filtered comma-separated list.
+    """
+    if service_query:
+        service_types = [
+            svc_type.lower() for svc_type in service_query.split(",")
+            if svc_type.strip() and svc_type.lower() in SERVICE_TYPE_DICT
+        ]
+    else:
+        service_types = list(SERVICE_TYPE_DICT)
+    return service_types

--- a/magpie/api/management/service/service_utils.py
+++ b/magpie/api/management/service/service_utils.py
@@ -122,16 +122,21 @@ def add_service_getcapabilities_perms(service, db_session, group_name=None):
             create_group_resource_permission_response(group, service, Permission.GET_CAPABILITIES.value, db_session)
 
 
-def filter_service_types(service_query):
-    # type: (Optional[Str]) -> List[Str]
+def filter_service_types(service_query, default_services=False):
+    # type: (Optional[Str], bool) -> Optional[List[Str]]
     """
     Obtains all valid case-insensitive service-type names from a filtered comma-separated list.
+
+    :param service_query: query string or service type(s) comma-separated to parse.
+    :param default_services: specify if the complete list of known service-types must be returned if no query to parse.
+    :returns: parsed service-types if query was provided, or None by default, or all known service-types if requested.
     """
     if service_query:
         service_types = [
             svc_type.lower() for svc_type in service_query.split(",")
             if svc_type.strip() and svc_type.lower() in SERVICE_TYPE_DICT
         ]
-    else:
-        service_types = list(SERVICE_TYPE_DICT)
-    return service_types
+        return service_types
+    if default_services:
+        return list(SERVICE_TYPE_DICT)
+    return None

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -197,7 +197,7 @@ def get_user_resources_view(request):
         json_res = {}
         perm_type = PermissionType.INHERITED if inherit_groups_perms else PermissionType.DIRECT
         services = ResourceService.all(models.Service, db_session=db)
-        services = services.filter(models.Service.type.in_(service_types))
+        services = services.filter(models.Service.type.in_(service_types))  # pylint: disable=E1101,no-member
         # add service-types so they are ordered and listed if no service of that type was defined
         for svc_type in sorted(service_types):
             json_res[svc_type] = {}

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -11,8 +11,8 @@ from magpie import models
 from magpie.api import exception as ax
 from magpie.api import requests as ar
 from magpie.api import schemas as s
-from magpie.api.management.service.service_formats import format_service_resources
-from magpie.api.management.service.service_utils import filter_service_types
+from magpie.api.management.service import service_formats as sf
+from magpie.api.management.service import service_utils as su
 from magpie.api.management.user import user_formats as uf
 from magpie.api.management.user import user_utils as uu
 from magpie.api.webhooks import WebhookAction, process_webhook_requests
@@ -183,7 +183,7 @@ def get_user_resources_view(request):
     resolve_groups_perms = asbool(ar.get_query_param(request, ["resolve", "resolved"]))
     filtered_perms = asbool(ar.get_query_param(request, ["filter", "filtered"]))
     service_types = ar.get_query_param(request, ["type", "types"], default="")
-    service_types = filter_service_types(service_types)
+    service_types = su.filter_service_types(service_types)
     user = ar.get_user_matchdict_checked_or_logged(request)
     db = request.db
 
@@ -211,7 +211,7 @@ def get_user_resources_view(request):
             # always allow admin to view full resource tree, unless explicitly requested to be filtered
             # otherwise (non-admin), only add details if there is at least one resource permission (any level)
             if (is_admin and not filtered_perms) or (svc_perms or res_perms_dict):
-                json_res[svc.type][svc.resource_name] = format_service_resources(
+                json_res[svc.type][svc.resource_name] = sf.format_service_resources(
                     svc,
                     db_session=db,
                     service_perms=svc_perms,
@@ -341,7 +341,7 @@ def get_user_services_view(request):
     resolve_groups_perms = asbool(ar.get_query_param(request, ["resolve", "resolved"]))
     format_as_list = asbool(ar.get_query_param(request, "flatten"))
     service_types = ar.get_query_param(request, ["type", "types"], default="")
-    service_types = filter_service_types(service_types)
+    service_types = su.filter_service_types(service_types)
 
     svc_json = uu.get_user_services(user, request=request,
                                     cascade_resources=cascade_resources,
@@ -472,7 +472,7 @@ def get_user_service_resources_view(request):
         user, service, request=request,
         inherit_groups_permissions=inherit_groups_perms,
         resolve_groups_permissions=resolve_groups_perms)
-    user_svc_res_json = format_service_resources(
+    user_svc_res_json = sf.format_service_resources(
         service=service,
         db_session=request.db,
         service_perms=service_perms,

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -183,7 +183,7 @@ def get_user_resources_view(request):
     resolve_groups_perms = asbool(ar.get_query_param(request, ["resolve", "resolved"]))
     filtered_perms = asbool(ar.get_query_param(request, ["filter", "filtered"]))
     service_types = ar.get_query_param(request, ["type", "types"], default="")
-    service_types = su.filter_service_types(service_types)
+    service_types = su.filter_service_types(service_types, default_services=True)
     user = ar.get_user_matchdict_checked_or_logged(request)
     db = request.db
 
@@ -339,9 +339,9 @@ def get_user_services_view(request):
     cascade_resources = asbool(ar.get_query_param(request, "cascade"))
     inherit_groups_perms = asbool(ar.get_query_param(request, ["inherit", "inherited"]))
     resolve_groups_perms = asbool(ar.get_query_param(request, ["resolve", "resolved"]))
-    format_as_list = asbool(ar.get_query_param(request, "flatten"))
+    format_as_list = asbool(ar.get_query_param(request, ["flatten", "list"]))
     service_types = ar.get_query_param(request, ["type", "types"], default="")
-    service_types = su.filter_service_types(service_types)
+    service_types = su.filter_service_types(service_types)  # don't use default service types to populate response
 
     svc_json = uu.get_user_services(user, request=request,
                                     cascade_resources=cascade_resources,

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -505,8 +505,8 @@ QueryFlattenServices = colander.SchemaNode(
 QueryFilterServiceType = colander.SchemaNode(
     colander.String(), name="type", missing=colander.drop,
     example="api,thredds",
-    description="Comma-separated list of service-type for which to obtain descriptions instead of all available ones. "
-                "Provided types are case insensitive. Unknown types are ignored.")
+    description="Comma-separated list of service-type for which to filter retrieved descriptions instead of all "
+                "available ones. Provided types matching is case insensitive. Unknown types are ignored.")
 
 
 class PhoenixServicePushOption(colander.SchemaNode):
@@ -2277,6 +2277,7 @@ class UserServices_GET_QuerySchema(QueryRequestSchemaAPI):
     cascade = QueryCascadeResourcesPermissions
     inherit = QueryInheritGroupsPermissions
     flatten = QueryFlattenServices
+    svc_type = QueryFilterServiceType
 
 
 class UserServices_GET_RequestSchema(BaseRequestSchemaAPI):
@@ -2499,8 +2500,13 @@ class GroupUsers_GET_ForbiddenResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
+class GroupServices_GET_QuerySchema(QueryRequestSchemaAPI):
+    svc_type = QueryFilterServiceType
+
+
 class GroupServices_GET_RequestSchema(BaseRequestSchemaAPI):
     path = Group_RequestPathSchema()
+    querystring = GroupServices_GET_QuerySchema()
 
 
 class GroupServices_GET_ResponseBodySchema(BaseResponseBodySchema):
@@ -2667,8 +2673,13 @@ class GroupResourcePermissions_InternalServerErrorResponseSchema(BaseResponseSch
         code=HTTPInternalServerError.code, description=description)
 
 
+class GroupResources_GET_QuerySchema(QueryRequestSchemaAPI):
+    svc_type = QueryFilterServiceType
+
+
 class GroupResources_GET_RequestSchema(BaseRequestSchemaAPI):
     path = Group_RequestPathSchema()
+    querystring = GroupResources_GET_QuerySchema()
 
 
 class GroupResources_GET_ResponseBodySchema(BaseResponseBodySchema):

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -479,13 +479,15 @@ QueryEffectivePermissions = colander.SchemaNode(
 QueryInheritGroupsPermissions = colander.SchemaNode(
     colander.Boolean(), name="inherited", default=False, missing=colander.drop,
     description="Include the user's groups memberships inheritance to retrieve all possible permissions. "
-                "(Note: Duplicate, redundant or conflicting permissions can be obtained considering applied group"
-                " permissions individually. See 'combined' query parameter to resolve such cases.)")
-QueryCombinedGroupsPermissions = colander.SchemaNode(
-    colander.Boolean(), name="combined", default=False, missing=colander.drop,
-    description="Combines corresponding user and groups inherited permissions into one, and locally resolves "
-                "for every resource the applicable permission modifiers considering group precedence. "
-                "(Note: Group inheritance is enforced regardless of 'inherited' query parameter.)")
+                "(Note: Duplicate, redundant and even conflicting permissions can be obtained when considering "
+                "multiple applied permissions individually applied fro different group memberships or for the user "
+                "itself. See 'resolve' query parameter to reduce the set into a single highest priority permission).")
+QueryResolvedUserGroupsPermissions = colander.SchemaNode(
+    colander.Boolean(), name="resolve", default=False, missing=colander.drop,
+    description="Combines corresponding direct user and groups inherited permissions into one, and locally resolves "
+                "for every resource the applicable permission modifiers considering group precedence and priorities. "
+                "(Note: Group permissions retrieval is enforced when using this option regardless of 'inherited' query "
+                "parameter since they are required to perform resolution).")
 QueryFilterResources = colander.SchemaNode(
     colander.Boolean(), name="filtered", default=False, missing=colander.drop,
     description="Filter returned resources only where user has permissions on, either directly or inherited by groups "
@@ -2012,7 +2014,7 @@ class UserGroup_DELETE_NotFoundResponseSchema(BaseResponseSchemaAPI):
 
 class UserResources_GET_QuerySchema(QueryRequestSchemaAPI):
     inherited = QueryInheritGroupsPermissions
-    combined = QueryCombinedGroupsPermissions
+    resolve = QueryResolvedUserGroupsPermissions
     filtered = QueryFilterResources
     svc_type = QueryFilterServiceType
 
@@ -2058,7 +2060,7 @@ class UserResourcePermissions_Check_ErrorResponseSchema(BaseResponseSchemaAPI):
 
 class UserResourcePermissions_GET_QuerySchema(QueryRequestSchemaAPI):
     inherited = QueryInheritGroupsPermissions
-    combined = QueryCombinedGroupsPermissions
+    resolve = QueryResolvedUserGroupsPermissions
     effective = QueryEffectivePermissions
 
 
@@ -2231,7 +2233,7 @@ class UserServiceResources_GET_OkResponseSchema(BaseResponseSchemaAPI):
 
 class UserServiceResources_GET_QuerySchema(QueryRequestSchemaAPI):
     inherited = QueryInheritGroupsPermissions
-    combined = QueryCombinedGroupsPermissions
+    resolve = QueryResolvedUserGroupsPermissions
 
 
 class UserServiceResources_GET_RequestSchema(BaseRequestSchemaAPI):
@@ -2296,7 +2298,7 @@ class UserServices_GET_OkResponseSchema(BaseResponseSchemaAPI):
 
 class UserServicePermissions_GET_QuerySchema(QueryRequestSchemaAPI):
     inherited = QueryInheritGroupsPermissions
-    combined = QueryCombinedGroupsPermissions
+    resolve = QueryResolvedUserGroupsPermissions
 
 
 class UserServicePermissions_GET_RequestSchema(BaseRequestSchemaAPI):

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1333,7 +1333,13 @@ class Service_CheckConfig_UnprocessableEntityResponseSchema(BaseResponseSchemaAP
     body = ErrorResponseBodySchema(code=HTTPUnprocessableEntity.code, description=description)
 
 
-Services_GET_RequestSchema = ServiceTypes_GET_RequestSchema
+class ServicesQuerySchema(QueryRequestSchemaAPI):
+    flatten = QueryFlattenServices
+    svc_type = QueryFilterServiceType
+
+
+class Services_GET_RequestSchema(BaseRequestSchemaAPI):
+    querystring = ServicesQuerySchema()
 
 
 class Service_GET_RequestSchema(BaseRequestSchemaAPI):

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -480,7 +480,7 @@ QueryInheritGroupsPermissions = colander.SchemaNode(
     colander.Boolean(), name="inherited", default=False, missing=colander.drop,
     description="Include the user's groups memberships inheritance to retrieve all possible permissions. "
                 "(Note: Duplicate, redundant and even conflicting permissions can be obtained when considering "
-                "multiple applied permissions individually applied fro different group memberships or for the user "
+                "multiple applied permissions individually applied from different group memberships or for the user "
                 "itself. See 'resolve' query parameter to reduce the set into a single highest priority permission).")
 QueryResolvedUserGroupsPermissions = colander.SchemaNode(
     colander.Boolean(), name="resolve", default=False, missing=colander.drop,

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -502,6 +502,11 @@ QueryFlattenServices = colander.SchemaNode(
     description="Return elements as a flattened list of JSON objects instead of default response format. "
                 "Default is a nested JSON of service-type keys with children service-name keys, each containing "
                 "their respective service definition as JSON object.")
+QueryFilterServiceType = colander.SchemaNode(
+    colander.String(), name="type", missing=colander.drop,
+    example="api,thredds",
+    description="Comma-separated list of service-type for which to obtain descriptions instead of all available ones. "
+                "Provided types are case insensitive. Unknown types are ignored.")
 
 
 class PhoenixServicePushOption(colander.SchemaNode):
@@ -2009,6 +2014,7 @@ class UserResources_GET_QuerySchema(QueryRequestSchemaAPI):
     inherited = QueryInheritGroupsPermissions
     combined = QueryCombinedGroupsPermissions
     filtered = QueryFilterResources
+    svc_type = QueryFilterServiceType
 
 
 class UserResources_GET_RequestSchema(BaseRequestSchemaAPI):

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -164,7 +164,7 @@ class PermissionSet(object):
         (to protect the :term:`Resource`), and :attr:`Scope.MATCH` is *closer* to the actual :term:`Resource` than
         :attr:`Scope.RECURSIVE` permission received from a *farther* parent in the hierarchy.
 
-        Explicitly, sorted explicit string representation becomes::
+        Sorted explicit string representation becomes::
 
             [name1]-[allow]-[match]
             [name1]-[allow]-[recursive]

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -8,10 +8,10 @@
     <ul class="tree-level-${level}">
     %for key in tree:
         %if tree[key]["children"]:
-        <li class="collapsible expanded">
+        <li class="collapsible expanded" id="${tree[key]['id']}">
         <div class="collapsible-marker"></div>
         %else:
-        <li class="no-child">
+        <li class="no-child" id="${tree[key]['id']}">
         %endif
             <div class="tree-line">
                 <div class="tree-key">

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -467,13 +467,15 @@ class ManagementViews(AdminRequests, BaseViews):
         if is_user:
             # because page can only show a single permission (per name/resource) at a time, apply resolution
             # on top of inheritance in order to display the highest priority permission in the tree hierarchy
-            query = "&inherited=true&resolve=true" if is_inherit_groups_permissions else ""
+            query = "inherited=true&resolve=true" if is_inherit_groups_permissions else ""
             path = schemas.UserResourcesAPI.path.format(user_name=user_or_group_name)
         else:
             query = ""
             path = schemas.GroupResourcesAPI.path.format(group_name=user_or_group_name)
 
-        path += "?type={}{}".format(query, service_type)  # try to limit results for faster processing time
+        query_type = "type={}".format(service_type)  # try to limit results for faster processing time
+        query_sep = "&" if query else ""
+        path += "?{}{}{}".format(query, query_sep, query_type)
         resp = request_api(self.request, path, "GET")
         check_response(resp)
         body = get_json(resp)

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -467,12 +467,13 @@ class ManagementViews(AdminRequests, BaseViews):
         if is_user:
             # because page can only show a single permission (per name/resource) at a time, apply resolution
             # on top of inheritance in order to display the highest priority permission in the tree hierarchy
-            query = "?inherited=true&resolve=true" if is_inherit_groups_permissions else ""
-            path = schemas.UserResourcesAPI.path.format(user_name=user_or_group_name) + query
+            query = "&inherited=true&resolve=true" if is_inherit_groups_permissions else ""
+            path = schemas.UserResourcesAPI.path.format(user_name=user_or_group_name)
         else:
+            query = ""
             path = schemas.GroupResourcesAPI.path.format(group_name=user_or_group_name)
 
-        path += "?type={}".format(service_type)  # try to limit results for faster processing time
+        path += "?type={}{}".format(query, service_type)  # try to limit results for faster processing time
         resp = request_api(self.request, path, "GET")
         check_response(resp)
         body = get_json(resp)

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -470,7 +470,7 @@ class ManagementViews(AdminRequests, BaseViews):
         else:
             path = schemas.GroupResourcesAPI.path.format(group_name=user_or_group_name)
 
-        path += "type={}".format(service_type)  # try to limit results for faster processing time
+        path += "?type={}".format(service_type)  # try to limit results for faster processing time
         resp = request_api(self.request, path, "GET")
         check_response(resp)
         body = get_json(resp)

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -465,7 +465,7 @@ class ManagementViews(AdminRequests, BaseViews):
               or :term:`Group` accordingly to specified arguments.
         """
         if is_user:
-            query = "?inherited=true" if is_inherit_groups_permissions else ""
+            query = "?inherited=true&resolve=true" if is_inherit_groups_permissions else ""
             path = schemas.UserResourcesAPI.path.format(user_name=user_or_group_name) + query
         else:
             path = schemas.GroupResourcesAPI.path.format(group_name=user_or_group_name)

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -470,6 +470,7 @@ class ManagementViews(AdminRequests, BaseViews):
         else:
             path = schemas.GroupResourcesAPI.path.format(group_name=user_or_group_name)
 
+        path += "type={}".format(service_type)  # try to limit results for faster processing time
         resp = request_api(self.request, path, "GET")
         check_response(resp)
         body = get_json(resp)

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -465,6 +465,8 @@ class ManagementViews(AdminRequests, BaseViews):
               or :term:`Group` accordingly to specified arguments.
         """
         if is_user:
+            # because page can only show a single permission (per name/resource) at a time, apply resolution
+            # on top of inheritance in order to display the highest priority permission in the tree hierarchy
             query = "?inherited=true&resolve=true" if is_inherit_groups_permissions else ""
             path = schemas.UserResourcesAPI.path.format(user_name=user_or_group_name) + query
         else:

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -3581,7 +3581,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
 
         svc_type1 = ServiceTHREDDS.service_type
         svc_type1_exist = body["services"][svc_type1]
-        svc_type1 = ServiceNCWMS2.service_type
+        svc_type2 = ServiceNCWMS2.service_type
         svc_type2_exist = body["services"][svc_type2]
 
         new_test_svc = [

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -1769,26 +1769,6 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         cls.test_group_name = "magpie-unittest-dummy-group"
         cls.test_user_name = "magpie-unittest-toto"
 
-    @classmethod
-    def check_GetUserResourcePermissions(cls, user_name, resource_id, query=None):
-        query = "?{}".format(query) if query else ""
-        path = "/users/{usr}/resources/{res}/permissions{q}".format(usr=user_name, res=resource_id, q=query)
-        resp = utils.test_request(cls, "GET", path, headers=cls.json_headers, cookies=cls.cookies)
-        body = utils.check_response_basic_info(resp, 200, expected_method="GET")
-        utils.check_val_is_in("permission_names", body)
-        utils.check_val_type(body["permission_names"], list)
-        return body
-
-    @classmethod
-    def check_GetUserResources(cls, user_name, query=None):
-        query = "?{}".format(query) if query else ""
-        path = "/users/{usr}/resources{q}".format(usr=user_name, q=query)
-        resp = utils.test_request(cls, "GET", path, headers=cls.json_headers, cookies=cls.cookies)
-        body = utils.check_response_basic_info(resp, 200, expected_method="GET")
-        utils.check_val_is_in("resources", body)
-        utils.check_val_type(body["resources"], dict)
-        return body
-
     @runner.MAGPIE_TEST_STATUS
     def test_unauthorized_forbidden_responses(self):
         """
@@ -1964,7 +1944,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.TestSetup.create_TestService(self)
         body = utils.TestSetup.create_TestServiceResource(self)
         res_id = body["resource"]["resource_id"]
-        self.check_GetUserResourcePermissions(get_constant("MAGPIE_LOGGED_USER"), res_id)
+        utils.TestSetup.check_GetUserResourcePermissions(self, get_constant("MAGPIE_LOGGED_USER"), res_id)
 
     @runner.MAGPIE_TEST_USERS
     @runner.MAGPIE_TEST_LOGGED
@@ -1994,85 +1974,85 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         #   |- test-resource (parent)    |            | r-m         |             |
         #       |- test-resource (child) |            |             | r-m         |
         body = utils.TestSetup.create_TestService(self, override_service_type=ServiceAPI.service_type)
-        test_svc_res_id = body["service"]["resource_id"]
-        test_res_type = Route.resource_type_name
-        body = utils.TestSetup.create_TestServiceResource(self, override_resource_type=test_res_type)
-        test_parent_res_id = body["resource"]["resource_id"]
+        svc_res_id = body["service"]["resource_id"]
+        res_type = Route.resource_type_name
+        body = utils.TestSetup.create_TestServiceResource(self, override_resource_type=res_type)
+        p_res_id = body["resource"]["resource_id"]  # parent
         child_resource_name = self.test_resource_name + "-child"
         override_data = {
             "resource_name": child_resource_name,
-            "resource_type": test_res_type,
-            "parent_id": test_parent_res_id
+            "resource_type": res_type,
+            "parent_id": p_res_id
         }
         body = utils.TestSetup.create_TestServiceResource(self, override_data=override_data)
-        test_child_res_id = body["resource"]["resource_id"]
-        anonym_usr = get_constant("MAGPIE_ANONYMOUS_USER")
-        anonym_grp = get_constant("MAGPIE_ANONYMOUS_GROUP")
+        c_res_id = body["resource"]["resource_id"]
+        usr_anon = get_constant("MAGPIE_ANONYMOUS_USER")
+        grp_anon = get_constant("MAGPIE_ANONYMOUS_GROUP")
 
         perm_recur = Permission.READ.value
         perm_match = "read-match"  # backward compatibility
         data_recur = {"permission_name": perm_recur}
         data_match = {"permission_name": perm_match}
-        path = "/users/{usr}/resources/{res}/permissions".format(res=test_svc_res_id, usr=self.usr)
+        path = "/users/{usr}/resources/{res}/permissions".format(res=svc_res_id, usr=self.usr)
         utils.test_request(self, "POST", path, data=data_recur, headers=self.json_headers, cookies=self.cookies)
-        path = "/groups/{grp}/resources/{res}/permissions".format(res=test_svc_res_id, grp=self.grp)
+        path = "/groups/{grp}/resources/{res}/permissions".format(res=svc_res_id, grp=self.grp)
         utils.test_request(self, "POST", path, data=data_match, headers=self.json_headers, cookies=self.cookies)
-        path = "/groups/{grp}/resources/{res}/permissions".format(res=test_parent_res_id, grp=self.grp)
+        path = "/groups/{grp}/resources/{res}/permissions".format(res=p_res_id, grp=self.grp)
         utils.test_request(self, "POST", path, data=data_match, headers=self.json_headers, cookies=self.cookies)
-        path = "/users/{usr}/resources/{res}/permissions".format(res=test_child_res_id, usr=anonym_usr)
+        path = "/users/{usr}/resources/{res}/permissions".format(res=c_res_id, usr=usr_anon)
         utils.test_request(self, "POST", path, data=data_match, headers=self.json_headers, cookies=self.cookies)
-        path = "/groups/{grp}/resources/{res}/permissions".format(res=test_svc_res_id, grp=anonym_grp)
+        path = "/groups/{grp}/resources/{res}/permissions".format(res=svc_res_id, grp=grp_anon)
         utils.test_request(self, "POST", path, data=data_recur, headers=self.json_headers, cookies=self.cookies)
 
         expect_perm_match = utils.TestSetup.get_PermissionNames(self, perm_match)
         expect_perm_recur = utils.TestSetup.get_PermissionNames(self, perm_recur)
 
         # tests
-        q_groups = "inherit=true"  # note: 'inherit' is old name, official is 'inherited', but backward supported
-        q_effect = "effective=true"
+        q_is = "inherit=true"  # note: 'inherit' is old name, official is 'inherited', but backward supported
+        q_e = "effective=true"
         test_effective = TestVersion(self.version) < TestVersion("3.0")
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_child_res_id, query=None)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=c_res_id, query=None)
         utils.check_val_equal(body["permission_names"], [])
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_child_res_id, query=q_groups)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=c_res_id, query=q_is)
         utils.check_val_equal(body["permission_names"], [])
         if test_effective:
-            body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_child_res_id, query=q_effect)
+            body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=c_res_id, query=q_e)
             utils.check_all_equal(body["permission_names"], expect_perm_recur, any_order=True)
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_parent_res_id, query=None)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=p_res_id, query=None)
         utils.check_val_equal(body["permission_names"], [])
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_parent_res_id, query=q_groups)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=p_res_id, query=q_is)
         utils.check_all_equal(body["permission_names"], expect_perm_match, any_order=True)
         if test_effective:
-            body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_parent_res_id, query=q_effect)
+            body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=p_res_id, query=q_e)
             utils.check_all_equal(body["permission_names"], expect_perm_recur + expect_perm_match, any_order=True)
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_svc_res_id, query=None)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=svc_res_id, query=None)
         utils.check_all_equal(body["permission_names"], expect_perm_recur, any_order=True)
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_svc_res_id, query=q_groups)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=svc_res_id, query=q_is)
         utils.check_all_equal(body["permission_names"], expect_perm_recur + expect_perm_match, any_order=True)
         if test_effective:
-            body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_svc_res_id, query=q_effect)
+            body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=svc_res_id, query=q_e)
             utils.check_all_equal(body["permission_names"], expect_perm_recur + expect_perm_match, any_order=True)
 
-        body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_child_res_id, query=None)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=c_res_id, query=None)
         utils.check_all_equal(body["permission_names"], expect_perm_match, any_order=True)
-        body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_child_res_id, query=q_groups)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=c_res_id, query=q_is)
         utils.check_all_equal(body["permission_names"], expect_perm_match, any_order=True)
         if test_effective:
-            body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_child_res_id, query=q_effect)
+            body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=c_res_id, query=q_e)
             utils.check_all_equal(body["permission_names"], expect_perm_recur + expect_perm_match, any_order=True)
-        body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_parent_res_id, query=None)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=p_res_id, query=None)
         utils.check_val_equal(body["permission_names"], [])
-        body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_parent_res_id, query=q_groups)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=p_res_id, query=q_is)
         utils.check_val_equal(body["permission_names"], [])
         if test_effective:
-            body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_parent_res_id, query=q_effect)
+            body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=p_res_id, query=q_e)
             utils.check_all_equal(body["permission_names"], expect_perm_recur, any_order=True)
-        body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_svc_res_id, query=None)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=svc_res_id, query=None)
         utils.check_val_equal(body["permission_names"], [])
-        body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_svc_res_id, query=q_groups)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=svc_res_id, query=q_is)
         utils.check_all_equal(body["permission_names"], expect_perm_recur, any_order=True)
         if test_effective:
-            body = self.check_GetUserResourcePermissions(anonym_usr, resource_id=test_svc_res_id, query=q_effect)
+            body = utils.TestSetup.check_GetUserResourcePermissions(self, usr_anon, resource_id=svc_res_id, query=q_e)
             utils.check_all_equal(body["permission_names"], expect_perm_recur, any_order=True)
 
     @runner.MAGPIE_TEST_USERS
@@ -2081,13 +2061,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
     def test_GetUserResourcesPermissions(self):
         utils.TestSetup.create_TestService(self)
         body = utils.TestSetup.create_TestServiceResource(self)
-        self.check_GetUserResourcePermissions(self.usr, body["resource"]["resource_id"])
-
-    @runner.MAGPIE_TEST_USERS
-    @runner.MAGPIE_TEST_RESOURCES
-    @runner.MAGPIE_TEST_PERMISSIONS
-    def test_GetUserResourcesPermissions_ServicePermissionsResolved(self):
-        self.check_GetUserResourcePermissions
+        utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, body["resource"]["resource_id"])
 
     @runner.MAGPIE_TEST_USERS
     @runner.MAGPIE_TEST_RESOURCES
@@ -2125,7 +2099,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/users/{usr}/resources/{res}/permissions".format(res=test_res_id, usr=self.usr)
         data = {"permission_name": self.test_resource_perm_name}
         utils.test_request(self, "POST", path, data=data, headers=self.json_headers, cookies=self.cookies)
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_res_id)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=test_res_id)
         utils.check_val_is_in(self.test_resource_perm_name, body["permission_names"],
                               msg="Can't test for conflicting permissions if it doesn't exist first.")
 
@@ -2164,7 +2138,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         # first request creates the permission when it doesn't exist, PUT works exactly as POST does without problem
         resp = utils.test_request(self, "PUT", path, data=data, headers=self.json_headers, cookies=self.cookies)
         utils.check_response_basic_info(resp, 201, expected_method="PUT")  # created, http code indicates new entity
-        body = self.check_GetUserResourcePermissions(self.usr, resource_id=test_res_id)
+        body = utils.TestSetup.check_GetUserResourcePermissions(self, self.usr, resource_id=test_res_id)
         perm = PermissionSet(data["permission"])
         utils.check_val_is_in("permission_names", body)
         utils.check_val_is_in(str(perm), body["permission_names"],
@@ -3254,6 +3228,157 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                 res = svc["resources"][str(res_id)]  # type: JSON
                 utils.check_all_equal(res["permission_names"], res_perms, any_order=True)
 
+    @runner.MAGPIE_TEST_USERS
+    @runner.MAGPIE_TEST_RESOURCES
+    @runner.MAGPIE_TEST_PERMISSIONS
+    def test_GetUserResources_ServicePermissionsResolved(self):
+        """
+        Validate fix of incorrect resolved permissions on top-most resource (aka service) over multiple groups.
+
+        Multiple permissions over groups where all returned instead of being combined as specified by ``resolve`` query.
+        For sanity check, also validate similar resolved permissions are reported correctly for children resource.
+
+        Finally, validate that both endpoints ``GET /users/{}/resources`` (full hierarchy)
+        and ``GET /users/{}/resources/{}/permissions`` (individual entries) report equivalent results
+        for respective services and resources.
+
+        .. seealso::
+            - :meth:`test_GetUserServices_ServicePermissionsResolved`
+              (similar result, but without nested resource tree, only service-level returned)
+        """
+        utils.warn_version(self, "user service resources permissions resolved fix", "3.16.0", skip=True)
+
+        anonymous = get_constant("MAGPIE_ANONYMOUS_GROUP")
+        grp1_info = utils.TestSetup.create_TestGroup(self, self.test_group_name + "-1", override_exist=True)
+        grp2_info = utils.TestSetup.create_TestGroup(self, self.test_group_name + "-2", override_exist=True)
+        grp1_name = grp1_info["group"]["group_name"]
+        grp2_name = grp2_info["group"]["group_name"]
+        user_info = utils.TestSetup.create_TestUser(self, override_group_name=anonymous, override_exist=True)
+        user_name = user_info["user"]["user_name"]
+        utils.TestSetup.assign_TestUserGroup(self, override_user_name=user_name, override_group_name=grp1_name)
+        utils.TestSetup.assign_TestUserGroup(self, override_user_name=user_name, override_group_name=grp2_name)
+
+        svc1_name = "test-service-1"
+        svc1_id, res1_id = utils.TestSetup.create_TestServiceResourceTree(
+            self, override_service_name=svc1_name, resource_depth=1, override_exist=True
+        )
+        svc2_name = "test-service-2"
+        svc2_id, res2_id = utils.TestSetup.create_TestServiceResourceTree(
+            self, override_service_name=svc2_name, resource_depth=1, override_exist=True
+        )
+        svc3_name = "test-service-3"
+        svc3_id, res3_id = utils.TestSetup.create_TestServiceResourceTree(
+            self, override_service_name=svc3_name, resource_depth=1, override_exist=True
+        )
+
+        # setup test permissions
+        #                 | User  | Group1 | Group2 | Anonymous | Resolved (reason)
+        # ----------------+-------+--------+--------+-----------+-------------------
+        #   [svc1]        | r-A-R |        | r-A-R  | r-D-R     | r-A-R (user)
+        #      [res1]     | r-A-R |        | r-D-R  | r-D-R     | r-A-R (user)
+        #   [svc2]        |       |        | r-A-R  | r-D-R     | r-A-R (group2)
+        #      [res2]     |       |        | r-D-R  | r-A-R     | r-D-R (group2)
+        #   [svc3]        |       | r-A-R  | r-D-R  |           | r-D-R (group2)
+        #      [res3]     |       | r-D-R  | r-A-R  |           | r-D-R (group1)
+        perm = Permission.READ
+        rAR = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE)  # noqa
+        rDR = PermissionSet(perm, Access.DENY, Scope.RECURSIVE)   # noqa
+        utils.TestSetup.create_TestUserResourcePermission(
+            self, override_user_name=user_name, override_resource_id=svc1_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=svc1_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=anonymous, override_resource_id=svc1_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestUserResourcePermission(
+            self, override_user_name=user_name, override_resource_id=res1_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=res1_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=anonymous, override_resource_id=res1_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=svc2_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=anonymous, override_resource_id=svc2_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=res2_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=anonymous, override_resource_id=res2_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp1_name, override_resource_id=svc3_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=svc3_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp1_name, override_resource_id=res3_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=res3_id, override_permission=rAR
+        )
+
+        rAR_direct = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE, PermissionType.DIRECT)      # noqa
+        rAR_inherit = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE, PermissionType.INHERITED)  # noqa
+        rDR_inherit = PermissionSet(perm, Access.DENY, Scope.RECURSIVE, PermissionType.INHERITED)   # noqa
+
+        # verify equal but also matching reasons to ensure resolution is not just by chance of duplicate permissions
+        def check_equal_perms(perm_resp_json, perm_test, reason_info):
+            # type: (JSON, PermissionSet, JSON) -> JSON
+            utils.check_val_equal(len(perm_resp_json["permissions"]), 1)
+            perm_resp_json = perm_resp_json["permissions"][0]
+            reason_type = "user" if perm_test.type == PermissionType.DIRECT else "group"
+            reason_name = reason_info[reason_type]["{}_name".format(reason_type)]
+            reason_id = reason_info[reason_type]["{}_id".format(reason_type)]
+            perm_test.reason = "{}:{}:{}".format(reason_type, reason_id, reason_name)
+            utils.check_val_equal(perm_resp_json, perm_test.json())
+            return perm_resp_json
+
+        resolve_query = "resolve=true"
+        svc1_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, svc1_id, query=resolve_query)
+        svc1_perm_json = check_equal_perms(svc1_perm_body, rAR_direct, user_info)
+        res1_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, res1_id, query=resolve_query)
+        res1_perm_json = check_equal_perms(res1_perm_body, rAR_direct, user_info)
+        svc1_tree_body = utils.TestSetup.check_GetUserResources(self, user_name, query=resolve_query)
+        svc1_tree_body = svc1_tree_body["resources"][self.test_service_type][svc1_name]  # noqa  # type: JSON
+        svc1_tree_json = check_equal_perms(svc1_tree_body, rAR_direct, user_info)  # noqa
+        res1_tree_body = svc1_tree_body["resources"][str(res1_id)]  # noqa  # type: JSON
+        res1_tree_json = check_equal_perms(res1_tree_body, rAR_direct, user_info)  # noqa
+        utils.check_val_equal(svc1_perm_json, svc1_tree_json)
+        utils.check_val_equal(res1_perm_json, res1_tree_json)
+
+        svc2_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, svc2_id, query=resolve_query)
+        svc2_perm_json = check_equal_perms(svc2_perm_body, rAR_inherit, grp2_info)
+        res2_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, res2_id, query=resolve_query)
+        res2_perm_json = check_equal_perms(res2_perm_body, rDR_inherit, grp2_info)
+        svc2_tree_body = utils.TestSetup.check_GetUserResources(self, user_name, query=resolve_query)
+        svc2_tree_body = svc2_tree_body["resources"][self.test_service_type][svc2_name]  # noqa  # type: JSON
+        svc2_tree_json = check_equal_perms(svc2_tree_body, rAR_inherit, grp2_info)  # noqa
+        res2_tree_body = svc2_tree_body["resources"][str(res2_id)]  # noqa  # type: JSON
+        res2_tree_json = check_equal_perms(res2_tree_body, rDR_inherit, grp2_info)  # noqa
+        utils.check_val_equal(svc2_perm_json, svc2_tree_json)
+        utils.check_val_equal(res2_perm_json, res2_tree_json)
+
+        svc3_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, svc3_id, query=resolve_query)
+        svc3_perm_json = check_equal_perms(svc3_perm_body, rDR_inherit, grp2_info)
+        res3_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, res3_id, query=resolve_query)
+        res3_perm_json = check_equal_perms(res3_perm_body, rDR_inherit, grp1_info)
+        svc3_tree_body = utils.TestSetup.check_GetUserResources(self, user_name, query=resolve_query)
+        svc3_tree_body = svc3_tree_body["resources"][self.test_service_type][svc3_name]  # noqa  # type: JSON
+        svc3_tree_json = check_equal_perms(svc3_tree_body, rDR_inherit, grp2_info)  # noqa
+        res3_tree_body = svc3_tree_body["resources"][str(res3_id)]  # noqa  # type: JSON
+        res3_tree_json = check_equal_perms(res3_tree_body, rDR_inherit, grp1_info)  # noqa
+        utils.check_val_equal(svc3_perm_json, svc3_tree_json)
+        utils.check_val_equal(res3_perm_json, res3_tree_json)
+
     def setup_GetUserServices(self):
         # type: () -> Dict[Str, Union[Str, List[Str], JSON]]
         """
@@ -3631,6 +3756,110 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.check_val_equal(set(svc_type2_items) - set(svc_type2_exist), {new_test_svc[2][0]})
 
     @runner.MAGPIE_TEST_USERS
+    @runner.MAGPIE_TEST_SERVICES
+    @runner.MAGPIE_TEST_PERMISSIONS
+    def test_GetUserServices_ServicePermissionsResolved(self):
+        """
+        Validate fix of incorrect resolved permissions on top-most resource (aka service) over multiple groups.
+
+        Multiple permissions over groups where all returned instead of being combined as specified by ``resolve`` query.
+
+        .. seealso::
+            - :meth:`test_GetUserResources_ServicePermissionsResolved`
+              (similar result, but provide more detailed nested resource tree with all corresponding permissions)
+        """
+        utils.warn_version(self, "user service resources permissions resolved fix", "3.16.0", skip=True)
+
+        anonymous = get_constant("MAGPIE_ANONYMOUS_GROUP")
+        grp1_info = utils.TestSetup.create_TestGroup(self, self.test_group_name + "-1", override_exist=True)
+        grp2_info = utils.TestSetup.create_TestGroup(self, self.test_group_name + "-2", override_exist=True)
+        grp1_name = grp1_info["group"]["group_name"]
+        grp2_name = grp2_info["group"]["group_name"]
+        user_info = utils.TestSetup.create_TestUser(self, override_group_name=anonymous, override_exist=True)
+        user_name = user_info["user"]["user_name"]
+        utils.TestSetup.assign_TestUserGroup(self, override_user_name=user_name, override_group_name=grp1_name)
+        utils.TestSetup.assign_TestUserGroup(self, override_user_name=user_name, override_group_name=grp2_name)
+
+        svc1_name = "test-service-1"
+        svc1_info = utils.TestSetup.create_TestService(self, override_service_name=svc1_name, override_exist=True)
+        svc1_id = utils.TestSetup.get_ResourceInfo(self, override_body=svc1_info)["resource_id"]
+        svc2_name = "test-service-2"
+        svc2_info = utils.TestSetup.create_TestService(self, override_service_name=svc2_name, override_exist=True)
+        svc2_id = utils.TestSetup.get_ResourceInfo(self, override_body=svc2_info)["resource_id"]
+        svc3_name = "test-service-3"
+        svc3_info = utils.TestSetup.create_TestService(self, override_service_name=svc3_name, override_exist=True)
+        svc3_id = utils.TestSetup.get_ResourceInfo(self, override_body=svc3_info)["resource_id"]
+
+        # setup test permissions
+        #                 | User  | Group1 | Group2 | Anonymous | Resolved (reason)
+        # ----------------+-------+--------+--------+-----------+-------------------
+        #   [svc1]        | r-A-R |        | r-A-R  | r-D-R     | r-A-R (user)
+        #   [svc2]        |       |        | r-A-R  | r-D-R     | r-A-R (group2)
+        #   [svc3]        |       | r-A-R  | r-D-R  |           | r-D-R (group2)
+        perm = Permission.READ
+        rAR = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE)  # noqa
+        rDR = PermissionSet(perm, Access.DENY, Scope.RECURSIVE)   # noqa
+        utils.TestSetup.create_TestUserResourcePermission(
+            self, override_user_name=user_name, override_resource_id=svc1_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=svc1_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=anonymous, override_resource_id=svc1_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=svc2_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=anonymous, override_resource_id=svc2_id, override_permission=rDR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp1_name, override_resource_id=svc3_id, override_permission=rAR
+        )
+        utils.TestSetup.create_TestGroupResourcePermission(
+            self, override_group_name=grp2_name, override_resource_id=svc3_id, override_permission=rDR
+        )
+
+        rAR_direct = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE, PermissionType.DIRECT)      # noqa
+        rAR_inherit = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE, PermissionType.INHERITED)  # noqa
+        rDR_inherit = PermissionSet(perm, Access.DENY, Scope.RECURSIVE, PermissionType.INHERITED)   # noqa
+
+        # verify equal but also matching reasons to ensure resolution is not just by chance of duplicate permissions
+        def check_equal_perms(perm_resp_json, perm_test, reason_info):
+            # type: (JSON, PermissionSet, JSON) -> JSON
+            utils.check_val_equal(len(perm_resp_json["permissions"]), 1)
+            perm_resp_json = perm_resp_json["permissions"][0]
+            reason_type = "user" if perm_test.type == PermissionType.DIRECT else "group"
+            reason_name = reason_info[reason_type]["{}_name".format(reason_type)]
+            reason_id = reason_info[reason_type]["{}_id".format(reason_type)]
+            perm_test.reason = "{}:{}:{}".format(reason_type, reason_id, reason_name)
+            utils.check_val_equal(perm_resp_json, perm_test.json())
+            return perm_resp_json
+
+        resolve_query = "resolve=true"
+        svc1_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, svc1_id, query=resolve_query)
+        svc1_perm_json = check_equal_perms(svc1_perm_body, rAR_direct, user_info)
+        svc1_tree_body = utils.TestSetup.check_GetUserResources(self, user_name, query=resolve_query)
+        svc1_tree_body = svc1_tree_body["resources"][self.test_service_type][svc1_name]  # noqa  # type: JSON
+        svc1_tree_json = check_equal_perms(svc1_tree_body, rAR_direct, user_info)  # noqa
+        utils.check_val_equal(svc1_perm_json, svc1_tree_json)
+
+        svc2_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, svc2_id, query=resolve_query)
+        svc2_perm_json = check_equal_perms(svc2_perm_body, rAR_inherit, grp2_info)
+        svc2_tree_body = utils.TestSetup.check_GetUserResources(self, user_name, query=resolve_query)
+        svc2_tree_body = svc2_tree_body["resources"][self.test_service_type][svc2_name]  # noqa  # type: JSON
+        svc2_tree_json = check_equal_perms(svc2_tree_body, rAR_inherit, grp2_info)  # noqa
+        utils.check_val_equal(svc2_perm_json, svc2_tree_json)
+
+        svc3_perm_body = utils.TestSetup.check_GetUserResourcePermissions(self, user_name, svc3_id, query=resolve_query)
+        svc3_perm_json = check_equal_perms(svc3_perm_body, rDR_inherit, grp2_info)
+        svc3_tree_body = utils.TestSetup.check_GetUserResources(self, user_name, query=resolve_query)
+        svc3_tree_body = svc3_tree_body["resources"][self.test_service_type][svc3_name]  # noqa  # type: JSON
+        svc3_tree_json = check_equal_perms(svc3_tree_body, rDR_inherit, grp2_info)  # noqa
+        utils.check_val_equal(svc3_perm_json, svc3_tree_json)
+
+    @runner.MAGPIE_TEST_USERS
     def test_GetUserServiceResources_format(self):
         utils.TestSetup.create_TestService(self)
         utils.TestSetup.create_TestServiceResource(self)
@@ -3671,153 +3900,6 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         res_perms = body["service"]["resources"][str(res_id)]["permission_names"]  # noqa
         usr_grp_res_perms = utils.TestSetup.get_PermissionNames(self, [perm_res_usr, perm_res_grp])
         utils.check_all_equal(res_perms, usr_grp_res_perms, any_order=True)
-
-    @runner.MAGPIE_TEST_USERS
-    @runner.MAGPIE_TEST_RESOURCES
-    @runner.MAGPIE_TEST_PERMISSIONS
-    def test_GetUserResourcesPermissions_ServicePermissionsResolved(self):
-        """
-        Validate fix of incorrect resolved permissions on top-most resource (aka service) over multiple groups.
-
-        Multiple permissions over groups where all returned instead of being combined as specified by ``resolve`` query.
-        For sanity check, also validate similar resolved permissions are reported correctly for children resource.
-
-        Finally, validate that both endpoints ``GET /users/{}/resources`` (full hierarchy)
-        and ``GET /users/{}/resources/{}/permissions`` (individual entries) report equivalent results
-        for respective services and resources.
-        """
-        utils.warn_version(self, "user service resources permissions resolved fix", "3.16.0", skip=True)
-
-        anonymous = get_constant("MAGPIE_ANONYMOUS_GROUP")
-        grp1_info = utils.TestSetup.create_TestGroup(self, self.test_group_name + "-1", override_exist=True)
-        grp2_info = utils.TestSetup.create_TestGroup(self, self.test_group_name + "-2", override_exist=True)
-        grp1_name = grp1_info["group"]["group_name"]
-        grp2_name = grp2_info["group"]["group_name"]
-        user_info = utils.TestSetup.create_TestUser(self, override_group_name=anonymous, override_exist=True)
-        user_name = user_info["user"]["user_name"]
-        utils.TestSetup.assign_TestUserGroup(self, override_user_name=user_name, override_group_name=grp1_name)
-        utils.TestSetup.assign_TestUserGroup(self, override_user_name=user_name, override_group_name=grp2_name)
-
-        svc1_name = "test-service-1"
-        svc1_id, res1_id = utils.TestSetup.create_TestServiceResourceTree(
-            self, override_service_name=svc1_name, resource_depth=1, override_exist=True
-        )
-        svc2_name = "test-service-2"
-        svc2_id, res2_id = utils.TestSetup.create_TestServiceResourceTree(
-            self, override_service_name=svc2_name, resource_depth=1, override_exist=True
-        )
-        svc3_name = "test-service-3"
-        svc3_id, res3_id = utils.TestSetup.create_TestServiceResourceTree(
-            self, override_service_name=svc3_name, resource_depth=1, override_exist=True
-        )
-
-        # setup test permissions
-        #                 | User  | Group1 | Group2 | Anonymous | Resolved (reason)
-        # ----------------+-------+--------+--------+-----------+-------------------
-        #   [svc1]        | r-A-R |        | r-A-R  | r-D-R     | r-A-R (user)
-        #      [res1]     | r-A-R |        | r-D-R  | r-D-R     | r-A-R (user)
-        #   [svc2]        |       |        | r-A-R  | r-D-R     | r-A-R (group2)
-        #      [res2]     |       |        | r-D-R  | r-A-R     | r-D-R (group2)
-        #   [svc3]        |       | r-A-R  | r-D-R  |           | r-D-R (group2)
-        #      [res3]     |       | r-D-R  | r-A-R  |           | r-D-R (group1)
-        perm = Permission.READ
-        rAR = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE)  # noqa
-        rDR = PermissionSet(perm, Access.DENY, Scope.RECURSIVE)   # noqa
-        utils.TestSetup.create_TestUserResourcePermission(
-            self, override_user_name=user_name, override_resource_id=svc1_id, override_permission=rAR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp2_name, override_resource_id=svc1_id, override_permission=rAR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=anonymous, override_resource_id=svc1_id, override_permission=rDR
-        )
-        utils.TestSetup.create_TestUserResourcePermission(
-            self, override_user_name=user_name, override_resource_id=res1_id, override_permission=rAR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp2_name, override_resource_id=res1_id, override_permission=rDR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=anonymous, override_resource_id=res1_id, override_permission=rDR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp2_name, override_resource_id=svc2_id, override_permission=rAR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=anonymous, override_resource_id=svc2_id, override_permission=rDR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp2_name, override_resource_id=res2_id, override_permission=rDR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=anonymous, override_resource_id=res2_id, override_permission=rAR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp1_name, override_resource_id=svc3_id, override_permission=rAR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp2_name, override_resource_id=svc3_id, override_permission=rDR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp1_name, override_resource_id=res3_id, override_permission=rDR
-        )
-        utils.TestSetup.create_TestGroupResourcePermission(
-            self, override_group_name=grp2_name, override_resource_id=res3_id, override_permission=rAR
-        )
-
-        rAR_direct = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE, PermissionType.DIRECT)      # noqa
-        rAR_inherit = PermissionSet(perm, Access.ALLOW, Scope.RECURSIVE, PermissionType.INHERITED)  # noqa
-        rDR_inherit = PermissionSet(perm, Access.DENY, Scope.RECURSIVE, PermissionType.INHERITED)   # noqa
-
-        # verify equal but also matching reasons to ensure resolution is not just by chance of duplicate permissions
-        def check_equal_perms(perm_resp_json, perm_test, reason_info):
-            # type: (JSON, PermissionSet, JSON) -> JSON
-            utils.check_val_equal(len(perm_resp_json["permissions"]), 1)
-            perm_resp_json = perm_resp_json["permissions"][0]
-            reason_type = "user" if perm_test.type == PermissionType.DIRECT else "group"
-            reason_name = reason_info[reason_type]["{}_name".format(reason_type)]
-            reason_id = reason_info[reason_type]["{}_id".format(reason_type)]
-            perm_test.reason = "{}:{}:{}".format(reason_type, reason_id, reason_name)
-            utils.check_val_equal(perm_resp_json, perm_test.json())
-            return perm_resp_json
-
-        resolve_query = "resolve=true"
-        svc1_perm_body = self.check_GetUserResourcePermissions(user_name, svc1_id, query=resolve_query)
-        svc1_perm_json = check_equal_perms(svc1_perm_body, rAR_direct, user_info)
-        res1_perm_body = self.check_GetUserResourcePermissions(user_name, res1_id, query=resolve_query)
-        res1_perm_json = check_equal_perms(res1_perm_body, rAR_direct, user_info)
-        svc1_tree_body = self.check_GetUserResources(user_name, query=resolve_query)
-        svc1_tree_body = svc1_tree_body["resources"][self.test_service_type][svc1_name]  # noqa  # type: JSON
-        svc1_tree_json = check_equal_perms(svc1_tree_body, rAR_direct, user_info)  # noqa
-        res1_tree_body = svc1_tree_body["resources"][str(res1_id)]  # noqa  # type: JSON
-        res1_tree_json = check_equal_perms(res1_tree_body, rAR_direct, user_info)  # noqa
-        utils.check_val_equal(svc1_perm_json, svc1_tree_json)
-        utils.check_val_equal(res1_perm_json, res1_tree_json)
-
-        svc2_perm_body = self.check_GetUserResourcePermissions(user_name, svc2_id, query=resolve_query)
-        svc2_perm_json = check_equal_perms(svc2_perm_body, rAR_inherit, grp2_info)
-        res2_perm_body = self.check_GetUserResourcePermissions(user_name, res2_id, query=resolve_query)
-        res2_perm_json = check_equal_perms(res2_perm_body, rDR_inherit, grp2_info)
-        svc2_tree_body = self.check_GetUserResources(user_name, query=resolve_query)
-        svc2_tree_body = svc2_tree_body["resources"][self.test_service_type][svc2_name]  # noqa  # type: JSON
-        svc2_tree_json = check_equal_perms(svc2_tree_body, rAR_inherit, grp2_info)  # noqa
-        res2_tree_body = svc2_tree_body["resources"][str(res2_id)]  # noqa  # type: JSON
-        res2_tree_json = check_equal_perms(res2_tree_body, rDR_inherit, grp2_info)  # noqa
-        utils.check_val_equal(svc2_perm_json, svc2_tree_json)
-        utils.check_val_equal(res2_perm_json, res2_tree_json)
-
-        svc3_perm_body = self.check_GetUserResourcePermissions(user_name, svc3_id, query=resolve_query)
-        svc3_perm_json = check_equal_perms(svc3_perm_body, rDR_inherit, grp2_info)
-        res3_perm_body = self.check_GetUserResourcePermissions(user_name, res3_id, query=resolve_query)
-        res3_perm_json = check_equal_perms(res3_perm_body, rDR_inherit, grp1_info)
-        svc3_tree_body = self.check_GetUserResources(user_name, query=resolve_query)
-        svc3_tree_body = svc3_tree_body["resources"][self.test_service_type][svc3_name]  # noqa  # type: JSON
-        svc3_tree_json = check_equal_perms(svc3_tree_body, rDR_inherit, grp2_info)  # noqa
-        res3_tree_body = svc3_tree_body["resources"][str(res3_id)]  # noqa  # type: JSON
-        res3_tree_json = check_equal_perms(res3_tree_body, rDR_inherit, grp1_info)  # noqa
-        utils.check_val_equal(svc3_perm_json, svc3_tree_json)
-        utils.check_val_equal(res3_perm_json, res3_tree_json)
 
     @runner.MAGPIE_TEST_USERS
     @runner.MAGPIE_TEST_GROUPS

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2436,7 +2436,7 @@ class TestSetup(object):
                                                     override_headers=override_headers,
                                                     override_cookies=override_cookies,
                                                     override_exist=False)
-            elif override_exist is null:
+            if override_exist is null:
                 path = "/services/{svc}".format(svc=svc_name)
                 resp = test_request(app_or_url, "GET", path, headers=override_headers, cookies=override_cookies)
                 body = check_response_basic_info(resp, 200, expected_method="GET")
@@ -2938,3 +2938,35 @@ class TestSetup(object):
         if not ignore_missing:
             check_val_equal(result["code"], 200)
         return result
+
+    @staticmethod
+    def check_GetUserResourcePermissions(test_case, user_name, resource_id, query=None):
+        # type: (AnyMagpieTestCaseType, Str, int, Optional[Str]) -> JSON
+        query = "?{}".format(query) if query else ""
+        path = "/users/{usr}/resources/{res}/permissions{q}".format(usr=user_name, res=resource_id, q=query)
+        resp = test_request(test_case, "GET", path, headers=test_case.json_headers, cookies=test_case.cookies)
+        body = check_response_basic_info(resp, 200, expected_method="GET")
+        check_val_is_in("permission_names", body)
+        check_val_type(body["permission_names"], list)
+        return body
+
+    @staticmethod
+    def check_GetUserResourcesOrService(test_case, user_name, service_or_resource_path, query=None):
+        # type: (AnyMagpieTestCaseType, Str, Str, Optional[Str]) -> JSON
+        query = "?{}".format(query) if query else ""
+        path = "/users/{usr}/{sr}{q}".format(usr=user_name, sr=service_or_resource_path, q=query)
+        resp = test_request(test_case, "GET", path, headers=test_case.json_headers, cookies=test_case.cookies)
+        body = check_response_basic_info(resp, 200, expected_method="GET")
+        check_val_is_in("resources", body)
+        check_val_type(body["resources"], dict)
+        return body
+
+    @staticmethod
+    def check_GetUserServices(test_case, user_name, query=None):
+        # type: (AnyMagpieTestCaseType, Str, Optional[Str]) -> JSON
+        return TestSetup.check_GetUserResourcesOrService(test_case, user_name, "services", query=query)
+
+    @staticmethod
+    def check_GetUserResources(test_case, user_name, query=None):
+        # type: (AnyMagpieTestCaseType, Str, Optional[Str]) -> JSON
+        return TestSetup.check_GetUserResourcesOrService(test_case, user_name, "resources", query=query)


### PR DESCRIPTION
# Changes

* Add ``type`` query parameter to multiple requests returning ``Services`` or ``Resources`` regrouped by ``ServiceType``
  for a given ``User`` or ``Group`` in order to limit listing in responses and optimise some operations where only a
  subset of details are needed.
* Using new ``type`` query to filter ``ServiceType``, improve ``Permissions`` listing in UI pages with faster processing
  because ``Services`` that are not required (since they are not currently being displayed by the tab-panel view) can
  be skipped entirely, removing the need to compute their underlying ``Resource`` and ``Permissions`` tree hierarchy.

# References

- fixes #463 