### PR TITLE
disable pyup notification about vulnerability of sqlalchemy_utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,8 +47,7 @@ six>=1.12.0
 #sqlalchemy<1.4
 sqlalchemy==1.3.22
 sqlalchemy_utils<0.36.4; python_version < "3"
-#sqlalchemy_utils!=0.36.8; python_version >= "3"
-sqlalchemy_utils==0.37.9; python_version >= "3"
+sqlalchemy_utils==0.37.9; python_version >= "3"  # pyup: ignore
 threddsclient==0.4.1; python_version < "3"
 threddsclient>=0.4.1; python_version >= "3"
 transaction


### PR DESCRIPTION
Issue is flagged since `sqlalchemy_utils==0.27.0` as vulnerability but is still not patched (opened since 2015-10-06). Latest at this date is `sqlalchemy_utils==0.37.9`, which is the specified version in requirements.

Issue seems to be suddenly flagged by pyup (because of new version released?).
There is nothing to do about it, so disable daily notifications. 

Relates to https://github.com/kvesteri/sqlalchemy-utils/issues/166