### PR TITLE
Fix reconnect user / session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,9 @@ Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix erroneous config variable name. Changed ``magpie.user_registration_email_template`` to
   ``magpie.user_registration_submission_email_template``.
-* Fix ``sqlalchemy.orm.exc.DetachedInstanceError`` occurring on ``user.groups`` call
-  within ``ServiceInterface.effective_permissions`` resolution when caching differs
+* Fix ``sqlalchemy.orm.exc.DetachedInstanceError`` and ``transaction.interfaces.NoTransaction`` that
+  could occur on the first ``user.groups`` or ``GroupService.by_group_name`` operations
+  within ``ServiceInterface.effective_permissions`` resolution when caching states differed
   between ``service`` and ``acl`` regions.
 
 `3.18.0 <https://github.com/Ouranosinc/Magpie/tree/3.18.0>`_ (2021-10-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix erroneous config variable name. Changed ``magpie.user_registration_email_template`` to
   ``magpie.user_registration_submission_email_template``.
+* Fix ``sqlalchemy.orm.exc.DetachedInstanceError`` occurring on ``user.groups`` call
+  within ``ServiceInterface.effective_permissions`` resolution when caching differs
+  between ``service`` and ``acl`` regions.
 
 `3.18.0 <https://github.com/Ouranosinc/Magpie/tree/3.18.0>`_ (2021-10-27)
 ------------------------------------------------------------------------------------
@@ -54,7 +57,8 @@ Features / Changes
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
-* Fix HTTP ``Internal Server Error [500]`` on the page to edit a ``Group`` when deleting the last ``User`` of a ``Group``.
+* Fix HTTP ``Internal Server Error [500]`` on the page to edit a ``Group``
+  when deleting the last ``User`` of a ``Group``.
 
 `3.16.1 <https://github.com/Ouranosinc/Magpie/tree/3.16.1>`_ (2021-10-18)
 ------------------------------------------------------------------------------------

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -232,10 +232,10 @@ class ServiceInterface(object):
         permissions = self.effective_permissions(user, resource, permissions, allow_match)
         return [perm.ace(self.request.user) for perm in permissions]
 
-    def _get_connected_resource(self, resource):
-        # type: (ServiceOrResourceType) -> Optional[ServiceOrResourceType]
+    def _get_connected_object(self, obj):
+        # type: (Union[ServiceOrResourceType, models.User]) -> Optional[ServiceOrResourceType]
         """
-        Retrieve the resource with an active session and attached state by refreshing connection with request session.
+        Retrieve the object with an active session and attached state by refreshing connection with request session.
 
         This operation is required mostly in cases of mismatching references between cached and active objects obtained
         according to timing of requests and whether caching took placed between them, and for different caching region
@@ -252,35 +252,47 @@ class ServiceInterface(object):
             db_session = get_session_from_other(db_session)
             LOGGER.debug("Session [%s] created.", db_session)
 
-        # Reconnect resource reference to active database session if it is detached or inactive.
-        # - This can happen during mismatching sources of cached objects for service/ACL combinations,
+        # Reconnect the referenced object to active database session if it is detached or inactive.
+        # - This can happen during mismatching sources of cached objects for service/ACL region combinations,
         #   where service/resource data is available from cache but not associated with an appropriate session state.
         # - Since this operation is being computed, ACL is not yet cached (or was reset before service cache was).
         #   The service/resource must be refreshed regardless of cache to resolve it with other object references.
+        # - Because of possibly reconnected objects from previous calls to this method, other objects might also need
+        #   to be synced with the same database session.
         # In case the DB session was inactive and a new one was recreated above, also ensure that the resource did not
         # already have an handle referring to the old session.
-        res_session = get_db_session(session=None, obj=resource)
-        if res_session is None or not res_session.is_active:
-            if res_session is None:
-                LOGGER.debug("Reconnect cached resource [%s] with active request session (missing session).", resource)
+        obj_session = get_db_session(session=None, obj=obj)
+        if isinstance(obj, models.User):
+            obj_type = "user"
+        elif isinstance(obj, models.Service):
+            obj_type = "service"
+        else:
+            obj_type = "resource"
+        if obj_session is None or not obj_session.is_active:
+            if obj_session is None:
+                LOGGER.debug("Reconnect cached %s [%s] with active request session (missing session).", obj_type, obj)
             else:
-                LOGGER.debug("Reconnect cached resource [%s] with active request session (inactive session).", resource)
-            resource = ResourceService.by_resource_id(resource.resource_id, db_session=db_session)
-            if resource is None:
-                LOGGER.warning("Reconnect cached resource to active session failed!")
-                LOGGER.debug("Session: %s, Resource: %s", db_session, resource)
+                LOGGER.debug("Reconnect cached %s [%s] with active request session (inactive session).", obj_type, obj)
+            if obj_type == "user":
+                obj_connect = UserService.by_id(obj.id, db_session=db_session)
+            else:
+                obj_connect = ResourceService.by_resource_id(obj.resource_id, db_session=db_session)
+            if obj_connect is None:
+                LOGGER.warning("Reconnect cached %s to active session failed!", obj_type)
+                LOGGER.debug("Session: %s, Resource: %s, Type: %s", db_session, obj, obj_type)
                 return None
+            obj = obj_connect
         # Merge retrieved resource to the active session if not already attached.
-        state = sa_inspect(resource)
+        state = sa_inspect(obj)
         if state.detached:
-            LOGGER.debug("Reconnect cached resource [%s] with active request session (detached state).", resource)
-            resource = db_session.merge(resource)
-            state = sa_inspect(resource)
+            LOGGER.debug("Reconnect cached %s [%s] with active request session (detached state).", obj_type, obj)
+            obj = db_session.merge(obj)
+            state = sa_inspect(obj)
 
-        LOGGER.debug("Resource [%s] is [%s] %s session [%s, active=%s, id=%s].",
-                     resource, "detached" if state.detached else "attached", "from" if state.detached else "to",
+        LOGGER.debug("Object [%s] is [%s] %s session [%s, active=%s, id=%s].",
+                     obj, "detached" if state.detached else "attached", "from" if state.detached else "to",
                      state.session, state.session.is_active, state.session_id)
-        return resource
+        return obj
 
     def _get_request_path_parts(self):
         # type: () -> Optional[List[Str]]
@@ -352,6 +364,7 @@ class ServiceInterface(object):
         requested_perms = set(permissions)  # type: Set[Permission]
         effective_perms = dict()            # type: Dict[Permission, PermissionSet]
 
+        user = self._get_connected_object(user)  # groups dynamically populated fail if not connected (for admin check)
         LOGGER.debug("Resolving effective permission for: [user: %s, resource: %s, permissions: %s, match: %s]",
                      user, resource, list(permissions), allow_match)
 
@@ -375,7 +388,7 @@ class ServiceInterface(object):
         # current and parent resource(s) recursive-scope
         while resource is not None and not full_break:  # bottom-up until service is reached
             LOGGER.debug("Resolving for (sub-)resource: [%s]", resource)
-            resource = self._get_connected_resource(resource)
+            resource = self._get_connected_object(resource)
             if resource is None:
                 LOGGER.warning("Resource 'None' after reconnection attempt. Early stop effective resolution loop.")
                 break


### PR DESCRIPTION
Using test results of https://github.com/bird-house/birdhouse-deploy/pull/197#issuecomment-978164867
And the extended stress-test logs in daccs-jenkins.crim.ca/job/PAVICS-e2e-workflow-tests/job/master/663

We can see that previous places where most of the time that ``DetachedInstanceError`` and ``NoTransaction`` were raised are gone. 
Only two case where raised within the thousands of requests.

Attempt to fix them with similar operation reconnecting the session or reattaching the object to it. 
Added a minimal test to early detect such situations in the future if a new step is added to the code, but those errors are really hard to evaluate more than this. 