### PR TITLE
Retry session tm failure

### DIFF
--- a/.github/.gitleaks.toml
+++ b/.github/.gitleaks.toml
@@ -115,8 +115,4 @@ title = "gitleaks config"
     '''(go.mod|go.sum)$''',
     # old commit files with false positives or dummy data
     '''magpie/login/login.py''',
-<<<<<<< HEAD
     '''.+(.js.map)$''']
-=======
-    '''magpie/ui/swagger-ui/swagger-ui-bundle.js.map''']
->>>>>>> 2b7ce217... ignore old dummy data

--- a/.github/.gitleaks.toml
+++ b/.github/.gitleaks.toml
@@ -115,4 +115,8 @@ title = "gitleaks config"
     '''(go.mod|go.sum)$''',
     # old commit files with false positives or dummy data
     '''magpie/login/login.py''',
+<<<<<<< HEAD
     '''.+(.js.map)$''']
+=======
+    '''magpie/ui/swagger-ui/swagger-ui-bundle.js.map''']
+>>>>>>> 2b7ce217... ignore old dummy data

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Features / Changes
   utilities in a common location and let the initialization part only include sub-modules.
 * Avoid double call of ``setup_ziggurat_config`` detected during refactor.
 * Adjust handling and ordering of tweens to ensure intended behaviour and compatibility with ``pyramid_retry``.
+* Update `Twitcher` base ``Docker.adapter`` image to ``v0.6.2`` to provide fixes related to session transaction
+  handling (relates to `bird-house/twitcher#111 <https://github.com/bird-house/twitcher/pull/111>`_).
 
 `3.18.2 <https://github.com/Ouranosinc/Magpie/tree/3.18.2>`_ (2021-11-26)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,15 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add ``pyramid_retry`` package to attempt auto-recovering from still unhandled errors
+  ``sqlalchemy.orm.exc.DetachedInstanceError`` and ``transaction.interfaces.NoTransaction``
+  following invalid cached/reset sessions and objects.
+* Refactor application configuration from ``magpie.__init__`` to ``magpie.app`` to setup all relevant modules and
+  utilities in a common location and let the initialization part only include sub-modules.
+* Avoid double call of ``setup_ziggurat_config`` detected during refactor.
+* Adjust handling and ordering of tweens to ensure intended behaviour and compatibility with ``pyramid_retry``.
 
 `3.18.2 <https://github.com/Ouranosinc/Magpie/tree/3.18.2>`_ (2021-11-26)
 ------------------------------------------------------------------------------------

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -3,7 +3,7 @@
 #   docker run will need to override ini file with mounted volume
 #   using config 'twitcher.adapter = magpie.adapter.MagpieAdapter'
 #
-FROM birdhouse/twitcher:v0.5.6
+FROM birdhouse/twitcher:v0.6.2-rc
 LABEL Description="Configures MagpieAdapter on top of Twitcher application."
 LABEL Maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL Vendor="CRIM"

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -3,7 +3,7 @@
 #   docker run will need to override ini file with mounted volume
 #   using config 'twitcher.adapter = magpie.adapter.MagpieAdapter'
 #
-FROM birdhouse/twitcher:v0.6.2-rc
+FROM birdhouse/twitcher:v0.6.2
 LABEL Description="Configures MagpieAdapter on top of Twitcher application."
 LABEL Maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL Vendor="CRIM"

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -89,6 +89,16 @@ cache.acl.enabled = false
 cache.service.enabled = false
 # cache.service.expire = 10
 
+# amount of retries to allow following failed requests for specific
+# database session/transaction errors (usually related to cache handling/reset timing)
+retry.attempts = 2
+
+# output request authentication details in logs
+# WARNING:
+#   Enabling this feature will leak important authentication details in debug logs.
+#   Magpie logger in below section must also be set to DEBUG level.
+magpie.debug_cookie_identity = false
+
 [app:api_app]
 use = egg:Paste#static
 document_root = %(here)s/ui/swagger

--- a/magpie/__init__.py
+++ b/magpie/__init__.py
@@ -1,50 +1,23 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-import sys
-
 # NOTE:
 #   Do not import anything here that is not part of the python standard library.
 #   Any external package could still not yet be installed when importing the package
 #   to access high-level information such as the metadata (__meta__.py).
+from __future__ import unicode_literals
+
+import sys
 
 
 def includeme(config):
     # import needs to be here, otherwise ImportError happens during setup.py install (modules not yet installed)
     # pylint: disable=C0415
-    from pyramid.events import NewRequest
-    from pyramid.tweens import EXCVIEW
-
-    from magpie.api import generic as ag
     from magpie.constants import get_constant
-    from magpie.utils import fully_qualified_name, get_logger, log_exception_tween, log_request, setup_ziggurat_config
+    from magpie.utils import get_logger
 
     mod_dir = get_constant("MAGPIE_MODULE_DIR", config)
     logger = get_logger(__name__)
     logger.info("Adding MAGPIE_MODULE_DIR='%s' to path.", mod_dir)
     sys.path.insert(0, mod_dir)
-
-    config.add_exception_view(ag.internal_server_error)
-    config.add_forbidden_view(ag.unauthorized_or_forbidden)
-    config.add_notfound_view(RemoveSlashNotFoundViewFactory(ag.not_found_or_method_not_allowed), append_slash=True)
-    config.set_default_permission(get_constant("MAGPIE_ADMIN_PERMISSION", config))
-
-    tween_position = fully_qualified_name(ag.apply_response_format_tween)
-    config.add_tween(tween_position, over=EXCVIEW)
-    if get_constant("MAGPIE_LOG_REQUEST", config):
-        config.add_subscriber(log_request, NewRequest)
-    if get_constant("MAGPIE_LOG_EXCEPTION", config):
-        tween_name = fully_qualified_name(log_exception_tween)
-        config.add_tween(tween_name, under=tween_position)
-        tween_position = tween_name
-    config.add_tween(fully_qualified_name(ag.validate_accept_header_tween), under=tween_position)
-
-    setup_ziggurat_config(config)
-    config.include("cornice")
-    config.include("cornice_swagger")
-    config.include("pyramid_chameleon")
-    config.include("pyramid_beaker")
-    config.include("pyramid_mako")
 
     config.include("magpie.api")
     config.include("magpie.db")
@@ -52,28 +25,3 @@ def includeme(config):
         config.include("magpie.ui")
     else:
         logger.warning("Magpie UI not enabled.")
-
-
-class RemoveSlashNotFoundViewFactory(object):
-    """
-    Utility that will try to resolve a path without appended slash if one was provided.
-    """
-    def __init__(self, notfound_view=None):
-        self.notfound_view = notfound_view
-
-    def __call__(self, request):
-        from pyramid.httpexceptions import HTTPMovedPermanently
-        from pyramid.interfaces import IRoutesMapper
-        path = request.path
-        registry = request.registry
-        mapper = registry.queryUtility(IRoutesMapper)
-        if mapper is not None and path.endswith("/"):
-            no_slash_path = path.rstrip("/")
-            no_slash_path = no_slash_path.split("/magpie", 1)[-1]
-            for route in mapper.get_routes():
-                if route.match(no_slash_path) is not None:
-                    query = request.query_string
-                    if query:
-                        no_slash_path += "?" + query
-                    return HTTPMovedPermanently(location=no_slash_path)
-        return self.notfound_view(request)

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -7,8 +7,8 @@ Magpie is a service for AuthN and AuthZ based on Ziggurat-Foundations.
 import logging
 
 from pyramid.events import NewRequest
-from pyramid.tweens import EXCVIEW, MAIN
 from pyramid.settings import asbool
+from pyramid.tweens import EXCVIEW, MAIN
 from pyramid_beaker import set_cache_regions_from_settings
 
 from magpie.api.generic import (

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -15,7 +15,14 @@ from magpie.constants import get_constant
 from magpie.db import get_db_session_from_config_ini, run_database_migration_when_ready, set_sqlalchemy_log_level
 from magpie.register import magpie_register_permissions_from_config, magpie_register_services_from_config
 from magpie.security import get_auth_config
-from magpie.utils import get_logger, patch_magpie_url, print_log, setup_cache_settings, setup_ziggurat_config
+from magpie.utils import (
+    get_logger,
+    patch_magpie_url,
+    print_log,
+    setup_cache_settings,
+    setup_session_config,
+    setup_ziggurat_config
+)
 
 LOGGER = get_logger(__name__)
 
@@ -96,6 +103,7 @@ def main(global_config=None, **settings):  # noqa: F811
     config = get_auth_config(settings)
     setup_cache_settings(settings)  # default 'cache=off' if missing since 'pyramid_beaker' enables it otherwise
     set_cache_regions_from_settings(settings)  # parse/convert cache settings into regions understood by beaker
+    setup_session_config(config)
     setup_ziggurat_config(config)
 
     # don't use scan otherwise modules like 'magpie.adapter' are

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -6,9 +6,19 @@ Magpie is a service for AuthN and AuthZ based on Ziggurat-Foundations.
 """
 import logging
 
+from pyramid.events import NewRequest
+from pyramid.tweens import EXCVIEW, MAIN
 from pyramid.settings import asbool
 from pyramid_beaker import set_cache_regions_from_settings
 
+from magpie.api.generic import (
+    RemoveSlashNotFoundViewFactory,
+    apply_response_format_tween,
+    internal_server_error,
+    not_found_or_method_not_allowed,
+    unauthorized_or_forbidden,
+    validate_accept_header_tween
+)
 from magpie.api.webhooks import setup_webhooks
 from magpie.cli.register_defaults import register_defaults
 from magpie.constants import get_constant
@@ -16,7 +26,10 @@ from magpie.db import get_db_session_from_config_ini, run_database_migration_whe
 from magpie.register import magpie_register_permissions_from_config, magpie_register_services_from_config
 from magpie.security import get_auth_config
 from magpie.utils import (
+    fully_qualified_name,
     get_logger,
+    log_exception_tween,
+    log_request,
     patch_magpie_url,
     print_log,
     setup_cache_settings,
@@ -105,6 +118,26 @@ def main(global_config=None, **settings):  # noqa: F811
     set_cache_regions_from_settings(settings)  # parse/convert cache settings into regions understood by beaker
     setup_session_config(config)
     setup_ziggurat_config(config)
+
+    config.add_exception_view(internal_server_error)
+    config.add_forbidden_view(unauthorized_or_forbidden)
+    config.add_notfound_view(RemoveSlashNotFoundViewFactory(not_found_or_method_not_allowed), append_slash=True)
+    config.set_default_permission(get_constant("MAGPIE_ADMIN_PERMISSION", config))
+
+    tween_position = fully_qualified_name(apply_response_format_tween)
+    config.add_tween(tween_position, over=EXCVIEW)
+    if get_constant("MAGPIE_LOG_REQUEST", config):
+        config.add_subscriber(log_request, NewRequest)
+    if get_constant("MAGPIE_LOG_EXCEPTION", config):
+        tween_name = fully_qualified_name(log_exception_tween)
+        config.add_tween(tween_name, under=tween_position)
+    config.add_tween(fully_qualified_name(validate_accept_header_tween), under=EXCVIEW, over=MAIN)
+
+    config.include("cornice")
+    config.include("cornice_swagger")
+    config.include("pyramid_chameleon")
+    config.include("pyramid_beaker")
+    config.include("pyramid_mako")
 
     # don't use scan otherwise modules like 'magpie.adapter' are
     # automatically found and cause import errors on missing packages

--- a/magpie/cli/batch_update_users.py
+++ b/magpie/cli/batch_update_users.py
@@ -39,7 +39,7 @@ def format_response(response):
 def get_login_session(magpie_url, username, password, return_response=False):
     session = requests.Session()
     data = {"user_name": username, "password": password}
-    response = session.post(magpie_url + "/signin", data=data)
+    response = session.post(magpie_url + "/signin", json=data)
     fmt_resp = format_response(response)
     if return_response:
         return fmt_resp

--- a/magpie/db.py
+++ b/magpie/db.py
@@ -18,6 +18,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.orm import configure_mappers, scoped_session
 from sqlalchemy.orm.session import Session, sessionmaker
 from zope.sqlalchemy import register
+from zope.sqlalchemy.datamanager import join_transaction
 
 from magpie.constants import get_constant
 from magpie.utils import get_logger, get_settings, get_settings_from_config_ini, print_log, raise_log
@@ -160,6 +161,9 @@ def get_connected_session(request):
         LOGGER.debug("Session [%s] was inactive, creating new scoped session for resource.", db_session)
         db_session = get_session_from_other(db_session)
         LOGGER.debug("Session [%s] created.", db_session)
+
+    # no-op if already joined, but make sure to initiate if no transaction when session reestablished from cache
+    join_transaction(db_session)
     return db_session
 
 

--- a/magpie/security.py
+++ b/magpie/security.py
@@ -69,18 +69,6 @@ def get_auth_config(container):
     """
     settings = get_settings(container)
 
-    # avoid sporadic errors session/transaction errors
-    #   - sqlalchemy.orm.exc.DetachedInstanceError
-    #   - transaction.interfaces.NoTransaction
-    # see also:
-    #   - https://docs.pylonsproject.org/projects/pyramid_tm/en/latest/
-    #   - https://github.com/Pylons/pyramid_tm/issues/74
-    #   - https://github.com/Ouranosinc/Magpie/issues/466
-    #   - https://github.com/Ouranosinc/Magpie/pull/473
-    # Note:
-    #   Set value here because both Magpie and Twitcher (via MagpieAdapter.configurator_factory) inherit this setting.
-    settings["tm.annotate_user"] = False
-
     magpie_secret = get_constant("MAGPIE_SECRET", settings, settings_name="magpie.secret")
     magpie_cookie_expire = get_constant("MAGPIE_COOKIE_EXPIRE", settings,
                                         settings_name="magpie.cookie_expire", default_value=None,

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -12,15 +12,14 @@ from typing import TYPE_CHECKING
 
 import requests
 import six
-from pyramid.config import PHASE1_CONFIG, ConfigurationError, Configurator
+from pyramid.config import ConfigurationError, Configurator
 from pyramid.httpexceptions import HTTPClientError, HTTPException, HTTPOk
-from pyramid.interfaces import IExecutionPolicy
 from pyramid.registry import Registry
 from pyramid.request import Request
 from pyramid.response import Response
 from pyramid.settings import asbool, truthy
 from pyramid.threadlocal import get_current_registry
-from pyramid_retry import IBeforeRetry, RetryableExecutionPolicy, mark_error_retryable
+from pyramid_retry import IBeforeRetry, mark_error_retryable
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict
 from six.moves import configparser

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -12,14 +12,15 @@ from typing import TYPE_CHECKING
 
 import requests
 import six
-from pyramid.config import ConfigurationError, Configurator
+from pyramid.config import PHASE1_CONFIG, ConfigurationError, Configurator
 from pyramid.httpexceptions import HTTPClientError, HTTPException, HTTPOk
+from pyramid.interfaces import IExecutionPolicy
 from pyramid.registry import Registry
 from pyramid.request import Request
 from pyramid.response import Response
 from pyramid.settings import asbool, truthy
 from pyramid.threadlocal import get_current_registry
-from pyramid_retry import IBeforeRetry, mark_error_retryable
+from pyramid_retry import IBeforeRetry, RetryableExecutionPolicy, mark_error_retryable
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict
 from six.moves import configparser

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+import time
 import types
 from distutils.dir_util import mkpath
 from typing import TYPE_CHECKING
@@ -18,11 +19,14 @@ from pyramid.request import Request
 from pyramid.response import Response
 from pyramid.settings import asbool, truthy
 from pyramid.threadlocal import get_current_registry
+from pyramid_retry import IBeforeRetry, mark_error_retryable
 from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict
 from six.moves import configparser
 from six.moves.urllib.parse import urlparse
 from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm.exc import DetachedInstanceError
+from transaction.interfaces import NoTransaction
 from webob.headers import EnvironHeaders, ResponseHeaders
 from ziggurat_foundations.models.services.user import UserService
 
@@ -40,6 +44,7 @@ if TYPE_CHECKING:
     from typing import Any, List, NoReturn, Optional, Type, Union
 
     from pyramid.events import NewRequest
+    from pyramid_retry import BeforeRetry
 
     from magpie import models
     from magpie.typedefs import (
@@ -266,6 +271,63 @@ def setup_cache_settings(settings, force=False, enabled=False, expire=0):
             settings.pop(cache_expire, None)
 
 
+def setup_session_config(config):
+    from magpie.db import get_engine, get_session_factory, get_tm_session
+
+    settings = get_settings(config)
+
+    # avoid sporadic errors session/transaction errors
+    #   - sqlalchemy.orm.exc.DetachedInstanceError
+    #   - transaction.interfaces.NoTransaction
+    # see also:
+    #   - https://docs.pylonsproject.org/projects/pyramid_tm/en/latest/
+    #   - https://github.com/Pylons/pyramid_tm/issues/74
+    #   - https://github.com/Ouranosinc/Magpie/issues/466
+    #   - https://github.com/Ouranosinc/Magpie/pull/473
+    # Note:
+    #   Set value here because both Magpie and Twitcher (via MagpieAdapter.configurator_factory) inherit this setting.
+    settings["tm.annotate_user"] = False
+
+    def retry_warn(event):
+        # type: (BeforeRetry) -> None
+        LOGGER.warning("Will retry request [%s %s] following raised error [%s] during previous attempt.",
+                       event.exception, event.request.method, event.request.url)
+
+    # retry sporadic transaction or detached instance errors
+    # since these errors happen most of the time during cache reset, following retry should work as intended
+    settings.setdefault("retry.attempts", 2)
+    config.include("pyramid_retry")
+    config.add_subscriber(retry_warn, IBeforeRetry)
+    mark_error_retryable(DetachedInstanceError)
+    mark_error_retryable(NoTransaction)
+
+    # use 'pyramid_tm' to hook the transaction lifecycle to the request
+    # make 'request.db' available for use in Pyramid
+    config.include("pyramid_tm")
+    session_factory = get_session_factory(get_engine(settings))
+    config.registry["dbsession_factory"] = session_factory
+    config.add_request_method(
+        # 'request.tm' is the transaction manager used by 'pyramid_tm'
+        lambda request: get_tm_session(session_factory, request.tm), "db", reify=True
+    )
+
+    def debug_request_user(request):
+        # type: (Request) -> Optional[models.User]
+        """
+        Log debug authentication details if requested, and then retrieves the authenticated user.
+        """
+        debug_cookie_identify(request)
+        return get_request_user(request)
+
+    # Register an improved 'request.user' that reattaches the detached session if a transaction commit occurred.
+    #   don't use 'reify=True' to ensure the function is called and re-evaluates the detached state
+    #   replicate the value substitution optimization offered by 'reify' with an explicit attribute
+    settings.setdefault("magpie.debug_cookie_identity", False)
+    debug_user = LOGGER.isEnabledFor(logging.DEBUG) and asbool(settings["magpie.debug_cookie_identity"])
+    get_user = debug_request_user if debug_user else get_request_user
+    config.add_request_method(get_user, "user", reify=False, property=True)
+
+
 def setup_ziggurat_config(config):
     # type: (Configurator) -> None
     """
@@ -292,10 +354,49 @@ def setup_ziggurat_config(config):
     settings["ziggurat_foundations.sign_in.sign_out_pattern"] = "/signout"
     config.include("ziggurat_foundations.ext.pyramid.sign_in")
 
-    # Register an improved ``request.user`` that reattaches the detached session if a transaction commit occurred.
-    #   don't use 'reify=True' to ensure the function is called and re-evaluates the detached state
-    #   replicate the value substitution optimization offered by 'reify' with an explicit attribute
-    config.add_request_method(get_request_user, "user", reify=False, property=True)
+
+def debug_cookie_identify(request):
+    """
+    Logs debug information about request cookie.
+
+    .. WARNING::
+
+        This function is intended for debugging purposes only. It reveals sensible configuration information.
+
+    Re-implements basic functionality of :func:`pyramid.AuthTktAuthenticationPolicy.cookie.identify` called via
+    :func:`request.unauthenticated_userid` within :func:`get_request_user` to provide additional logging.
+
+    .. seealso::
+        - :class:`pyramid.authentication.AuthTktCookieHelper`
+        - :class:`pyramid.authentication.AuthTktAuthenticationPolicy`
+    """
+    # pylint: disable=W0212
+    cookie_inst = request._get_authentication_policy().cookie  # noqa: W0212
+    cookie = request.cookies.get(cookie_inst.cookie_name)
+
+    LOGGER.debug("Cookie (name: %s, secret: %s, hash-alg: %s) : %s",
+                 cookie_inst.cookie_name, cookie_inst.secret, cookie_inst.hashalg, cookie)
+
+    if not cookie:
+        LOGGER.debug("No Cookie!")
+    else:
+        if cookie_inst.include_ip:
+            environ = request.environ
+            remote_addr = environ["REMOTE_ADDR"]
+        else:
+            remote_addr = "0.0.0.0"  # nosec # only for log debugging
+
+        LOGGER.debug("Cookie remote addr (include_ip: %s) : %s", cookie_inst.include_ip, remote_addr)
+        now = time.time()
+        timestamp, _, _, _ = cookie_inst.parse_ticket(cookie_inst.secret, cookie, remote_addr, cookie_inst.hashalg)
+        LOGGER.debug("Cookie timestamp: %s, timeout: %s, now: %s", timestamp, cookie_inst.timeout, now)
+
+        if cookie_inst.timeout and ((timestamp + cookie_inst.timeout) < now):
+            # the auth_tkt data has expired
+            LOGGER.debug("Cookie is expired")
+
+        # Could raise useful exception explaining why unauthenticated_userid is None
+        request._get_authentication_policy().cookie.identify(request)  # noqa: W0212
 
 
 def get_request_user(request):

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -291,7 +291,7 @@ def setup_session_config(config):
     def retry_warn(event):
         # type: (BeforeRetry) -> None
         LOGGER.warning("Will retry request [%s %s] following raised error [%s] during previous attempt.",
-                       event.exception, event.request.method, event.request.url)
+                       event.request.method, event.request.url, event.exception)
 
     # retry sporadic transaction or detached instance errors
     # since these errors happen most of the time during cache reset, following retry should work as intended

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ pylint<2.7; python_version < "3.6"  # pyup: ignore
 pylint>=2.7,!=2.7.3,<2.8; python_version >= "3.6"
 pylint-quotes
 # bird-house/twticher, must match version in Dockerfile.adapater
-pyramid-twitcher>=0.5.3  # pyup: ignore
+pyramid-twitcher>=0.6.2
 pytest
 python2-secrets; python_version <= "3.5"
 safety

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,8 @@ pylint<2.7; python_version < "3.6"  # pyup: ignore
 pylint>=2.7,!=2.7.3,<2.8; python_version >= "3.6"
 pylint-quotes
 # bird-house/twticher, must match version in Dockerfile.adapater
-pyramid-twitcher>=0.6.2
+pyramid-twitcher>=0.5.3; python_version < "3.6"  # pyup: ignore
+pyramid-twitcher>=0.6.2; python_version >= "3.6"
 pytest
 python2-secrets; python_version <= "3.5"
 safety

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pyramid>=1.10.2,<2
 pyramid_beaker==0.8
 pyramid_chameleon>=0.3
 pyramid_mako>=1.0.2
-pyramid_retry==1.0
+pyramid_retry==2.1.1
 pyramid_tm>=2.2.1
 python-dotenv
 python2-secrets; python_version <= "3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ pyramid>=1.10.2,<2
 pyramid_beaker==0.8
 pyramid_chameleon>=0.3
 pyramid_mako>=1.0.2
+pyramid_retry
 pyramid_tm>=2.2.1
 python-dotenv
 python2-secrets; python_version <= "3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,5 +59,4 @@ wheel
 webob
 ziggurat_foundations==0.8.4
 zope.interface>=4.7.2,<5
-zope.sqlalchemy<1.2; python_version < "3.7"
-zope.sqlalchemy==1.3; python_version >= "3.7"
+zope.sqlalchemy==1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pyramid>=1.10.2,<2
 pyramid_beaker==0.8
 pyramid_chameleon>=0.3
 pyramid_mako>=1.0.2
-pyramid_retry
+pyramid_retry==1.0
 pyramid_tm>=2.2.1
 python-dotenv
 python2-secrets; python_version <= "3.5"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -960,7 +960,8 @@ def test_request(test_item,             # type: AnyMagpieTestItemType
         if _body is not None and (json is not None or kwargs["content_type"] == CONTENT_TYPE_JSON):
             kwargs["params"] = json_pkg.dumps(_body, cls=json_pkg.JSONEncoder)
             kwargs["content_type"] = CONTENT_TYPE_JSON  # enforce if only 'json' keyword provided
-            kwargs["headers"]["Content-Length"] = str(len(kwargs["params"]))  # need to fix with override JSON payload
+        # always recalculate in case it was fixed with override JSON payload, or simply incorrect value provided
+        kwargs["headers"]["Content-Length"] = str(len(kwargs["params"]))
         if status and status >= 300:
             kwargs["expect_errors"] = True
         err_code = None


### PR DESCRIPTION
## Overview

Even with previous patches in `3.18.x` releases, some cases still seem to generate sporadic `NoTransaction` errors. 

## Changes 

- In order to (hopefully) fix this once and for all, add a retry operation specifically for the corresponding errors happening when desync of cached vs live db session are used.
- Combine the transaction/database/user configuration attached to the request on both `Magpie` itself and the `MagpieAdapter`, into a reusable setup function. 
- Clean/refactor the config setup using above function and centralize them into application main.
- Attempt session reconnect in a few more places that where highlighted in https://github.com/bird-house/birdhouse-deploy/pull/197#issuecomment-980431919
- Integrate fixes from https://github.com/bird-house/twitcher/pull/111