### PR TITLE
Implement combined Geoserver service and Workspace/Layer effective permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ venv
 
 # Node
 node_modules
+package.json
 package-lock.json
 
 # Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ share
 
 # Node
 node_modules
+package.json
 package-lock.json
 
 # Makefile

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Features / Changes
 * Add missing ``ServiceWFS`` permissions according to `OGC WFS standard <https://www.ogc.org/standards/wfs>`_.
 * Add missing ``DescribeLayer`` permission to ``ServiceGeoserverWMS`` according
   to `GeoServer WMS implementation <https://docs.geoserver.org/latest/en/user/services/wms/reference.html>`_.
+* Add support of specific hierarchy of ``Resource`` type ``Layer`` nested under ``Workspace``
+  for ``ServiceGeoserverWMS``.
+* Add support of ``Resource`` type ``Layer`` under ``ServiceWFS``.
 * Allow ``Resource`` and ``Service`` name to contain colon (``:``) character in order to define scoped names
   as it is often the case for ``Layer`` names.
 * Add ``child_structure_allowed`` attribute to ``Service`` implementations allowing them to define specific path-like

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ Features / Changes
 * Add ``child_structure_allowed`` to ``ServiceAPI`` and ``ServiceTHREDDS`` to be more explicit about allowed structure
   hierarchies in API responses. Their original behaviour remains unchanged, but is further enforced during validation
   of their children resource type creation against explicit structure.
+* Add multiple ``Resource`` ACL resolution within the same request to support ``Service`` implementations that can refer
+  to multiple items simultaneously. An example of this is the comma-separated list of ``Layer`` defined by ``typeNames``
+  of new ``ServiceGeoserverWMS`` implementation. Access is granted if the ``User`` has access to **ALL** ``Resource``
+  resolved from parsing the request.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ Features / Changes
 * Adjust UI to consider ``child_structure_allowed`` definitions to propose only applicable ``Resource`` types in the
   combobox when creating a new ``Resource`` in the tree hierarchy.
 * Add UI submission field to provide ``Service`` JSON configuration at creation when supported by the type.
+* Add ``child_structure_allowed`` to ``ServiceAPI`` and ``ServiceTHREDDS`` to be more explicit about allowed structure
+  hierarchies in API responses. Their original behaviour remains unchanged, but is further enforced during validation
+  of their children resource type creation against explicit structure.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ Bug Fixes
   custom configuration, ``ServiceTHREDDS`` implementation would not report their default configuration and would
   instead return ``null``, making it difficult to know from the API if default or no configuration was being applied
   for a given ``Service``.
+* Fix `Effective Resolution` of ``Permission`` applied for ``ServiceGeoserverWMS`` to consider ``Scope`` modifier
+  of ``Service`` and ``Workspace`` for access to be resolved at the ``Layer`` level.
 
 `3.20.0 <https://github.com/Ouranosinc/Magpie/tree/3.20.0>`_ (2022-01-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ Bug Fixes
 * Fix base ``Permission`` definitions for all variants of `WMS` according to their reference implementations.
 * Remove multiple invalid schema path definitions that are not mapped against any concrete API endpoint.
 * Fix reporting of ``Service`` configuration for any type that supports it. Unless overridden during creation with a
-  custom configuration, ``ServiceTHREDDS`` implementation would not report their default configuration and would
+  custom configuration, ``ServiceTHREDDS`` instances would not report their default ``configuration`` field and would
   instead return ``null``, making it difficult to know from the API if default or no configuration was being applied
   for a given ``Service``.
 * Fix `Effective Resolution` of ``Permission`` applied for ``ServiceGeoserverWMS`` to consider ``Scope`` modifier

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,12 +22,12 @@ Features / Changes
 * Add support of ``Resource`` type ``Layer`` under ``ServiceWFS``.
 * Allow ``Resource`` and ``Service`` name to contain colon (``:``) character in order to define scoped names
   as it is often the case for ``Layer`` names.
-* Add ``child_structure_allowed`` attribute to ``Service`` implementations allowing them to define specific path-like
-  structures of allowed ``Resource`` types hierarchies in order to control at which level and which combinations
-  of nested ``Resource`` types are valid under their root ``Service``. When not defined under a ``Service``
-  implementation, any defined ``Resource`` type will remain available for creation at any level of the hierarchy,
-  unless the corresponding ``Resource`` in the tree already defined ``child_resource_allowed = False``. This was
-  already the original behaviour in previous versions.
+* Add ``child_structure_allowed`` attribute to ``Service`` implementations allowing them to define specific
+  structures of allowed ``Resource`` types hierarchies in order to control which combinations of nested ``Resource``
+  types are valid under their root ``Service``. When not defined under a ``Service`` implementation, any defined
+  ``Resource`` type will remain available for creation at any level of the hierarchy, unless the corresponding
+  ``Resource`` in the tree already defined ``child_resource_allowed = False``. This was already the original behaviour
+  in previous versions.
 * Add ``GET /resources/{id}/types`` endpoint that allows retrieval of applicable children ``Resource`` types under
   a given ``Resource`` considering the nested hierarchy definition of its root ``Service`` defined by the new
   attribute ``child_structure_allowed``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,11 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* Allow ``Resource`` and ``Service`` name to contain colon (``:``) character in order to define scoped names.
+* Add missing ``ServiceWFS`` permissions according to `OGC WFS standard <https://www.ogc.org/standards/wfs>`_.
+* Add missing ``DescribeLayer`` permission to ``ServiceGeoserverWMS`` according
+  to `GeoServer WMS implementation <https://docs.geoserver.org/latest/en/user/services/wms/reference.html>`_.
+* Allow ``Resource`` and ``Service`` name to contain colon (``:``) character in order to define scoped names
+  as it is often the case for ``Layer`` names.
 * Add ``child_structure_allowed`` attribute to ``Service`` implementations allowing them to define specific path-like
   structures of allowed ``Resource`` types hierarchies in order to control at which level and which combinations
   of nested ``Resource`` types are valid under their root ``Service``. When not defined under a ``Service``
@@ -31,7 +35,9 @@ Features / Changes
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
-* Remove invalid ``request`` parameter in ``ServiceTHREDDS`` implementation.
+* Remove invalid ``params_expected`` parameter from ``Service`` implementations (``ServiceAccess``, ``ServiceAPI``,
+  ``ServiceTHREDDS``) that don't make use of it since they don't derive from ``ServiceOWS``.
+* Fix base ``Permission`` definitions for all variants of `WMS` according to their reference implementations.
 * Remove multiple invalid schema path definitions that are not mapped against any concrete API endpoint.
 * Fix reporting of ``Service`` configuration for any type that supports it. Unless overridden during creation with a
   custom configuration, ``ServiceTHREDDS`` implementation would not report their default configuration and would

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,26 @@ Changes
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Allow ``Resource`` and ``Service`` name to contain colon (``:``) character in order to define scoped names.
+* Add ``child_structure_allowed`` attribute to ``Service`` implementations allowing them to define specific path-like
+  structures of allowed ``Resource`` types hierarchies in order to control at which level and which combinations
+  of nested ``Resource`` types are valid under their root ``Service``. When not defined under a ``Service``
+  implementation, any defined ``Resource`` type will remain available for creation at any level of the hierarchy,
+  unless the corresponding ``Resource`` in the tree already defined ``child_resource_allowed = False``. This was
+  already the original behaviour in previous versions.
+* Add ``GET /resources/{id}/types`` endpoint that allows retrieval of applicable children ``Resource`` types under
+  a given ``Resource`` considering the nested hierarchy definition of its root ``Service`` defined by the new
+  attribute ``child_structure_allowed``.
+* Add ``child_structure_allowed`` attribute to the response of ``GET /service/{name}`` endpoint.
+  For backward compatibility, ``resource_types_allowed`` parameter already available in the same response will continue
+  to report all possible ``Resource`` types *at any level* under the ``Service`` hierarchy, although not necessarily
+  applicable as immediate child ``Resource`` under that ``Service``.
+* Adjust UI to consider ``child_structure_allowed`` definitions to propose only applicable ``Resource`` types in the
+  combobox when creating a new ``Resource`` in the tree hierarchy.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Remove invalid ``request`` parameter in ``ServiceTHREDDS`` implementation.
+* Remove multiple invalid schema path definitions that are not mapped against any concrete API endpoint.
 
 `3.20.0 <https://github.com/Ouranosinc/Magpie/tree/3.20.0>`_ (2022-01-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,22 +7,6 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
-
-`3.20.1 <https://github.com/Ouranosinc/Magpie/tree/3.20.1>`_ (2022-01-19)
-------------------------------------------------------------------------------------
-
-Bug Fixes
-~~~~~~~~~~~~~~~~~~~~~
-* Fix `Twitcher` ``/verify`` endpoint integrated through ``MagpieAdapter`` to validate synchronized authentication
-  policies across both services. The endpoint now supports query parameter credentials to facilitate call directly
-  within a web browser (not assuming JSON contents) and properly parses cookies from both policies to report more
-  detailed error messages in case of failure.
-* Fix ``error`` and ``type`` representation when handling raised exception by ``evaluate_call`` utility function.
-
-`3.20.0 <https://github.com/Ouranosinc/Magpie/tree/3.20.0>`_ (2022-01-06)
-------------------------------------------------------------------------------------
-
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Add missing ``ServiceWFS`` permissions according to `OGC WFS standard <https://www.ogc.org/standards/wfs>`_.
@@ -64,6 +48,17 @@ Bug Fixes
   for a given ``Service``.
 * Fix `Effective Resolution` of ``Permission`` applied for ``ServiceGeoserverWMS`` to consider ``Scope`` modifier
   of ``Service`` and ``Workspace`` for access to be resolved at the ``Layer`` level.
+
+`3.20.1 <https://github.com/Ouranosinc/Magpie/tree/3.20.1>`_ (2022-01-19)
+------------------------------------------------------------------------------------
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix `Twitcher` ``/verify`` endpoint integrated through ``MagpieAdapter`` to validate synchronized authentication
+  policies across both services. The endpoint now supports query parameter credentials to facilitate call directly
+  within a web browser (not assuming JSON contents) and properly parses cookies from both policies to report more
+  detailed error messages in case of failure.
+* Fix ``error`` and ``type`` representation when handling raised exception by ``evaluate_call`` utility function.
 
 `3.20.0 <https://github.com/Ouranosinc/Magpie/tree/3.20.0>`_ (2022-01-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,9 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Allow ``Resource`` and ``Service`` name to contain colon (``:``) character in order to define scoped names.
 
 `3.20.0 <https://github.com/Ouranosinc/Magpie/tree/3.20.0>`_ (2022-01-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+* Nothing new for the moment.
+
+`3.20.0 <https://github.com/Ouranosinc/Magpie/tree/3.20.0>`_ (2022-01-06)
+------------------------------------------------------------------------------------
+
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Add improved UI display of long ``Permission`` titles for ``Resource`` hierarchy tree headers.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,13 +23,20 @@ Features / Changes
   For backward compatibility, ``resource_types_allowed`` parameter already available in the same response will continue
   to report all possible ``Resource`` types *at any level* under the ``Service`` hierarchy, although not necessarily
   applicable as immediate child ``Resource`` under that ``Service``.
+* Add ``configurable`` attribute to ``Service`` types that supports custom definitions modifying their behaviour.
+* Add ``service_configurable`` to response of ``GET /service/{name}`` endpoint.
 * Adjust UI to consider ``child_structure_allowed`` definitions to propose only applicable ``Resource`` types in the
   combobox when creating a new ``Resource`` in the tree hierarchy.
+* Add UI submission field to provide ``Service`` JSON configuration at creation when supported by the type.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Remove invalid ``request`` parameter in ``ServiceTHREDDS`` implementation.
 * Remove multiple invalid schema path definitions that are not mapped against any concrete API endpoint.
+* Fix reporting of ``Service`` configuration for any type that supports it. Unless overridden during creation with a
+  custom configuration, ``ServiceTHREDDS`` implementation would not report their default configuration and would
+  instead return ``null``, making it difficult to know from the API if default or no configuration was being applied
+  for a given ``Service``.
 
 `3.20.0 <https://github.com/Ouranosinc/Magpie/tree/3.20.0>`_ (2022-01-06)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,7 @@ Features / Changes
 * Add ``child_structure_allowed`` to ``ServiceAPI`` and ``ServiceTHREDDS`` to be more explicit about allowed structure
   hierarchies in API responses. Their original behaviour remains unchanged, but is further enforced during validation
   of their children resource type creation against explicit structure.
-* Add multiple ``Resource`` ACL resolution within the same request to support ``Service`` implementations that can refer
+* Add multi-``Resource`` ACL resolution within the same request to support ``Service`` implementations that can refer
   to multiple items simultaneously. An example of this is the comma-separated list of ``Layer`` defined by ``typeNames``
   of new ``ServiceGeoserverWMS`` implementation. Access is granted if the ``User`` has access to **ALL** ``Resource``
   resolved from parsing the request.

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ install-npm:    		## install npm package manager if it cannot be found
 	)
 	@[ `npm ls 2>/dev/null | grep stylelint-config-standard | wc -l` = 1 ] || ( \
 		echo "Install required libraries for style checks." && \
-		npm install stylelint stylelint-config-standard --save-dev \
+		npm install stylelint@13.13.1 stylelint-config-standard@22.0.0 --save-dev \
 	)
 
 ## --- Launchers targets --- ##

--- a/Makefile
+++ b/Makefile
@@ -696,7 +696,7 @@ test-remote-only:		## run only remote tests with the environment Python
 .PHONY: test-custom-only
 test-custom-only:		## run custom marker tests using SPEC="<marker-specification>"
 	@echo "Running custom tests..."
-	@[ "${SPEC}" ] || ( echo ">> 'TESTS' is not set"; exit 1 )
+	@[ "${SPEC}" ] || ( echo ">> 'SPEC' is not set"; exit 1 )
 	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) -m "${SPEC}" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-docker

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ MAKEFILE_NAME := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
 # Application
 APP_ROOT    := $(abspath $(lastword $(MAKEFILE_NAME))/..)
 APP_NAME    := magpie
-APP_VERSION ?= 3.19.1
+APP_VERSION ?= 3.20.0
 APP_INI     ?= $(APP_ROOT)/config/$(APP_NAME).ini
 
 # guess OS (Linux, Darwin,...)

--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,13 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
     :alt: Requires Python 2.7, 3.5+
     :target: https://www.python.org/getit
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/Ouranosinc/Magpie/3.19.1.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/Ouranosinc/Magpie/3.20.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/Ouranosinc/Magpie/compare/3.19.1...master
+    :target: https://github.com/Ouranosinc/Magpie/compare/3.20.0...master
 
-.. |version| image:: https://img.shields.io/badge/tag-3.19.1-blue.svg?style=flat
+.. |version| image:: https://img.shields.io/badge/tag-3.20.0-blue.svg?style=flat
     :alt: Latest Tag
-    :target: https://github.com/Ouranosinc/Magpie/tree/3.19.1
+    :target: https://github.com/Ouranosinc/Magpie/tree/3.20.0
 
 .. |dependencies| image:: https://pyup.io/repos/github/Ouranosinc/Magpie/shield.svg
     :alt: Dependencies Status
@@ -45,9 +45,9 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
     :alt: Github Actions CI Build Status (master branch)
     :target: https://github.com/Ouranosinc/Magpie/actions?query=workflow%3ATests+branch%3Amaster
 
-.. |github_tagged| image:: https://img.shields.io/github/workflow/status/Ouranosinc/Magpie/Tests/3.19.1?label=3.19.1
+.. |github_tagged| image:: https://img.shields.io/github/workflow/status/Ouranosinc/Magpie/Tests/3.20.0?label=3.20.0
     :alt: Github Actions CI Build Status (latest tag)
-    :target: https://github.com/Ouranosinc/Magpie/actions?query=workflow%3ATests+branch%3A3.19.1
+    :target: https://github.com/Ouranosinc/Magpie/actions?query=workflow%3ATests+branch%3A3.20.0
 
 .. |readthedocs| image:: https://img.shields.io/readthedocs/pavics-magpie
     :alt: Readthedocs Build Status (master branch)
@@ -75,7 +75,7 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
 
 .. |docker_semver_tag| image:: https://img.shields.io/docker/v/pavics/magpie?label=version&sort=semver
     :alt: Docker Version Tag
-    :target: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=3.19.1
+    :target: https://hub.docker.com/r/pavics/magpie/tags?page=1&ordering=last_updated&name=3.20.0
 
 .. end-badges
 
@@ -119,8 +119,8 @@ Following most recent variants are available:
     * - Magpie
       - Twitcher |br|
         (with integrated ``MagpieAdapter``)
-    * - ``pavics/magpie:3.19.1``
-      - ``pavics/twitcher:magpie-3.19.1``
+    * - ``pavics/magpie:3.20.0``
+      - ``pavics/twitcher:magpie-3.20.0``
     * - ``pavics/magpie:latest``
       - ``pavics/twitcher:magpie-latest``
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -59,22 +59,18 @@ div.bordered-content {
 div.parent-list-numbers ol {
     counter-reset: item;
 }
+
 div.parent-list-numbers ol li {
     counter-increment: item;
 }
-/*div.parent-list-numbers > li:before {
-    content: counters(item, ".") " ";
-    counter-increment: item
-}*/
+
 div.parent-list-numbers ol ol > li::before {
-    content: counters(item, ".")")";
+    content: counters(item, ".") ")";
     margin-left: -3em;
 }
-div.parent-list-numbers ol li {
-    counter-increment: item;
-}
+
 div.parent-list-numbers > ol > li > ol > li {
-    list-style: None;
+    list-style: none;
     display: inline-flex;
     display: -webkit-box;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -52,3 +52,17 @@ div.bordered-content {
     border: 1px solid #C6C9CB;
     padding: 0 1em 1em 0;
 }
+
+/* apply the parent list number prefixed to the current list numbers
+    https://stackoverflow.com/a/13841818
+*/
+div.parent-list-numbers > ol {
+    counter-reset: item;
+}
+div.parent-list-numbers > li {
+    display: block;
+}
+div.parent-list-numbers > li:before {
+    content: counters(item, ".") " ";
+    counter-increment: item
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -56,13 +56,25 @@ div.bordered-content {
 /* apply the parent list number prefixed to the current list numbers
     https://stackoverflow.com/a/13841818
 */
-div.parent-list-numbers > ol {
+div.parent-list-numbers ol {
     counter-reset: item;
 }
-div.parent-list-numbers > li {
-    display: block;
+div.parent-list-numbers ol li {
+    counter-increment: item;
 }
-div.parent-list-numbers > li:before {
+/*div.parent-list-numbers > li:before {
     content: counters(item, ".") " ";
     counter-increment: item
+}*/
+div.parent-list-numbers ol ol > li::before {
+    content: counters(item, ".")")";
+    margin-left: -3em;
+}
+div.parent-list-numbers ol li {
+    counter-increment: item;
+}
+div.parent-list-numbers > ol > li > ol > li {
+    list-style: None;
+    display: inline-flex;
+    display: -webkit-box;
 }

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -242,8 +242,8 @@ Authorization Headers
 Following any successful :term:`Authentication` request as presented in the previous section, the obtained ``Cookie``
 defines which :term:`Logged User` attempts to accomplish an operation against a given protected URI. `Magpie` employs
 the same ``Cookie`` both for operations provided by its API and for accessing the real :term:`Resource` protected
-behind the :term:`Proxy` according to resolution of :term:`Effective Permissions` based on :term:`Applied Permission`
-definitions.
+behind the :term:`Proxy` according to resolution of :term:`Effective Permissions <Effective Permission>` based on
+:term:`Applied Permission` definitions.
 
 Access to Magpie Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -259,14 +259,14 @@ Access to Protected Resources
 
 When sending requests to the :term:`Policy Enforcement Point` (PEP) (e.g.: `Twitcher`_ :term:`Proxy`),
 appropriate ``Cookie`` headers must be defined for it to identify the :term:`Logged User` and resolve its
-:term:`Effective Permissions` accordingly. Not providing those tokens will default to using
+:term:`Effective Permissions <Effective Permission>` accordingly. Not providing those tokens will default to using
 :envvar:`MAGPIE_ANONYMOUS_USER`, which will result into either one of HTTP ``Unauthorized [401]`` or
 ``Forbidden [403]``, depending on how the PEP interprets and returns the response indicated by `Magpie`, unless the
 corresponding :term:`Resource` was allowed for :ref:`perm_public_access`.
 
 When appropriately authenticated, access to the targeted :term:`Resource` will be granted or denied depending on the
-:term:`Effective Permissions` that :term:`Logged User` has for it. This decision is extensively explained in section
-:ref:`perm_resolution`.
+:term:`Effective Permissions <Effective Permission>` that :term:`Logged User` has for it. This decision is extensively
+explained in section :ref:`perm_resolution`.
 
 Another alternative to obtain :term:`Authorization` (only when using the :ref:`utilities_adapter<Magpie Adapter>`) is
 by providing the ``Authorization`` header in the request with appropriate credentials. In this situation, the adapter

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -62,9 +62,10 @@ Query Parameters
 
 This method employs the query string parameters in the URL to provide the credentials. The format is as follows.
 
-.. code-block::
+.. code-block:: http
 
-    GET {MAGPIE_URL}/signin?user_name=<usr>&password=<pwd>
+    GET /signin?user_name=<usr>&password=<pwd> HTTP/1.1
+    Host: {MAGPIE_URL}
 
 
 The response will contain :ref:`Authentication Headers` detail needed for user identification.
@@ -89,37 +90,39 @@ Body content requests allow multiple variants, based on the specified ``Content-
 All variants employ a similar structure, but indicate the format of the body to be parsed.
 By default, ``application/json`` is employed if none was specified.
 
-.. code-block::
+.. code-block:: http
 
-    POST {MAGPIE_URL}/signin
-    Headers
-        Content-Type: multipart/form-data; boundary=<boundary-string>
-    Body
-        user_name: "<usr>"
-        password: "<pwd>"
-        provider_name: "<provider>"     # optional
+    POST /signin HTTP/1.1
+    Host: {MAGPIE_URL}
+    Content-Type: multipart/form-data; boundary=<boundary-string>
 
-
-.. code-block::
-
-    POST {MAGPIE_URL}/signin
-    Headers
-        Content-Type: application/x-www-form-urlencoded
-    Body
-        user_name=<usr>&password=<pwd>&provider_name=<provider>
+    --<boundary-string>
+    user_name: "<usr>"
+    password: "<pwd>"
+    provider_name: "<provider>"     # optional
+    --<boundary-string>--
 
 
-.. code-block::
+.. code-block:: http
 
-    POST {MAGPIE_URL}/signin
-    Headers
-        Content-Type: application/json
-    Body
-        {
-            "user_name": "<usr>",
-            "password": "<pwd>",
-            "provider_name": "<provider>"
-        }
+    POST /signin HTTP/1.1
+    Host: {MAGPIE_URL}
+    Content-Type: application/x-www-form-urlencoded
+
+    user_name=<usr>&password=<pwd>&provider_name=<provider>
+
+
+.. code-block::  http
+
+    POST /signin HTTP/1.1
+    Host: {MAGPIE_URL}
+    Content-Type: application/json
+
+    {
+        "user_name": "<usr>",
+        "password": "<pwd>",
+        "provider_name": "<provider>"
+    }
 
 
 The response will contain :ref:`Authentication Headers` detail needed for user identification.
@@ -196,7 +199,7 @@ Authentication Headers
 After execution of an :term:`Authentication` request, a ``Set-Cookie`` header with `Magpie` user identification token
 named according to :ref:`config_security` should be set in the response as follows.
 
-.. code-block::
+.. code-block:: http
 
     Set-Cookie: {MAGPIE_COOKIE_NAME}=<auth-token>!userid_type:int;
                 [Domain=<domain>; Path=<path>; HttpOnly; SameSite=Lax; Max-Age=<seconds>; expires=<datetime>]
@@ -239,7 +242,7 @@ Authorization Headers
 Following any successful :term:`Authentication` request as presented in the previous section, the obtained ``Cookie``
 defines which :term:`Logged User` attempts to accomplish an operation against a given protected URI. `Magpie` employs
 the same ``Cookie`` both for operations provided by its API and for accessing the real :term:`Resource` protected
-behind the :term:`Proxy` according to resolution of :term:`Effective Permissions` based on :term:`Applied Permissions`
+behind the :term:`Proxy` according to resolution of :term:`Effective Permissions` based on :term:`Applied Permission`
 definitions.
 
 Access to Magpie Operations
@@ -276,7 +279,7 @@ employed instead to process :term:`Authentication` only once.
 
 The format of the ``Authorization`` header is has follows.
 
-.. code-block::
+.. code-block:: http
 
     Authorization: Bearer <access_token>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,8 @@ extensions = [
     "doc_redirect",
     "sphinxcontrib.redoc",
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosectionlabel",  # help make cross-references to title/sections
+    "cloud_sptheme.ext.autodoc_sections",  # allow sections in docstrings code
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
@@ -174,7 +176,11 @@ language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = [
+    # ignore multiple over-verbose warnings caused
+    # by file not yet generated when TOC is processed
+    "api.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -686,7 +686,7 @@ remain available as described at the start of the :ref:`Configuration` section.
     (Value: ``"admin"``)
 
     Name of the :term:`Permission` used to represent highest administration privilege in the application. It is one of
-    the special :term:`Access Permissions` known by the application (see also :ref:`Route Access` section).
+    the special :term:`Access Permission` known by the application (see also :ref:`Route Access` section).
 
 .. envvar:: MAGPIE_LOGGED_PERMISSION
 
@@ -695,7 +695,7 @@ remain available as described at the start of the :ref:`Configuration` section.
 
     .. versionadded:: 2.0
 
-    Defines a special condition of :term:`Access Permissions` related to the :term:`Logged User` session and the
+    Defines a special condition of :term:`Access Permission` related to the :term:`Logged User` session and the
     targeted :term:`User` by the request. See details in :ref:`Route Access` for when it applies.
 
 .. envvar:: MAGPIE_LOGGED_USER

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -137,9 +137,9 @@ Glossary
         geospatial data and service methodologies in order to improve access to geospatial and location information.
 
     OWS
-        Acronym that regroups all :term:`OGC` Web Services. This includes `Web Feature Service` (WFS),
-        `Web Map Service` (WMS) and `Web Processing Service` (WPS) for which `Magpie` offers some specific
-        :term:`Service` request parser implementations.
+        Acronym that regroups all :term:`OGC` Web Services. This includes :term:`Web Feature Service <WFS>` (WFS),
+        :term:`Web Map Service <WMS>` (WMS) and :term:`Web Processing Service <WMS>` (WPS), amongst others, for which
+        `Magpie` offers some specific :term:`Service` request parser implementations.
 
     Pending User
         Account that is pending for validation or approval following self-registration when the application is
@@ -226,3 +226,19 @@ Glossary
 
         .. seealso::
             :ref:`config_webhook` and :ref:`config_file` sections for details.
+
+    Web Feature Service
+    WFS
+
+        One of the :term:`OWS` implementation which `Magpie` offers an implementation
+        for controlling access to layers and their features.
+
+    Web Map Service
+    WMS
+        One of the :term:`OWS` implementation which `Magpie` offers an implementation
+        for controlling access to layers and generated maps from them.
+
+    Web Processing Service
+    WPS
+        One of the :term:`OWS` implementation which `Magpie` offers an implementation
+        for controlling access to description and execution of processes.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -27,13 +27,13 @@ Glossary
         grants or denies :term:`Permission` access to the applicable :term:`User` for the targeted :term:`Resource`.
         Formed of multiple :term:`ACE`.
 
-    Allowed Permissions
+    Allowed Permission
         Set of applicable :term:`Permission` values onto an element.
 
         .. seealso::
             :ref:`Allowed Permissions <allowed-permissions>` section for details.
 
-    Applied Permissions
+    Applied Permission
         An active :term:`Permission` for a given :term:`User` or :term:`Group` depending on context.
 
         .. seealso::
@@ -75,12 +75,19 @@ Glossary
         :term:`Group` that has property ``discoverable=True``, making it publicly viewable to any-level user.
         Otherwise, groups can be listed or accessed only by administrators.
 
-    Effective Permissions
+    Effective Permission
         A :term:`Permission` that has been completely resolved according to all applicable contexts, that indicates
         the final granted or denied result.
 
         .. seealso::
             :ref:`Effective Permissions <effective_permissions>` section for details.
+
+    Effective Resolution
+        Process of resolving :term:`Effective Permission` over a :term:`Resource` considering any applicable
+        :ref:`permission_modifiers`.
+
+        .. seealso::
+            :ref:`perm_resolution` section for details.
 
     External Providers
         Set of all known user-identity :term:`Provider` defined externally to `Magpie`. Each of these :term:`Provider`
@@ -97,14 +104,14 @@ Glossary
         request to ask for confirmation. The terms and conditions can only be defined upon the :term:`Group` creation
         and can never be modified afterwards.
 
-    Immediate Permissions
+    Immediate Permission
         Describes a :term:`Permission` that originates directly and only from a :term:`Service`.
         This is referenced in only a few use-cases, notably for :ref:`Finding User Permissions`.
 
         .. seealso::
             :ref:`Immediate Permissions <immediate_permissions>` section for details.
 
-    Inherited Permissions
+    Inherited Permission
         Describes a :term:`Permission` that includes both :term:`User` and :term:`Group` contexts simultaneously.
 
         .. seealso::

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -10,10 +10,10 @@ requests are execute in rapid succession. `PostgreSQL`_ and `SQLAlchemy`_ are us
 when more than a couple requests per second are needed, some solutions are possible to
 improve the performance of these requests by avoiding unnecessary reload of static data.
 
-We can take advantage of the fact that individual :temr:`Permission` and :term:`Service` definitions are not
+We can take advantage of the fact that individual :term:`Permission` and :term:`Service` definitions are not
 susceptible to change often and cache the results of these queries.
 
-While not activated by default, it's possible to cache the :term:`Access Control Lists` (ACLs) and :term:`Service`
+While not activated by default, it's possible to cache the :term:`Access Control List` (ACL) and :term:`Service`
 retrieval operations for all services, and give it an expiration timeout.
 
 .. code-block:: ini
@@ -26,8 +26,8 @@ retrieval operations for all services, and give it an expiration timeout.
 .. warning::
     Take into consideration that settings must be applied to `Twitcher`_ INI file such that incoming proxy requests
     will be effective in its web application, in turn using the :class:`magpie.adapter.MagpieAdapter`. Caching settings
-    defined in `Magpie` INI file will be employed only when requesting :term:`Effective Permissions` resolution using
-    `Magpie`'s API endpoints.
+    defined in `Magpie` INI file will be employed only when requesting
+    :term:`Effective Permissions <Effective Permission>` resolution using `Magpie`'s API endpoints.
 
 
 In the above example, for a particular request that queries a :term:`Logged User`'s ACL for a specific :term:`Service`,

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -643,14 +643,15 @@ for |perm_reason|_ field. Following pseudo-code presents the overall procedure.
 .. seealso::
     - |perm_example_resolve|_
 
-In some cases, :term:`Service` implementations will support simultaneous references to multiple :term:`Resources`
-with a single request. One such example is when a request parameter allows a comma-separated list of values referring to
+In some cases, :term:`Service` implementations will support simultaneous references to
+multiple :term:`Resources <Resource>` with a single request.
+One such example is when a request parameter allows a comma-separated list of values referring to
 distinct :term:`Resource` items, for which :term:`Effective Resolution` must be computed for each element of the list.
 When a :term:`Service` supports this type of references, the above |algo_resolve_effective|_ is applied
 iteratively for every :term:`Resource` until all have been validated for :attr:`Access.ALLOW`, or until the first
 :attr:`Access.DENY` is found. For this kind of |effective_permissions|_ to be granted access, **ALL** requested
-:term:`Permission` on every :term:`Resources` in the set must be :attr:`Access.ALLOW` indiscriminately. Denied access
-to any element takes precedence over the whole set.
+:term:`Permission` on every :term:`Resources <Resource>` in the set must be :attr:`Access.ALLOW` indiscriminately.
+Denied access to any element takes precedence over the whole set.
 
 This procedure over multiple :term:`Resource` only applies during :term:`ACL` computation of an actual request to access
 the remote :term:`Service` provider or one of its children :term:`Resource`. When managing |applied_permissions|_ on

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -522,11 +522,11 @@ Below are the resolution steps which are applied for every distinct :term:`Permi
 
        1. There is only one :term:`Group` for which a :term:`Permission` is defined. The :term:`User` inherits that
           specification, whether it is :attr:`Access.ALLOW` or :attr:`Access.DENY`.
-          |
+
        2. Many :term:`Group` membership exist and share of same highest priority. In this case, if any :term:`Group`
           has :attr:`Access.DENY`, the resolved access is marked as denied. If every equally prioritized :term:`Group`
           indicate :attr:`Access.ALLOW`, then access is granted to the :term:`User`.
-          |
+
        3. Otherwise, the highest priority :term:`Group` dictates the :class:`Access` resolution. This can
           potentially *revert* a previous :term:`Group` decision.
 

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -325,7 +325,7 @@ when resolving the :term:`Resource` tree hierarchy. This helps solving special u
 conditions must be applied at different hierarchy levels. By default, if no |perm_access|_ indication is provided when
 creating a new :term:`Permission`, :attr:`Access.ALLOW` is employed since `Magpie` resolves all |perm_access|_ to a
 :term:`Resource` as :attr:`Access.DENY` unless explicitly granted. In other words, `Magpie` assumes that administrators
-adding new :term:`Permission` entries intent to grant :term:`Service` or :term:`Resource` access for the targeted
+adding new :term:`Permission` entries intend to grant :term:`Service` or :term:`Resource` access for the targeted
 :term:`User` or :term:`Group`. Any :term:`Permission` specifically created using :attr:`Access.DENY` should be involved
 only to revert a previously resolved :attr:`Access.ALLOW`, as they are otherwise redundant to default
 |effective_permissions|_ resolution.
@@ -334,11 +334,12 @@ only to revert a previously resolved :attr:`Access.ALLOW`, as they are otherwise
 .. |perm_scope| replace:: ``scope``
 
 The |perm_scope|_ concept is defined by :class:`magpie.permissions.Scope` enum. This tells `Magpie` whether the
-:term:`Applied Permission` should impact only the immediate :term:`Resource` (i.e.: when ``match``) or should instead
-be applied recursively for it and all its children. By applying a recursive :term:`Permission` on a higher-level
-:term:`Resource`, this modifier avoids having to manually set the same :term:`Permission` on every sub-:term:`Resource`
-when access as to be provided over a large hierarchy. Also, when combined with the |perm_access|_ component, the
-|perm_scope|_ modifier can provide advanced control over granted or denied access.
+:term:`Applied Permissions <Applied Permission>` should impact only the immediate :term:`Resource`
+(i.e.: when ``match``) or should instead be applied recursively for it and all its children. By applying a recursive
+:term:`Permission` on a higher-level :term:`Resource`, this modifier avoids having to manually set the same
+:term:`Permission` on every sub-:term:`Resource` when access as to be provided over a large hierarchy.
+Also, when combined with the |perm_access|_ component, the |perm_scope|_ modifier can provide advanced control over
+granted or denied access.
 
 As a general rule of thumb, all :term:`Permission` are resolved such that more restrictive access applied *closer* to
 the actual :term:`Resource` for the targeted :term:`User` will have priority, both in terms of inheritance by tree
@@ -348,6 +349,16 @@ hierarchy and by :term:`Group` memberships.
     - |perm_example_modifiers|_
     - |perm_example_resolve|_
 
+.. warning::
+    Whenever possible, it is preferable and strongly advised to define new :term:`Permission` definitions using
+    :attr:`Access.ALLOW` *as close as possible* to the target child :term:`Resource` for which to allow access,
+    and leave the parent :term:`Resource` without any :term:`Permission` to let it be resolved by default to
+    :attr:`Access.DENY` as well as any other :term:`Resource` under it except the explicitly allowed one.
+    This is safer than the error prone alternative to :attr:`Access.ALLOW` everything at the root and revoke access
+    at lower levels using :attr:`Access.DENY` to add "allowed exceptions" to the :term:`Resource` hierarchy. In case
+    of incorrect request parsing, this second approach could potentially erroneously grant access to :term:`Resource`
+    intended to be blocked. Using the first approach (only explicitly :attr:`Access.ALLOW` granted items) would still
+    block by default all incorrectly parsed requests, ensuring children :term:`Resource` would still be protected.
 
 .. _permission_representations:
 
@@ -499,7 +510,8 @@ Below are the resolution steps which are applied for every distinct :term:`Permi
 
     |inherited_permissions|_ resolution
 
-.. container:: bordered-content
+.. container class generates '#.#' numbering with parent list reference automatically for proper alignment of text
+.. container:: bordered-content parent-list-numbers
     :name: steps_resolve_inherited_block
 
     1. Any |direct_permissions|_ applied explicitly for the evaluated :term:`User` and :term:`Resource` combination
@@ -508,15 +520,15 @@ Below are the resolution steps which are applied for every distinct :term:`Permi
 
     2. Following is the resolution of |inherited_permissions|_. In this case, there are three possibilities:
 
-        2.1 There is only one :term:`Group` for which a :term:`Permission` is defined. The :term:`User` inherits that
-            specification, whether it is :attr:`Access.ALLOW` or :attr:`Access.DENY`.
-
-        2.2 Many :term:`Group` membership exist and share of same highest priority. In this case, if any :term:`Group`
-            has :attr:`Access.DENY`, the resolved access is marked as denied. If every equally prioritized :term:`Group`
-            indicate :attr:`Access.ALLOW`, then access is granted to the :term:`User`.
-
-        2.3 Otherwise, the highest priority :term:`Group` dictates the :class:`Access` resolution. This can
-            potentially *revert* a previous :term:`Group` decision.
+       1. There is only one :term:`Group` for which a :term:`Permission` is defined. The :term:`User` inherits that
+          specification, whether it is :attr:`Access.ALLOW` or :attr:`Access.DENY`.
+          |
+       2. Many :term:`Group` membership exist and share of same highest priority. In this case, if any :term:`Group`
+          has :attr:`Access.DENY`, the resolved access is marked as denied. If every equally prioritized :term:`Group`
+          indicate :attr:`Access.ALLOW`, then access is granted to the :term:`User`.
+          |
+       3. Otherwise, the highest priority :term:`Group` dictates the :class:`Access` resolution. This can
+          potentially *revert* a previous :term:`Group` decision.
 
 
 The specific use case of step (2.3) is intended to give higher resolution precedence to any *generic* :term:`Group`
@@ -556,33 +568,32 @@ scoped inheritance over the :term:`Resource` tree. The following resolution prio
 .. container:: bordered-content
     :name: steps_resolve_effective_block
 
-    1. Resolve administrative access (i.e.: full access).
-       [only during |effective_permissions|_]
-    2. Resolution of |direct_permissions|_.
-       [same as step (1) of |steps_resolve_inherited|_]
-    3. Resolution of |inherited_permissions|_ from :term:`Group` memberships.
-       [same as step (2) of |steps_resolve_inherited|_]
-    4. Rewinding of the :term:`Resource` tree to consider scoped inheritance.
-       [only during |effective_permissions|_]
+    1. | Resolve administrative access (i.e.: full access).
+       | [only during |effective_permissions|_]
+    2. | Resolution of |direct_permissions|_.
+       | [same as step (1) of |steps_resolve_inherited|_]
+    3. | Resolution of |inherited_permissions|_ from :term:`Group` memberships.
+       | [same as step (2) of |steps_resolve_inherited|_]
+    4. | Rewinding of the :term:`Resource` tree to consider scoped inheritance.
+       | [only during |effective_permissions|_]
 
-
-In this case, step (1) that verifies if the :term:`User` is a member for :envvar:`MAGPIE_ADMIN_GROUP`.
+In this case, step (1) verifies if the :term:`User` is a member for :envvar:`MAGPIE_ADMIN_GROUP`.
 In such case, :attr:`Access.ALLOW` is immediately returned for every possible |allowed_permissions|_ for the
 targeted :term:`Resource` without further resolution involved.
 The reason why this check is accomplished only during |effective_permissions|_ resolution is to avoid over
 populating the database with :envvar:`MAGPIE_ADMIN_GROUP` :term:`Permission` for every possible :term:`Resource`.
-It can be noted that effectively, ``"administrator"`` reason will never be returned when requesting any other type of
-:term:`Permission` than when specifying ``effective=true`` query, as there is no need to explicitly define
-:envvar:`MAGPIE_ADMIN_GROUP` |applied_permissions|_.
+It can be noted that effectively, ``"administrator"`` as :term:`Permission` ``reason`` will never be returned when
+requesting any other type of :term:`Permission` than when specifying ``effective=true`` query, as there is no need
+to explicitly define :envvar:`MAGPIE_ADMIN_GROUP` |applied_permissions|_.
 Furthermore, doing this pre-check step ensures that :envvar:`MAGPIE_ADMIN_GROUP` members are always granted full access
 regardless of any explicit :term:`Applied Permission` that could exist for that *special* :term:`Group`.
 
-When the :term:`User` is not a member of :envvar:`MAGPIE_ADMIN_GROUP`, |effective_permissions|_ would then pursue
-with the traditional |steps_resolve_inherited|_ listed earlier. The resolution process continues by rewinding the parent
-:term:`Resource` hierarchy until the first :term:`Permission` is found, or until reaching the top-most :term:`Service`.
-Only on the first iteration (when the targeted :term:`Resource` is the same as the one looked for potential
-|inherited_permissions|_) does :attr:`Scope.MATCH` take effect. Only :attr:`Scope.RECURSIVE` are considered
-afterwards.
+When the :term:`User` is not a member of :envvar:`MAGPIE_ADMIN_GROUP`, |effective_permissions|_ would then pursue to
+steps (2) and (3) with the traditional |steps_resolve_inherited|_ listed earlier. The resolution process continues with
+step (4) by rewinding the parent :term:`Resource` hierarchy until the first :term:`Permission` is found, or until the
+root :term:`Service` is reached. Only on the first iteration (when the targeted :term:`Resource` is the same as the one
+looked for potential |inherited_permissions|_) does :attr:`Scope.MATCH` take effect. Only :attr:`Scope.RECURSIVE` are
+considered afterwards.
 
 When the first :term:`Permission` is found, the procedure *remembers* the :class:`Access` of the
 |resolved_permissions|_ for the current scope. If the found :term:`Permission` is linked directly to the
@@ -631,6 +642,23 @@ for |perm_reason|_ field. Following pseudo-code presents the overall procedure.
 
 .. seealso::
     - |perm_example_resolve|_
+
+In some cases, :term:`Service` implementations will support simultaneous references to multiple :term:`Resources`
+with a single request. One such example is when a request parameter allows a comma-separated list of values referring to
+distinct :term:`Resource` items, for which :term:`Effective Resolution` must be computed for each element of the list.
+When a :term:`Service` supports this type of references, the above |algo_resolve_effective|_ is applied
+iteratively for every :term:`Resource` until all have been validated for :attr:`Access.ALLOW`, or until the first
+:attr:`Access.DENY` is found. For this kind of |effective_permissions|_ to be granted access, **ALL** requested
+:term:`Permission` on every :term:`Resources` in the set must be :attr:`Access.ALLOW` indiscriminately. Denied access
+to any element takes precedence over the whole set.
+
+This procedure over multiple :term:`Resource` only applies during :term:`ACL` computation of an actual request to access
+the remote :term:`Service` provider or one of its children :term:`Resource`. When managing |applied_permissions|_ on
+:term:`Resource` definitions in `Magpie`, operations are always applied on elements individually.
+
+.. versionadded:: 3.21
+    Resolution over multiple simultaneous :term:`Resource` referred by a common request.
+
 
 Examples
 -------------------

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -174,7 +174,7 @@ attempting access of a specific :term:`Resource` of type :class:`magpie.models.F
     Permission :attr:`Permission.READ` does not offer *metadata* content listing of :class:`magpie.models.Directory`
     anymore. For this, :attr:`Permission.BROWSE` should be used instead. Setting :attr:`Permission.READ` on a
     directory will only be logical when combined with :attr:`Scope.RECURSIVE`, in which case `Magpie` will interpret
-    the :term:`Effective Permissions` to allow read access to all :class:`magpie.models.File` under that directory, at
+    the :term:`Effective Permission` to allow read access to all :class:`magpie.models.File` under that directory, at
     any depth level, unless denied by a lower-level specification.
 
 Finally, :attr:`Permission.WRITE` can also be applied on all of the resources, but are not explicitly employed during
@@ -186,7 +186,7 @@ parsing of incoming requests.
     only returns either :attr:`Permission.BROWSE` or :attr:`Permission.READ`. A :term:`User` or :term:`Group` can still
     have this :term:`Applied Permission` to allow a third party service to interrogate `Magpie API` about the presence
     of :attr:`Permission.WRITE` permission and perform the appropriate action with the result. The
-    :term:`Effective Permissions` API routes will provide the resolved ``access``. It is only `Twitcher`_ proxy that
+    :term:`Effective Permission` API routes will provide the resolved ``access``. It is only `Twitcher`_ proxy that
     will not be able to make use of it during incoming requests as it depends on
     :class:`magpie.adapter.magpieowssecurity.MagpieOWSSecurity`, which in turn employs the result from the :term:`ACL`.
 
@@ -312,7 +312,7 @@ To summarize, if ``file_patterns`` produces a match, that matched portion will b
 name is used directly (as is from the specified request path). The plain name is also used if ``file_patterns`` is
 explicitly specified as an empty list or ``null``. Not explicitly overriding the field will result into using the
 above *default* ``file_patterns``. The ``file_patterns`` allow for example to consider ``file.nc``, ``file.ncml`` and
-``file.nc.html`` as the same :term:`Resource` internally, which avoids duplicating :term:`Applied Permissions` across
+``file.nc.html`` as the same :term:`Resource` internally, which avoids duplicating :term:`Applied Permission` across
 multiple :term:`Resource` for their corresponding *metadata* or *data* representations.
 
 

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -78,8 +78,8 @@ On top of the above methods, the following attributes must be defined.
         :Term:`Allowed Permissions`, their type and further nested children :term:`Resource`.
     * - :attr:`ServiceInterface.params_expected` |br| (``List[str]``)
       - Represents specific parameter names that can be preprocessed during HTTP request parsing to ease following
-        resolution of :term:`ACL` use cases. Employed most notably by :term:`Service` implementations based on
-        :class:`magpie.services.ServiceOWS`.
+        resolution of :term:`ACL` use cases. Employed only by :term:`Service` implementations derived from
+        :class:`magpie.services.ServiceOWS`. Can be omitted otherwise.
 
 
 .. _services_available:

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -32,14 +32,15 @@ Every :term:`Service` type provided by `Magpie` must derive from :class:`magpie.
 specific implementation (see :ref:`services_available`) serves to convert a given incoming HTTP request components
 (method, path, query parameters, body, etc.) into the appropriate :term:`Service`, :term:`Resource` and
 :term:`Permission` elements. This ultimately provides the required elements to resolve :term:`ACL` access of a
-:term:`Request User` toward the targeted :term:`Resource` according to its :term:`Effective Permissions`.
+:term:`Request User` toward the targeted :term:`Resource` according to its
+:term:`Effective Permissions <Effective Permission>`.
 
 In order to implement a new :term:`Service` type, two (2) methods and a few attributes are required. The first method is
 :meth:`magpie.services.ServiceInterface.permission_requested` which basically indicates how the HTTP request should be
 interpreted into a given :class:`Permission`. The second is :meth:`magpie.services.ServiceInterface.resource_requested`
 which similarly tells the interpretation method to convert the request into a :class:`magpie.models.Resource` reference.
 
-Whenever :term:`Effective Permissions` or :term:`ACL` needs to be resolved in order to determine if a
+Whenever :term:`Effective Permission` or :term:`ACL` needs to be resolved in order to determine if a
 :term:`Request User` can have access or not to a :term:`Resource`, `Magpie` will employ the appropriate :term:`Service`
 implementation and call the methods to process the result.
 
@@ -79,7 +80,7 @@ On top of the above methods, the following attributes must be defined.
         also provides details about :Term:`Allowed Permissions <Allowed Permission>`, their type and further nested
         children :term:`Resource`.
     * - :attr:`child_structure_allowed` |br| (``Dict[Type[ServiceOrResourceType], List[Type[models.Resource]]]``)
-      - Map of allowed :term:`Resource`type nesting hierarchy for the :term:`Service`.
+      - Map of allowed :term:`Resource` type nesting hierarchy for the :term:`Service`.
         This controls whether some children :term:`Resource` can be placed under another to limit creation only to
         cases that are relevant for the implemented :term:`Service`.
     * - :attr:`configurable` |br| (``bool``)
@@ -176,9 +177,9 @@ ServiceAPI
 The implementation of this :term:`Service` is handled by class :class:`magpie.services.ServiceAPI`. It refers to a
 remote URL endpoint that should have a :term:`Resource` tree formed out of the path segments. The :term:`Service` only
 has one (1) type of :term:`Resource`, namely :class:`magpie.models.Route`, that can have an unlimited amount of nested
-children of the same type. The :term:`Allowed Permissions` for this :term:`Service` are :attr:`Permission.READ` and
-:attr:`Permission.WRITE`. All requests using ``GET`` or ``HEAD`` are mapped to :attr:`Permission.READ` access while all
-other HTTP methods represent a :attr:`Permission.WRITE` access.
+children of the same type. The :term:`Allowed Permissions <Allowed Permission>` for this :term:`Service`
+are :attr:`Permission.READ` and :attr:`Permission.WRITE`. All requests using ``GET`` or ``HEAD`` are mapped
+to :attr:`Permission.READ` access while all other HTTP methods represent a :attr:`Permission.WRITE` access.
 
 Request path segments follow the natural hierarchy of the nested :class:`magpie.models.Route` under the :term:`Service`.
 For example, a proxy employing :class:`magpie.adapter.MagpieAdapter` such that ``{PROXY_URL}`` is the base of the
@@ -211,9 +212,9 @@ The implementation of this :term:`Service` is handled by class :class:`magpie.se
 remote data server named `Thematic Real-time Environmental Distributed Data Services` (`THREDDS`_). The :term:`Service`
 employs two (2) types of :term:`Resource`, namely :class:`magpie.models.Directory` and :class:`magpie.models.File`.
 All the directory resources can be nested any number of times, and files can only reside as leaves of the hierarchy,
-similarly to a traditional file system. The :term:`Allowed Permissions` on both the :term:`Service` itself or any of
-its children :term:`Resource` are :attr:`Permission.BROWSE`, :attr:`Permission.READ`, and :attr:`Permission.WRITE`
-(see note below regarding this last permission).
+similarly to a traditional file system. The :term:`Allowed Permissions <Allowed Permission>` on both the :term:`Service`
+itself or any of its children :term:`Resource` are :attr:`Permission.BROWSE`, :attr:`Permission.READ`, and
+:attr:`Permission.WRITE` (see note below regarding this last permission).
 
 .. versionadded:: 3.1
     The :attr:`Permission.BROWSE` permission is used to provide listing access of contents when targeting a
@@ -405,9 +406,8 @@ ServiceBaseWMS
 .. seealso::
 
     Derived implementations:
-
-    - `ServiceGeoserverWMS`_
-    - `ServiceNCWMS2`_
+    - :ref:`ServiceGeoserverWMS`
+    - :ref:`ServiceNCWMS2`
 
 This is a *partial base* class employed to represent :term:`OWS` `Web Map Service` extended via other complete classes.
 It cannot be employed directly as :term:`Service` instance. The derived classes provide different parsing methodologies
@@ -483,9 +483,9 @@ The implementation of this :term:`Service` is handled by class :class:`magpie.se
 control access to the operations provided by an :term:`OWS` `Web Processing Service`. This :term:`Service` allows
 one (1) type of child :term:`Resource`, namely the :class:`magpie.models.Process` which represent the execution units
 that are registered under a remote `WPS`. Every :class:`magpie.models.Process` cannot itself have a child
-:term:`Resource`, making `ServiceWPS`_ maximally a 2-tier level hierarchy.
+:term:`Resource`, making :ref:`ServiceWPS` maximally a 2-tier level hierarchy.
 
-There are three (3) types of :term:`Allowed Permissions` which each represent an operation that can be requested from it
+There are three (3) types of :term:`Allowed Permission` which each represent an operation that can be requested from it
 (via ``request`` query parameter value of the HTTP request), specifically the :attr:`Permission.GET_CAPABILITIES`,
 :attr:`Permission.DESCRIBE_PROCESS`, and :attr:`Permission.EXECUTE`. The :attr:`Permission.GET_CAPABILITIES`
 corresponds to the retrieval of available list of *Processes* on the `WPS` instance, and therefore, can only be applied
@@ -494,9 +494,9 @@ on individual :class:`magpie.models.Process` :term:`Resource` definitions. When 
 :attr:`Scope.RECURSIVE` modifier, the corresponding :term:`Permission` becomes effective to all underlying *Processes*.
 Otherwise, the :term:`Permission` applied on specific :class:`magpie.models.Process` entries control the specific
 :term:`ACL` only for it. When a specific :term:`Permission` is involved on a :class:`magpie.models.Process` during
-:term:`Effective Permissions` resolution, the value of the query parameter ``identifier`` is employ to attempt mapping
-it against an existing :term:`Resource`. The resolution of :term:`Effective Permissions` in even of multi-level tree
-:term:`Resource` is computed in the usual manner described in the :ref:`Permissions` chapter.
+:term:`Effective Permission` resolution, the value of the query parameter ``identifier`` is employ to attempt mapping
+it against an existing :term:`Resource`. The resolution of :term:`Effective Permissions <Effective Permission>` in the
+event of multi-level tree :term:`Resource` is computed in the usual manner described in the :ref:`Permissions` chapter.
 
 
 .. warning::
@@ -540,7 +540,7 @@ ServiceGeoserver
     - :ref:`ServiceGeoserverWPS`
 
 This :term:`Service` is combined :term:`OWS` implementation for `GeoServer`_ that allows simultaneous representation of
-:term:`WFS`, :term:`WMS` and :term:`WPS` :term:`Resources <Resource> all nested under a single reference hosted under
+:term:`WFS`, :term:`WMS` and :term:`WPS` :term:`Resources <Resource>` all nested under a single reference hosted under
 common remote URL. Using this implementation, :class:`magpie.models.Workspace` are first required as immediate children
 under the root :term:`Service`, and can be followed by both :term:`Resources <Resource>` of type
 :class:`magpie.models.Layer` and :class:`magpie.models.Process`.
@@ -614,9 +614,9 @@ element.
 .. note::
     If only :attr:`Scope.RECURSIVE` :term:`Permission` are being applied on the :term:`Service` or their children
     :term:`Resource`, it is better to enter *fewer* children element in the tree to reduce computation time of
-    :term:`Effective Permissions`. The complete hierarchy should be employed only when the depth of the tree is
-    relatively shallow or that :attr:`Scope.MATCH` must be applied specifically for some :term:`Resource` to obtain
-    desired access behaviour.
+    :term:`Effective Permissions <Effective Permission>`. The complete hierarchy should be employed only when the depth
+    of the tree is relatively shallow or that :attr:`Scope.MATCH` must be applied specifically for some :term:`Resource`
+    to obtain desired access behaviour.
 
 When using the `Magpie` Docker image, the default command run the `magpie-cron`_ utility in parallel to the API. This
 cron job will periodically execute the :term:`Resource` auto-synchronization feature for a given :term:`Service` that

--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -2,7 +2,7 @@
 General meta information on the magpie package.
 """
 
-__version__ = "3.19.1"
+__version__ = "3.20.0"
 __title__ = "Magpie"
 __package__ = "magpie"  # pylint: disable=W0622
 __author__ = "Francois-Xavier Derue, Francis Charette-Migneault"

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -259,6 +259,7 @@ class MagpieOWSSecurity(OWSSecurityInterface):
             raise OWSAccessForbidden(error_desc, status_base=error_base, **error_kw)
 
     def update_request_cookies(self, request):
+        # type: (Request) -> None
         """
         Ensure login of the user and update the request cookies if Twitcher is in a special configuration.
 

--- a/magpie/adapter/magpieowssecurity.py
+++ b/magpie/adapter/magpieowssecurity.py
@@ -175,7 +175,7 @@ class MagpieOWSSecurity(OWSSecurityInterface):
         Otherwise, ignore request access validation.
 
         In the case `Twitcher` proxy path is matched, the :term:`Logged User` **MUST** be allowed access following
-        :term:`Effective Permissions` resolution via :term:`ACL`.
+        :term:`Effective Permissions <Effective Permission>` resolution via :term:`ACL`.
         Otherwise, :exception:`OWSAccessForbidden` is raised.
 
         Failing to parse the request or any underlying component that raises an exception will be left up to the

--- a/magpie/api/exception.py
+++ b/magpie/api/exception.py
@@ -44,6 +44,7 @@ RAISE_RECURSIVE_SAFEGUARD_COUNT = 0
 
 # utility parameter validation regexes for 'matches' argument
 PARAM_REGEX = r"^[A-Za-z0-9]+(?:[\s_\-\.][A-Za-z0-9]+)*$"    # request parameters
+SCOPE_REGEX = r"^[A-Za-z0-9]+(?:[\:\s_\-\.][A-Za-z0-9]+)*$"  # allow scoped names (e.g.: 'namespace:value')
 EMAIL_REGEX = colander.EMAIL_RE
 UUID_REGEX = colander.UUID_REGEX
 URL_REGEX = colander.URL_REGEX

--- a/magpie/api/management/group/__init__.py
+++ b/magpie/api/management/group/__init__.py
@@ -17,6 +17,5 @@ def includeme(config):
     config.add_route(**s.service_api_route_info(s.GroupResourcesAPI))
     config.add_route(**s.service_api_route_info(s.GroupResourcePermissionsAPI))
     config.add_route(**s.service_api_route_info(s.GroupResourcePermissionAPI))
-    config.add_route(**s.service_api_route_info(s.GroupResourceTypesAPI))
 
     config.scan()

--- a/magpie/api/management/resource/__init__.py
+++ b/magpie/api/management/resource/__init__.py
@@ -10,5 +10,6 @@ def includeme(config):
     config.add_route(**s.service_api_route_info(s.ResourcesAPI))
     config.add_route(**s.service_api_route_info(s.ResourceAPI))
     config.add_route(**s.service_api_route_info(s.ResourcePermissionsAPI))
+    config.add_route(**s.service_api_route_info(s.ResourceTypesAPI))
 
     config.scan()

--- a/magpie/api/management/resource/resource_formats.py
+++ b/magpie/api/management/resource/resource_formats.py
@@ -80,10 +80,11 @@ def format_resource_tree(children, db_session, resources_perms_dict=None, permis
     :param resources_perms_dict:
         Any pre-established :term:`Applied Permission` to set to corresponding resources by ID.
         When provided, these will define the :term:`User`, :term:`Group` or both
-        (i.e.: :term:`Inherited Permissions <inherited permission>`)
-        actual permissions, or even the :term:`Effective Permissions`, according to parent caller function's context.
-        Otherwise (``None``), defaults to extracting :term:`Allowed Permissions` for the given :term:`Resource` scoped
-        under the corresponding root :term:`Service`.
+        (i.e.: :term:`Inherited Permissions <Inherited Permission>`)
+        actual permissions, or even the :term:`Effective Permissions <Effective Permission>`, according to parent
+        caller function's context.
+        Otherwise (``None``), defaults to extracting :term:`Allowed Permissions <Allowed Permission>` for the given
+        :term:`Resource` scoped under the corresponding root :term:`Service`.
     :return: formatted resource tree
     """
     # optimization to avoid re-lookup of 'allowed permissions' when already fetched

--- a/magpie/api/management/resource/resource_formats.py
+++ b/magpie/api/management/resource/resource_formats.py
@@ -78,8 +78,9 @@ def format_resource_tree(children, db_session, resources_perms_dict=None, permis
     :param children: service or resource for which to generate the formatted resource tree
     :param db_session: connection to db
     :param resources_perms_dict:
-        Any pre-established :term:`Applied Permissions` to set to corresponding resources by ID.
-        When provided, these will define the :term:`User`, :term:`Group` or both (i.e.: :term:`Inherited Permissions`)
+        Any pre-established :term:`Applied Permission` to set to corresponding resources by ID.
+        When provided, these will define the :term:`User`, :term:`Group` or both
+        (i.e.: :term:`Inherited Permissions <inherited permission>`)
         actual permissions, or even the :term:`Effective Permissions`, according to parent caller function's context.
         Otherwise (``None``), defaults to extracting :term:`Allowed Permissions` for the given :term:`Resource` scoped
         under the corresponding root :term:`Service`.

--- a/magpie/api/management/resource/resource_utils.py
+++ b/magpie/api/management/resource/resource_utils.py
@@ -84,18 +84,20 @@ def check_valid_service_resource(parent_resource, resource_type, db_session):
     ax.verify_param(resource_type, is_in=True, http_error=HTTPForbidden,
                     param_name="resource_type", param_compare=root_svc_cls.resource_type_names,
                     msg_on_fail="Invalid 'resource_type' specified for service type '{}'".format(root_service.type))
-    ax.verify_param(root_svc_cls.validate_nested_resource_type(parent_resource, resource_type), is_true=True,
-                    param_content={
-                        "resource_structure_allowed": root_svc_cls.child_structure_allowed,
-                        "resource_types_allowed": [
-                            res.resource_type for res in root_svc_cls.nested_resource_allowed(parent_resource)
-                        ]
-                    },
-                    http_error=HTTPUnprocessableEntity,
-                    msg_on_fail=(
-                        "Invalid 'resource_type' specified for service type '{}' is not allowed at this position "
-                        "under '{}' resource.".format(root_service.type, parent_type)
-                    ))
+    ax.verify_param(
+        root_svc_cls.validate_nested_resource_type(parent_resource, resource_type), is_true=True,
+        param_content={
+            "resource_structure_allowed": root_svc_cls.child_structure_allowed,
+            "resource_types_allowed": [
+                res.resource_type for res in root_svc_cls.nested_resource_allowed(parent_resource)
+            ]
+        },
+        http_error=HTTPUnprocessableEntity,
+        msg_on_fail=(
+            "Invalid 'resource_type' specified for service type '{}' is not allowed at this position "
+            "under '{}' resource.".format(root_service.type, parent_type)
+        )
+    )
     return root_service
 
 

--- a/magpie/api/management/resource/resource_utils.py
+++ b/magpie/api/management/resource/resource_utils.py
@@ -58,6 +58,7 @@ def check_valid_service_or_resource_permission(permission_name, service_or_resou
 
 
 def check_valid_service_resource(parent_resource, resource_type, db_session):
+    # type: (ServiceOrResourceType, Str, Session) -> models.Service
     """
     Checks if a new Resource can be contained under a parent Resource given the requested type and the corresponding
     Service under which the parent Resource is already assigned.
@@ -69,20 +70,32 @@ def check_valid_service_resource(parent_resource, resource_type, db_session):
     """
     parent_type = parent_resource.resource_type_name
     parent_msg_err = "Child resource not allowed for specified parent resource type '{}'".format(parent_type)
-    ax.verify_param(models.RESOURCE_TYPE_DICT[parent_type].child_resource_allowed, is_equal=True,
-                    param_compare=True, http_error=HTTPForbidden, msg_on_fail=parent_msg_err)
+    ax.verify_param(models.RESOURCE_TYPE_DICT[parent_type].child_resource_allowed, is_true=True,
+                    http_error=HTTPForbidden, msg_on_fail=parent_msg_err)
     root_service = get_resource_root_service(parent_resource, db_session=db_session)
     ax.verify_param(root_service, not_none=True, http_error=HTTPInternalServerError,
                     msg_on_fail="Failed retrieving 'root_service' from db")
     ax.verify_param(root_service.resource_type, is_equal=True, http_error=HTTPInternalServerError,
                     param_name="resource_type", param_compare=models.Service.resource_type_name,
                     msg_on_fail="Invalid 'root_service' retrieved from db is not a service")
-    ax.verify_param(SERVICE_TYPE_DICT[root_service.type].child_resource_allowed, is_equal=True,
-                    param_compare=True, http_error=HTTPForbidden,
+    root_svc_cls = SERVICE_TYPE_DICT[root_service.type]
+    ax.verify_param(root_svc_cls.child_resource_allowed, is_true=True, http_error=HTTPForbidden,
                     msg_on_fail="Child resource not allowed for specified service type '{}'".format(root_service.type))
     ax.verify_param(resource_type, is_in=True, http_error=HTTPForbidden,
-                    param_name="resource_type", param_compare=SERVICE_TYPE_DICT[root_service.type].resource_type_names,
+                    param_name="resource_type", param_compare=root_svc_cls.resource_type_names,
                     msg_on_fail="Invalid 'resource_type' specified for service type '{}'".format(root_service.type))
+    ax.verify_param(root_svc_cls.validate_nested_resource_type(parent_resource, resource_type), is_true=True,
+                    param_content={
+                        "resource_structure_allowed": root_svc_cls.child_structure_allowed,
+                        "resource_types_allowed": [
+                            res.resource_type for res in root_svc_cls.nested_resource_allowed(parent_resource)
+                        ]
+                    },
+                    http_error=HTTPUnprocessableEntity,
+                    msg_on_fail=(
+                        "Invalid 'resource_type' specified for service type '{}' is not allowed at this position "
+                        "under '{}' resource.".format(root_service.type, parent_type)
+                    ))
     return root_service
 
 

--- a/magpie/api/management/resource/resource_utils.py
+++ b/magpie/api/management/resource/resource_utils.py
@@ -273,6 +273,7 @@ def get_resource_root_service_impl(resource, request):
 def create_resource(resource_name, resource_display_name, resource_type, parent_id, db_session):
     # type: (Str, Optional[Str], Str, int, Session) -> HTTPException
     ax.verify_param(resource_name, param_name="resource_name", not_none=True, not_empty=True,
+                    matches=True, param_compare=ax.SCOPE_REGEX,
                     http_error=HTTPUnprocessableEntity,
                     msg_on_fail="Invalid 'resource_name' specified for child resource creation.")
     ax.verify_param(resource_type, param_name="resource_type", not_none=True, not_empty=True,

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -55,7 +55,7 @@ def create_resource_view(request):
     """
     Register a new resource.
     """
-    resource_name = ar.get_value_multiformat_body_checked(request, "resource_name")
+    resource_name = ar.get_multiformat_body(request, "resource_name")
     resource_display_name = ar.get_multiformat_body(request, "resource_display_name", default=resource_name)
     resource_type = ar.get_value_multiformat_body_checked(request, "resource_type")
     parent_id = ar.get_value_multiformat_body_checked(request, "parent_id", check_type=int)

--- a/magpie/api/management/service/service_formats.py
+++ b/magpie/api/management/service/service_formats.py
@@ -118,10 +118,11 @@ def format_service_resources(service,                       # type: Service
     :param db_session: database session
     :param service_perms:
         If provided, sets all :term:`Applied Permission` to display on the formatted :paramref:`service`.
-        Otherwise, sets the :term:`Allowed Permissions` specific to the :paramref:`service`'s type.
+        Otherwise, sets :term:`Allowed Permissions <Allowed Permission>` specific to the :paramref:`service`'s type.
     :param resources_perms_dict:
         If provided (not ``None``), set the :term:`Applied Permission` on each specified resource matched by ID.
-        If ``None``, retrieve and set :term:`Allowed Permissions` for the corresponding resources under the service.
+        If ``None``, retrieve and set :term:`Allowed Permissions <Allowed Permission>` for the corresponding
+        :term:`Resources <Resource>` under the :term:`Service`.
         To set empty :term:`Applied Permission` (e.g.: :term:`User` doesn't have permissions on that resource), provide
         an explicit empty dictionary instead.
     :param permission_type: Provide permission type being rendered.

--- a/magpie/api/management/service/service_formats.py
+++ b/magpie/api/management/service/service_formats.py
@@ -117,12 +117,12 @@ def format_service_resources(service,                       # type: Service
     :param service: service for which to display details with sub-resources
     :param db_session: database session
     :param service_perms:
-        If provided, sets :term:`Applied Permissions` to display on the formatted :paramref:`service`.
+        If provided, sets all :term:`Applied Permission` to display on the formatted :paramref:`service`.
         Otherwise, sets the :term:`Allowed Permissions` specific to the :paramref:`service`'s type.
     :param resources_perms_dict:
-        If provided (not ``None``), set the :term:`Applied Permissions` on each specified resource matched by ID.
+        If provided (not ``None``), set the :term:`Applied Permission` on each specified resource matched by ID.
         If ``None``, retrieve and set :term:`Allowed Permissions` for the corresponding resources under the service.
-        To set empty :term:`Applied Permissions` (e.g.: :term:`User` doesn't have permissions on that resource), provide
+        To set empty :term:`Applied Permission` (e.g.: :term:`User` doesn't have permissions on that resource), provide
         an explicit empty dictionary instead.
     :param permission_type: Provide permission type being rendered.
     :param show_all_children:

--- a/magpie/api/management/service/service_formats.py
+++ b/magpie/api/management/service/service_formats.py
@@ -76,11 +76,13 @@ def format_service(service,                         # type: Service
             return svc_info
         if show_configuration:
             svc_info["configuration"] = service.configuration
-        perms = SERVICE_TYPE_DICT[service.type].permissions if permissions is None else permissions
+        svc_type = SERVICE_TYPE_DICT[service.type]
+        perms = svc_type.permissions if permissions is None else permissions
         svc_info.update(format_permissions(perms, permission_type))
         if show_resources_allowed:
-            svc_info["resource_types_allowed"] = sorted(SERVICE_TYPE_DICT[service.type].resource_type_names)
-            svc_info["resource_child_allowed"] = SERVICE_TYPE_DICT[service.type].child_resource_allowed
+            svc_info["resource_child_allowed"] = svc_type.child_resource_allowed
+            svc_info["resource_types_allowed"] = sorted(svc_type.resource_type_names)
+            svc_info["resource_structure_allowed"] = sorted(svc_type.child_structure_allowed)
         return svc_info
 
     return evaluate_call(

--- a/magpie/api/management/service/service_formats.py
+++ b/magpie/api/management/service/service_formats.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
 
     from magpie.models import Resource, Service
-    from magpie.permissions import PermissionSet
+    from magpie.permissions import Permission, PermissionSet
     from magpie.services import ServiceInterface
     from magpie.typedefs import JSON, ResourcePermissionMap
 
@@ -59,13 +59,15 @@ def format_service(service,                         # type: Service
         :func:`magpie.api.management.resource.resource_formats.format_resource`
     """
     def fmt_svc():
+        # type: () -> JSON
         sep = "." if dotted else "_"
         svc_sync_type = str(service.sync_type) if service.sync_type is not None else service.sync_type
+        svc_type = SERVICE_TYPE_DICT[service.type]
         svc_info = {
             "service{}name".format(sep): str(service.resource_name),
             "service{}type".format(sep): str(service.type),
             "service{}sync_type".format(sep): svc_sync_type,
-            "service{}configurable".format(sep): SERVICE_TYPE_DICT[service.type].configurable,
+            "service{}configurable".format(sep): svc_type.configurable,
             "resource{}id".format(sep): service.resource_id,
         }
         if show_public_url:
@@ -75,7 +77,6 @@ def format_service(service,                         # type: Service
             svc_info["service{}url".format(sep)] = str(service.url)
         if basic_info:
             return svc_info
-        svc_type = SERVICE_TYPE_DICT[service.type]  # type: Type[ServiceInterface]
         if show_configuration:
             # make sure to generate the default configuration if applicable
             if svc_type.configurable:
@@ -130,6 +131,7 @@ def format_service_resources(service,                       # type: Service
     :return: JSON body representation of the service resource tree
     """
     def fmt_svc_res(svc, db, svc_perms, res_perms, show_all):
+        # type: (Service, Session, Optional[List[Permission]], Optional[List[Permission]], bool) -> JSON
         tree = get_resource_children(svc, db)
         if not show_all:
             filter_res_ids = list(res_perms) if res_perms else []

--- a/magpie/api/management/service/service_formats.py
+++ b/magpie/api/management/service/service_formats.py
@@ -65,6 +65,7 @@ def format_service(service,                         # type: Service
             "service{}name".format(sep): str(service.resource_name),
             "service{}type".format(sep): str(service.type),
             "service{}sync_type".format(sep): svc_sync_type,
+            "service{}configurable".format(sep): SERVICE_TYPE_DICT[service.type].configurable,
             "resource{}id".format(sep): service.resource_id,
         }
         if show_public_url:
@@ -74,9 +75,14 @@ def format_service(service,                         # type: Service
             svc_info["service{}url".format(sep)] = str(service.url)
         if basic_info:
             return svc_info
-        if show_configuration:
-            svc_info["configuration"] = service.configuration
         svc_type = SERVICE_TYPE_DICT[service.type]
+        if show_configuration:
+            # make sure to generate the default configuration if applicable
+            if svc_type.configurable:
+                svc_config = svc_type(service, request=None).get_config()
+            else:
+                svc_config = None
+            svc_info["configuration"] = svc_config
         perms = svc_type.permissions if permissions is None else permissions
         svc_info.update(format_permissions(perms, permission_type))
         if show_resources_allowed:

--- a/magpie/api/management/service/service_formats.py
+++ b/magpie/api/management/service/service_formats.py
@@ -75,7 +75,7 @@ def format_service(service,                         # type: Service
             svc_info["service{}url".format(sep)] = str(service.url)
         if basic_info:
             return svc_info
-        svc_type = SERVICE_TYPE_DICT[service.type]
+        svc_type = SERVICE_TYPE_DICT[service.type]  # type: Type[ServiceInterface]
         if show_configuration:
             # make sure to generate the default configuration if applicable
             if svc_type.configurable:
@@ -88,7 +88,10 @@ def format_service(service,                         # type: Service
         if show_resources_allowed:
             svc_info["resource_child_allowed"] = svc_type.child_resource_allowed
             svc_info["resource_types_allowed"] = sorted(svc_type.resource_type_names)
-            svc_info["resource_structure_allowed"] = sorted(svc_type.child_structure_allowed)
+            svc_info["resource_structure_allowed"] = {
+                res.resource_type_name: list(sorted(child_res.resource_type_name for child_res in children_res))
+                for res, children_res in svc_type.child_structure_allowed.items()
+            }
         return svc_info
 
     return evaluate_call(

--- a/magpie/api/management/service/service_utils.py
+++ b/magpie/api/management/service/service_utils.py
@@ -67,7 +67,7 @@ def create_service(service_name, service_type, service_url, service_push, servic
     ax.verify_param(service_url, matches=True, param_compare=ax.URL_REGEX, param_name="service_url",
                     http_error=HTTPBadRequest, msg_on_fail=s.Services_POST_Params_BadRequestResponseSchema.description)
     ax.verify_param(service_name, not_empty=True, not_none=True, matches=True,
-                    param_name="service_name", param_compare=ax.PARAM_REGEX,
+                    param_name="service_name", param_compare=ax.SCOPE_REGEX,
                     http_error=HTTPBadRequest, msg_on_fail=s.Services_POST_Params_BadRequestResponseSchema.description)
     ax.verify_param(models.Service.by_service_name(service_name, db_session=db_session), is_none=True,
                     param_name="service_name", with_param=False, content={"service_name": str(service_name)},

--- a/magpie/api/management/service/service_views.py
+++ b/magpie/api/management/service/service_views.py
@@ -113,7 +113,7 @@ def register_service_view(request):
     Registers a new service.
     """
     # accomplish basic validations here, create_service will do more field-specific checks
-    service_name = ar.get_value_multiformat_body_checked(request, "service_name")
+    service_name = ar.get_value_multiformat_body_checked(request, "service_name", pattern=ax.SCOPE_REGEX)
     service_url = ar.get_value_multiformat_body_checked(request, "service_url", pattern=ax.URL_REGEX)
     service_type = ar.get_value_multiformat_body_checked(request, "service_type")
     service_push = asbool(ar.get_multiformat_body(request, "service_push", default=False))
@@ -166,6 +166,9 @@ def update_service_view(request):
         ax.verify_param(svc_name, not_in=True, param_compare=all_svc_names, with_param=False,
                         http_error=HTTPConflict, content={"service_name": str(svc_name)},
                         msg_on_fail=s.Service_PATCH_ConflictResponseSchema.description)
+        ax.verify_param(svc_name, not_none=True, not_empty=True, matches=True, param_compare=ax.SCOPE_REGEX,
+                        http_error=HTTPBadRequest,
+                        msg_on_fail=s.Service_PATCH_UnprocessableEntityResponseSchema.description)
 
     def update_service_magpie_and_phoenix(_svc, new_name, new_url, svc_push, db_session):
         _svc.resource_name = new_name

--- a/magpie/api/management/user/__init__.py
+++ b/magpie/api/management/user/__init__.py
@@ -21,7 +21,6 @@ def includeme(config):
     config.add_route(**s.service_api_route_info(s.UserServicePermissionAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.UserServiceResourcesAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.UserResourcesAPI, **user_kwargs))
-    config.add_route(**s.service_api_route_info(s.UserResourceTypesAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.UserResourcePermissionsAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.UserResourcePermissionAPI, **user_kwargs))
     # Logged User routes
@@ -33,7 +32,6 @@ def includeme(config):
     config.add_route(**s.service_api_route_info(s.LoggedUserServicePermissionAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.LoggedUserServiceResourcesAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.LoggedUserResourcesAPI, **user_kwargs))
-    config.add_route(**s.service_api_route_info(s.LoggedUserResourceTypesAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.LoggedUserResourcePermissionsAPI, **user_kwargs))
     config.add_route(**s.service_api_route_info(s.LoggedUserResourcePermissionAPI, **user_kwargs))
 

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -571,10 +571,10 @@ def get_user_services(user, request, cascade_resources=False, format_as_list=Fal
         :term:`Inherited Permission` according to the value of :paramref:`inherit_groups_permissions`.
     :param inherit_groups_permissions:
         If ``False``, return only user-specific service/sub-resources :term:`Direct Permissions`.
-        Otherwise, resolve :term:`Inherited Permissions <inherited permission>` using all groups the user is member of.
+        Otherwise, resolve :term:`Inherited Permissions <Inherited Permission>` using all groups the user is member of.
     :param resolve_groups_permissions:
-        Whether to combine :term:`Direct Permissions <direct permission>` and
-        :term:`Inherited Permissions <inherited permission` for respective resources or not.
+        Whether to combine :term:`Direct Permissions <Direct Permission>` and
+        :term:`Inherited Permissions <Inherited Permission>` for respective resources or not.
     :param format_as_list:
         Returns as list of service dict information (not grouped by type and by name)
     :param service_types:
@@ -646,7 +646,7 @@ def get_user_service_permissions(user, service, request,
     Retrieve the permissions the user has directly on a service or inherited permissions by its group memberships.
 
     .. warning::
-        - Does not consider :term:`Effective Permissions` ownership.
+        - Does not consider :term:`Effective Permissions <Effective Permission>` ownership.
         - Considers direct :term:`Service` ownership, but not implemented everywhere (not operational).
 
     .. seealso::
@@ -682,7 +682,7 @@ def resolve_user_group_permissions(resource_permission_list):
     found for corresponding resource. In such case, only one entry is possible (it is invalid to have more than one
     combination of ``(User, Resource, Permission)``, including modifiers, as per validation during their creation).
 
-    Otherwise, for corresponding :term:`Inherited Permissions <inherited permission>`, resolve the prioritized
+    Otherwise, for corresponding :term:`Inherited Permissions <Inherited Permission>`, resolve the prioritized
     :term:`Permission` across every group.
     Similarly to users, :func:`magpie.groups.group_utils.get_similar_group_resource_permission` validate that only one
     combination of ``(Group, Resource, Permission)`` can exist including permission modifiers. Only, cross-group
@@ -693,10 +693,11 @@ def resolve_user_group_permissions(resource_permission_list):
            other more explicit group membership, regardless of permission modifiers applied on it.
         2. Permissions of same group priority with :attr:`Access.DENY` are prioritized over :attr:`Access.ALLOW`.
         3. Permissions of same group priority with :attr:`Scope.RECURSIVE` are prioritized over :attr:`Access.MATCH` as
-           they affect a larger range of resources when :term:`Effective Permissions` are eventually requested.
+           they affect a larger range of resources when :term:`Effective Permissions <Effective Permission>` are
+           eventually requested.
 
     .. note::
-        Resource tree inherited resolution is not considered here (no recursive :term:`Effective Permissions` computed).
+        Resource tree inherited resolution is not considered here (no recursive :term:`Effective Permission` computed).
         Only same-level scope of every given resource is processed independently. The intended behaviour here is
         therefore to help illustrate in responses *how deep* is a given permission going to have an impact onto
         lower-level resources, making :attr:`Scope.RECURSIVE` more important than specific instance :attr:`Scope.MATCH`.
@@ -732,8 +733,8 @@ def regroup_permissions_by_resource(resource_permissions, resolve=False):
     """
     Regroups multiple uncategorized permissions into a dictionary of corresponding resource IDs.
 
-    While regrouping the various permissions (both :term:`Direct Permissions <direct permission>` and any amount of
-    groups :term:`Inherited Permissions <inherited permission>`) under their respective resource by ID, optionally
+    While regrouping the various permissions (both :term:`Direct Permissions <Direct Permission>` and any amount of
+    groups :term:`Inherited Permissions <Inherited Permission>`) under their respective resource by ID, optionally
     resolve overlapping or conflicting permissions by name such that only one permission persists for that resource
     and name.
 
@@ -742,8 +743,8 @@ def regroup_permissions_by_resource(resource_permissions, resolve=False):
 
     :param resource_permissions:
         List of resource permissions to process.
-        Can include both user :term:`Direct Permissions <direct permission>` and its groups
-        :term:`Inherited Permissions <inherited permission>`.
+        Can include both user :term:`Direct Permissions <Direct Permission>` and its groups
+        :term:`Inherited Permissions <Inherited Permission>`.
     :param resolve:
         When ``False``, only mapping by resource ID is accomplished. Full listing of permissions is returned.
         Otherwise, resolves the corresponding resource permissions (by same ID) considering various priority rules to
@@ -788,7 +789,7 @@ def get_user_resources_permissions_dict(user, request, resource_types=None, reso
     :param resolve_groups_permissions: whether to combine corresponding user/group permissions into one or not.
     :return:
         Only resources which the user has permissions on, or including all
-        :term:`Inherited Permissions <inherited permission>`, according to
+        :term:`Inherited Permissions <Inherited Permission>`, according to
         :paramref:`inherit_groups_permissions` argument.
     """
     ax.verify_param(user, not_none=True, http_error=HTTPNotFound,
@@ -809,7 +810,7 @@ def get_user_service_resources_permissions_dict(user, service, request,
     Retrieves all permissions the user has for every :term:`Resource` nested under the :term:`Service`.
 
     The retrieved permissions can either include only :term:`Direct Permissions` or a combination of user and group
-    :term:`Inherited Permissions <inherited permission>` accordingly to provided options.
+    :term:`Inherited Permissions <Inherited Permission>` accordingly to provided options.
 
     .. seealso::
         :func:`get_user_resources_permissions_dict`

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -568,19 +568,20 @@ def get_user_services(user, request, cascade_resources=False, format_as_list=Fal
         top-level resources corresponding to a :term:`Service`.
         Otherwise, return every service that has at least one sub-resource with permissions (children at any-level).
         In both cases, the *permissions* looked for consider either only :term:`Direct Permissions` or any
-        :term:`Inherited Permissions` according to the value of :paramref:`inherit_groups_permissions`.
+        :term:`Inherited Permission` according to the value of :paramref:`inherit_groups_permissions`.
     :param inherit_groups_permissions:
         If ``False``, return only user-specific service/sub-resources :term:`Direct Permissions`.
-        Otherwise, resolve :term:`Inherited Permissions` using all groups the user is member of.
+        Otherwise, resolve :term:`Inherited Permissions <inherited permission>` using all groups the user is member of.
     :param resolve_groups_permissions:
-        Whether to combine :term:`Direct Permissions` and :term:`Inherited Permissions` for respective resources or not.
+        Whether to combine :term:`Direct Permissions <direct permission>` and
+        :term:`Inherited Permissions <inherited permission` for respective resources or not.
     :param format_as_list:
         Returns as list of service dict information (not grouped by type and by name)
     :param service_types:
         Filter list of service types for which to return details. All service types are used if omitted.
     :return:
         Only services which the user as :term:`Direct Permissions` or considering all tree hierarchy,
-        and for each case, either considering only user permissions or every :term:`Inherited Permissions`,
+        and for each case, either considering only user permissions or every :term:`Inherited Permission`,
         according to provided options.
     :rtype:
         Mapping of services by type to corresponding services by name containing each sub-mapping of their information,
@@ -675,13 +676,14 @@ def filter_user_permission(resource_permission_list, user):
 def resolve_user_group_permissions(resource_permission_list):
     # type: (List[ResolvablePermissionType]) -> Iterable[PermissionSet]
     """
-    Reduces overlapping user :term:`Inherited Permissions` for corresponding resources/services amongst the given list.
+    Reduces overlapping user :term:`Inherited Permission` for corresponding resources/services amongst the given list.
 
     User :term:`Direct Permissions` have the top-most priority and are therefore selected first if permissions are
     found for corresponding resource. In such case, only one entry is possible (it is invalid to have more than one
     combination of ``(User, Resource, Permission)``, including modifiers, as per validation during their creation).
 
-    Otherwise, for corresponding :term:`Inherited Permissions`, resolve the prioritized permission across every group.
+    Otherwise, for corresponding :term:`Inherited Permissions <inherited permission>`, resolve the prioritized
+    :term:`Permission` across every group.
     Similarly to users, :func:`magpie.groups.group_utils.get_similar_group_resource_permission` validate that only one
     combination of ``(Group, Resource, Permission)`` can exist including permission modifiers. Only, cross-group
     memberships for a given resource must then be computed.
@@ -730,16 +732,18 @@ def regroup_permissions_by_resource(resource_permissions, resolve=False):
     """
     Regroups multiple uncategorized permissions into a dictionary of corresponding resource IDs.
 
-    While regrouping the various permissions (both :term:`Direct Permissions` and any amount of groups
-    :term:`Inherited Permissions`) under their respective resource by ID, optionally resolve overlapping or conflicting
-    permissions by name such that only one permission persists for that resource and name.
+    While regrouping the various permissions (both :term:`Direct Permissions <direct permission>` and any amount of
+    groups :term:`Inherited Permissions <inherited permission>`) under their respective resource by ID, optionally
+    resolve overlapping or conflicting permissions by name such that only one permission persists for that resource
+    and name.
 
     .. seealso::
         :func:`resolve_user_group_permissions`
 
     :param resource_permissions:
         List of resource permissions to process.
-        Can include both user :term:`Direct Permissions` and its groups :term:`Inherited Permissions`.
+        Can include both user :term:`Direct Permissions <direct permission>` and its groups
+        :term:`Inherited Permissions <inherited permission>`.
     :param resolve:
         When ``False``, only mapping by resource ID is accomplished. Full listing of permissions is returned.
         Otherwise, resolves the corresponding resource permissions (by same ID) considering various priority rules to
@@ -783,7 +787,8 @@ def get_user_resources_permissions_dict(user, request, resource_types=None, reso
         Otherwise, resolve inherited permissions using all groups the user is member of.
     :param resolve_groups_permissions: whether to combine corresponding user/group permissions into one or not.
     :return:
-        Only resources which the user has permissions on, or including all :term:`Inherited Permissions`, according to
+        Only resources which the user has permissions on, or including all
+        :term:`Inherited Permissions <inherited permission>`, according to
         :paramref:`inherit_groups_permissions` argument.
     """
     ax.verify_param(user, not_none=True, http_error=HTTPNotFound,
@@ -804,7 +809,7 @@ def get_user_service_resources_permissions_dict(user, service, request,
     Retrieves all permissions the user has for every :term:`Resource` nested under the :term:`Service`.
 
     The retrieved permissions can either include only :term:`Direct Permissions` or a combination of user and group
-    :term:`Inherited Permissions` accordingly to provided options.
+    :term:`Inherited Permissions <inherited permission>` accordingly to provided options.
 
     .. seealso::
         :func:`get_user_resources_permissions_dict`

--- a/magpie/api/requests.py
+++ b/magpie/api/requests.py
@@ -311,7 +311,7 @@ def get_service_matchdict_checked(request, service_name_key="service_name"):
     :raises HTTPForbidden: if the requesting user does not have sufficient permission to execute this request.
     :raises HTTPNotFound: if the specified service name does not correspond to any existing service.
     """
-    service_name = get_value_matchdict_checked(request, service_name_key)
+    service_name = get_value_matchdict_checked(request, service_name_key, pattern=ax.SCOPE_REGEX)
     service = ax.evaluate_call(lambda: models.Service.by_service_name(service_name, db_session=request.db),
                                fallback=lambda: request.db.rollback(), http_error=HTTPForbidden,
                                msg_on_fail=s.Service_MatchDictCheck_ForbiddenResponseSchema.description)

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1669,11 +1669,24 @@ class ResourceTypesAllowed(colander.SequenceSchema):
     )
 
 
-class ResourceStructuresAllowed(colander.SequenceSchema):
-    description = "List of allowed combinations of resource type hierarchical structures under the service."
-    res_type_path = colander.SchemaNode(
+class ResourceTypeChildrenAllowed(colander.SequenceSchema):
+    title = "ResourceTypeChildrenAllowed"
+    res_type = colander.SchemaNode(
         colander.String(),
-        description="Path-like resource type structure allowed under the service."
+        description="Allowed child resource type."
+    )
+
+
+class ResourceStructuresAllowed(colander.MappingSchema):
+    description = (
+        "Mapping of allowed combinations of nested resource type structures under the service. "
+        "If undefined, the service does not impose any specific resource type hierarchy other "
+        "than whether individual resource types themselves allow children resources."
+    )
+    unknown = "preserve"
+    res_type = ResourceTypeChildrenAllowed(
+        name="{resource_type}",
+        description="List of children resource types in structure allowed under the parent resource type."
     )
 
 

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -890,7 +890,11 @@ class GroupDetailBodySchema(GroupPublicBodySchema, GroupInfoBodySchema):
 
 
 class ServiceConfigurationSchema(colander.MappingSchema):
-    description = "Custom configuration of the service. Expected format and fields specific to each service type."
+    description = (
+        "Custom configuration of the service. "
+        "Expected format and fields specific to each service type. "
+        "Service type must support custom configuration."
+    )
     missing = colander.drop
     default = colander.null
 
@@ -914,6 +918,11 @@ class ServiceSummarySchema(colander.MappingSchema):
         colander.String(),
         description="Type of resource synchronization implementation.",
         example="thredds"
+    )
+    service_configurable = colander.SchemaNode(
+        colander.Boolean(),
+        description="Indicates if the service supports custom configuration.",
+        examble=False,
     )
     public_url = colander.SchemaNode(
         colander.String(),

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1509,6 +1509,11 @@ class Service_PATCH_ConflictResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
+class Service_PATCH_UnprocessableEntityResponseSchema(BaseResponseSchemaAPI):
+    description = "Specified value is in incorrectly or unsupported format."
+    body = ErrorResponseBodySchema(code=HTTPUnprocessableEntity.code, description=description)
+
+
 Service_DELETE_RequestBodySchema = Resource_DELETE_RequestBodySchema
 
 

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import requests
+import six
 import transaction
 from pyramid.httpexceptions import HTTPInternalServerError
 from six.moves.urllib.parse import urlparse
@@ -215,22 +216,22 @@ def replace_template(params, payload, force_str=False):
                 for key, value in payload.items()}
     if isinstance(payload, list):
         return [replace_template(params, value) for value in payload]
-    if isinstance(payload, str):  # template fields are always string since '{<param>}' must be provided
+    if isinstance(payload, six.string_types):  # template fields are always string since '{<param>}' must be provided
         for template_param in params:
             template_replace = "{{" + template_param + "}}"
             if template_param in WEBHOOK_TEMPLATE_PARAMS and template_replace in payload:
                 template_value = params[template_param]
                 # if result field is not a string and template is defined as is, allow value type replacement
-                if not force_str and not isinstance(template_value, str) and payload == template_replace:
+                if not force_str and not isinstance(template_value, six.string_types) and payload == template_replace:
                     return template_value
                 # otherwise, enforce convert to string to avoid failing string replacement,
                 # but remove any additional quotes that might be defined to enforce non-string to string conversion
                 template_single_string = "'" + template_replace + "'"
                 template_double_string = "\"" + template_replace + "\""
                 for template_str in [template_single_string, template_double_string]:
-                    if payload == template_str and not isinstance(template_value, str):
+                    if payload == template_str and not isinstance(template_value, six.string_types):
                         template_replace = template_str
-                payload = payload.replace(template_replace, str(template_value))
+                payload = payload.replace(template_replace, six.text_type(template_value))
         return payload
     # For any other type, no replacing to do
     return payload

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -694,17 +694,35 @@ class PathBase(object):
 
 
 class File(Resource, PathBase):
+    """
+    Resource that represents the leaf node in a file-system-like hierarchy.
+
+    In the context of `THREDDS`, this represents the corresponding files exposed by the service.
+    This resource cannot have any children resource under it.
+    """
     child_resource_allowed = False
     resource_type_name = "file"
     __mapper_args__ = {"polymorphic_identity": resource_type_name}
 
 
 class Directory(Resource, PathBase):
+    """
+    Resource that represents an intermediate directory node within a file-system-like hierarchy.
+
+    In the context of `THREDDS`, this represents the corresponding directories exposed by the service.
+    Any amount of :class:`Directory` can be nested under itself to form the tree hierarchy.
+    """
     resource_type_name = "directory"
     __mapper_args__ = {"polymorphic_identity": resource_type_name}
 
 
 class Layer(Resource):
+    """
+    Resource that defines multiple corresponding representations of a layer according to the :term:`OWS` it lies under.
+
+    In the context of `WFS`, this is the represented collection of features.
+    In the context of `WMS`, this is the referenced features employed to generate the map.
+    """
     child_resource_allowed = False
     resource_type_name = "layer"
     __mapper_args__ = {"polymorphic_identity": resource_type_name}
@@ -718,6 +736,9 @@ class Layer(Resource):
 
 
 class Workspace(Resource):
+    """
+    Resource employed to contain a group of scoped :class:`Layer` within a `Geoserver` instance.
+    """
     resource_type_name = "workspace"
     __mapper_args__ = {"polymorphic_identity": resource_type_name}
 
@@ -730,6 +751,9 @@ class Workspace(Resource):
 
 
 class Route(Resource):
+    """
+    Resource employed to represent a single request path fragment.
+    """
     resource_type_name = "route"
     __mapper_args__ = {"polymorphic_identity": resource_type_name}
 
@@ -740,6 +764,9 @@ class Route(Resource):
 
 
 class Process(Resource):
+    """
+    Resource that represents a process under an :term:`OWS` instance servicing a `WPS` endpoint.
+    """
     child_resource_allowed = False
     resource_type_name = "process"
     __mapper_args__ = {"polymorphic_identity": resource_type_name}

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from sqlalchemy.orm.query import Query
     from sqlalchemy.orm.session import Session
 
-    from magpie.typedefs import AnySettingsContainer, AccessControlListType, GroupPriority, JSON, Str
+    from magpie.typedefs import JSON, AccessControlListType, AnySettingsContainer, GroupPriority, Str
 
     # for convenience of methods using both, using strings because of future definition
     AnyUser = Union["User", "UserPending"]

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         AccessControlEntryType,
         AnyPermissionType,
         GroupPriority,
+        JSON,
         PermissionDict,
         ResolvablePermissionType,
         Str
@@ -37,18 +38,24 @@ class Permission(ExtendedEnum):
     WRITE = "write"
     ACCESS = "access"
     BROWSE = "browse"
-    # WPS permissions
+    # WFS/WMS/WPS permissions (https://www.ogc.org/standards/<OWS-type>)
     GET_CAPABILITIES = "getcapabilities"
     GET_MAP = "getmap"
     GET_FEATURE_INFO = "getfeatureinfo"
     GET_LEGEND_GRAPHIC = "getlegendgraphic"
     GET_METADATA = "getmetadata"
+    GET_PROPERTY_VALUE = "getpropertyvalue"
     GET_FEATURE = "getfeature"
+    GET_FEATURE_WITH_LOCK = "getfeaturewithlock"
     DESCRIBE_FEATURE_TYPE = "describefeaturetype"
     DESCRIBE_PROCESS = "describeprocess"
     EXECUTE = "execute"
     LOCK_FEATURE = "lockfeature"
     TRANSACTION = "transaction"
+    CREATE_STORED_QUERY = "createstoredquery"
+    DROP_STORED_QUERY = "dropstoredquery"
+    LIST_STORED_QUERIES = "liststoredqueries"
+    DESCRIBE_STORED_QUERIES = "describestoredqueries"
 
 
 class PermissionType(ExtendedEnum):
@@ -233,6 +240,7 @@ class PermissionSet(object):
         return perm_repr_template.format(self.name.value, self.access.value, self.scope.value, perm_type, perm_reason)
 
     def like(self, other):
+        # type: (Any) -> bool
         """
         Evaluates if one permission is *similar* to another permission definition regardless of *modifiers*.
 
@@ -258,6 +266,7 @@ class PermissionSet(object):
         return perm
 
     def webhook_params(self):
+        # type: () -> JSON
         """
         Obtain JSON representation employed for :term:`Webhook` reference.
         """

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -96,13 +96,13 @@ class PermissionSet(object):
 
     The :class:`Permission` is the *name* of the applicable permission on the :class:`magpie.models.Resource`.
     The :class:`Scope` defines how the :class:`Permission` should impact the resolution of the perceived
-    :term:`Effective Permissions` over a :class:`magpie.models.Resource` tree hierarchy.
+    :term:`Effective Permissions <Effective Permission>` over a :class:`magpie.models.Resource` tree hierarchy.
     The :class:`Access` defines how the :class:`Permission` access should be interpreted (granted or denied).
 
     Optionally, a :class:`PermissionType` can be provided to specifically indicate which kind of permission this set
     represents. This type is only for informative purposes, and is not saved to database nor displayed by the explicit
     string representation. It is returned within JSON representation and can be employed by
-    :term:`Effective Permissions` resolution to be more verbose about returned results.
+    :term:`Effective Permissions <Effective Permission>` resolution to be more verbose about returned results.
 
     On missing :class:`Access` or :class:`Scope` specifications, they default to :attr:`Access.ALLOW` and
     :attr:`Scope.RECURSIVE` to handle backward compatible naming convention of plain ``permission_name``.
@@ -334,7 +334,7 @@ class PermissionSet(object):
 
         Permissions **MUST** have the same :term:`Permission` name.
         The associated :term:`Resource` on which the two compared permissions are applied on should also be the same
-        This method **SHOULD NOT** be used by itself to obtain for :term:`Effective Permissions` since it does not
+        This method **SHOULD NOT** be used by itself to obtain for :term:`Effective Permission` since it does not
         handle multi-level :term:`Resource` resolution. Resolution is accomplished in this case only for a given level
         in the tree hierarchy.
 

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -14,10 +14,10 @@ if TYPE_CHECKING:
 
     from magpie import models
     from magpie.typedefs import (
+        JSON,
         AccessControlEntryType,
         AnyPermissionType,
         GroupPriority,
-        JSON,
         PermissionDict,
         ResolvablePermissionType,
         Str

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -338,8 +338,8 @@ class PermissionSet(object):
         handle multi-level :term:`Resource` resolution. Resolution is accomplished in this case only for a given level
         in the tree hierarchy.
 
-        The comparison considers both the :class:`Access` and :class:`Scope` of :term:`Inherited Permissions` of the
-        :term:`User`, as well as its :term:`Group` memberships sorted by their priority.
+        The comparison considers both the :class:`Access` and :class:`Scope` of every  :term:`Inherited Permission` of
+        the :term:`User`, as well as its :term:`Group` memberships sorted by their priority.
 
         .. seealso::
             - :meth:`magpie.services.ServiceInterface.effective_permissions`
@@ -601,7 +601,7 @@ def format_permissions(permissions,             # type: Optional[Collection[AnyP
     definition of allowed permissions under :class:`magpie.services.Services` and their children :term:`Resource` by
     only defining :class:`Permission` names without manually listing all variations of :class:`PermissionSet`.
 
-    For other :paramref:`permission_type` values, which represent :term:`Applied Permissions` only explicitly
+    For other :paramref:`permission_type` values, which represent :term:`Applied Permission` only explicitly
     provided :paramref:`permissions` are returned, to effectively return the collection of *active* permissions.
 
     :param permissions: multiple permissions of any implementation and type, to be rendered both as names and JSON.

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -48,6 +48,7 @@ class Permission(ExtendedEnum):
     GET_FEATURE = "getfeature"
     GET_FEATURE_WITH_LOCK = "getfeaturewithlock"
     DESCRIBE_FEATURE_TYPE = "describefeaturetype"
+    DESCRIBE_LAYER = "describelayer"
     DESCRIBE_PROCESS = "describeprocess"
     EXECUTE = "execute"
     LOCK_FEATURE = "lockfeature"

--- a/magpie/permissions.py
+++ b/magpie/permissions.py
@@ -47,6 +47,7 @@ class Permission(ExtendedEnum):
     GET_PROPERTY_VALUE = "getpropertyvalue"
     GET_FEATURE = "getfeature"
     GET_FEATURE_WITH_LOCK = "getfeaturewithlock"
+    GET_GML_OBJECT = "getgmlobject"
     DESCRIBE_FEATURE_TYPE = "describefeaturetype"
     DESCRIBE_LAYER = "describelayer"
     DESCRIBE_PROCESS = "describeprocess"

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -446,7 +446,7 @@ class ServiceInterface(object):
     def nested_resource_allowed(cls, parent_resource):
         # type: (ServiceOrResourceType) -> List[Type[models.Resource]]
         """
-        Obtain the nested resource types allowed as children children resource within structure definitions.
+        Obtain the nested resource types allowed as children resource within structure definitions.
         """
         if not cls.child_resource_allowed:
             return []
@@ -876,7 +876,7 @@ class ServiceGeoserverBase(ServiceOWS):
     def service_base(self):
         # type: () -> Str
         """
-        Name of the base `OWS` functionality serviced by `Geoserver`.
+        Name of the base :term:`OWS` functionality serviced by `Geoserver`.
         """
         raise NotImplementedError
 
@@ -894,7 +894,7 @@ class ServiceGeoserverBase(ServiceOWS):
     def resource_types_permissions(self):
         # type: () -> ResourceTypePermissions
         """
-        Explicit permissions provided for resources for a given `OWS` implementation.
+        Explicit permissions provided for resources for a given :term:`OWS` implementation.
         """
         raise NotImplementedError
 
@@ -1261,7 +1261,7 @@ class ServiceTHREDDS(ServiceInterface):
 
 class ServiceGeoserverMeta(ServiceMeta):
     """
-    Mapping and grouping of property definitions for ``GeoServer`` services from distinct `OWS` implementations.
+    Mapping and grouping of property definitions for `GeoServer` services from distinct :term:`OWS` implementations.
     """
     service_map = {
         "wfs": ServiceGeoserverWFS,
@@ -1310,7 +1310,7 @@ class ServiceGeoserverMeta(ServiceMeta):
 @six.add_metaclass(ServiceGeoserverMeta)
 class ServiceGeoserver(ServiceOWS):
     """
-    Service that encapsulates the multiple `OWS` endpoints from ``GeoServer`` services.
+    Service that encapsulates the multiple :term:`OWS` endpoints from `GeoServer` services.
 
     .. seealso::
         https://docs.geoserver.org/stable/en/user/services/index.html
@@ -1346,9 +1346,9 @@ class ServiceGeoserver(ServiceOWS):
     def get_config(self):
         # type: () -> ServiceConfiguration
         """
-        Obtain the configuration defining which `OWS` services are enabled under this instance.
+        Obtain the configuration defining which :term:`OWS` services are enabled under this instance.
 
-        Should provide a mapping of all `OWS` service type names to enabled boolean status.
+        Should provide a mapping of all :term:`OWS` service type names to enabled boolean status.
         """
         if self._config is not None:
             return self._config
@@ -1363,7 +1363,7 @@ class ServiceGeoserver(ServiceOWS):
     def service_requested(self):
         # type: () -> Optional[Type[ServiceOWS]]
         """
-        Obtain the applicable `OWS` implementation according to parsed request parameters.
+        Obtain the applicable :term:`OWS` implementation according to parsed request parameters.
         """
         # guaranteed to exist and lowercase string if provided, otherwise None
         svc = self.parser.params["service"]

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -508,8 +508,9 @@ class ServiceInterface(object):
         permissions can be immediately resolved such as when more restrictive conditions enforce denied access.
 
         Both user and group permission inheritance is resolved simultaneously to tree hierarchy with corresponding
-        allow and deny conditions. User :term:`Direct Permissions` have priority over all its groups
-        :term:`Inherited Permissions`, and denied permissions have priority over allowed access ones.
+        allow and deny conditions. User :term:`Direct Permissions <direct permission>` have priority over all its groups
+        :term:`Inherited Permissions <inherited permission>`, and denied permissions have priority over allowed access
+        ones.
 
         All applicable permissions on the resource (as defined by :meth:`allowed_permissions`) will have their
         resolution (Allow/Deny) provided as output, unless a specific subset of permissions is requested using

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -508,8 +508,8 @@ class ServiceInterface(object):
         permissions can be immediately resolved such as when more restrictive conditions enforce denied access.
 
         Both user and group permission inheritance is resolved simultaneously to tree hierarchy with corresponding
-        allow and deny conditions. User :term:`Direct Permissions <direct permission>` have priority over all its groups
-        :term:`Inherited Permissions <inherited permission>`, and denied permissions have priority over allowed access
+        allow and deny conditions. User :term:`Direct Permissions <Direct Permission>` have priority over all its groups
+        :term:`Inherited Permissions <Inherited Permission>`, and denied permissions have priority over allowed access
         ones.
 
         All applicable permissions on the resource (as defined by :meth:`allowed_permissions`) will have their

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -866,7 +866,7 @@ class ServiceNCWMS2(ServiceBaseWMS):
         return found_child, target
 
 
-class ServiceGeoserverBase(ServiceInterface):
+class ServiceGeoserverBase(ServiceOWS):
     """
     Provides basic configuration parameters and functionalities shared by `Geoserver` implementations.
     """
@@ -1270,28 +1270,28 @@ class ServiceGeoserverMeta(ServiceMeta):
     }
 
     @property
-    def params_expected(self):
+    def params_expected(cls):
         # type: () -> List[Str]
         params = set()
-        for svc in self.supported_ows:
+        for svc in cls.supported_ows:  # pylint: disable=E1133,not-an-iterable
             if issubclass(svc, ServiceOWS) and hasattr(svc, "params_expected"):
                 params.update(svc.params_expected)
         return list(params)
 
     @property
-    def permissions(self):
+    def permissions(cls):
         # type: () -> List[Permission]
         perms = set()
-        for svc in self.supported_ows:
+        for svc in cls.supported_ows:  # pylint: disable=E1133,not-an-iterable
             if issubclass(svc, ServiceOWS) and hasattr(svc, "permissions"):
                 perms.update(svc.permissions)
         return list(perms)
 
     @property
-    def resource_types_permissions(self):
+    def resource_types_permissions(cls):
         # type: () -> ResourceTypePermissions
         perms = {}
-        for svc in self.supported_ows:
+        for svc in cls.supported_ows:  # pylint: disable=E1133,not-an-iterable
             if issubclass(svc, ServiceOWS) and hasattr(svc, "resource_types_permissions"):
                 svc_res_perms = svc.resource_types_permissions
                 for res_type, res_perms in svc_res_perms.items():
@@ -1302,9 +1302,9 @@ class ServiceGeoserverMeta(ServiceMeta):
         return perms
 
     @property
-    def supported_ows(self):
+    def supported_ows(cls):
         # type: () -> Set[Type[ServiceOWS]]
-        return set(self.service_map.values())
+        return set(cls.service_map.values())
 
 
 @six.add_metaclass(ServiceGeoserverMeta)

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -141,7 +141,15 @@ class ServiceInterface(object):
     """
 
     def __init__(self, service, request):
-        # type: (models.Service, Request) -> None
+        # type: (models.Service, Optional[Request]) -> None
+        """
+        Initialize the service.
+
+        :param service: Base service resource that must be handled by this service implementation.
+        :param request: Active request to handle requested resources, permissions and effective access.
+            The request can be omitted if basic service definition details are to be retrieved.
+            It is mandatory for any ``requested`` or ``effective`` component that should be resolved.
+        """
         self.service = service          # type: models.Service
         self.request = request          # type: Request
         self._flag_acl_cached = {}      # type: Dict[Tuple[Str, Str, Str, Optional[int]], bool]

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -994,7 +994,7 @@ class ServiceGeoserverBase(ServiceOWS):
             impl_params = cls.resource_param
         else:
             name = fully_qualified_name(cls)
-            raise NotImplementedError(f"Missing or invalid definition of 'resource_param' in service: {name}")
+            raise NotImplementedError("Missing or invalid definition of 'resource_param' in service: {}".format(name))
         base_params = [
             "request",
             "service",

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -912,7 +912,7 @@ class ServiceGeoserverBase(ServiceOWS):
     def resource_scoped(self):
         # type: () -> bool
         """
-        Indicates if the service is allowed to employ scoped :class:`models.Workspace` naming.
+        Indicates if the :term:`Service` is allowed to employ scoped :class:`models.Workspace` naming.
 
         When allowed, the :class:`models.Workspace` can be inferred from the request parameter
         defined by :attr:`resource_param` to retrieve scoped name as ``<WORKSPACE>:<RESOURCE>``.
@@ -927,7 +927,7 @@ class ServiceGeoserverBase(ServiceOWS):
     def resource_multi(self):
         # type: () -> bool
         """
-        Indicates if the service supports multiple simultaneous :term:`Resource` references.
+        Indicates if the :term:`Service` supports multiple simultaneous :term:`Resource` references.
 
         When supported, the value retrieved from :attr:`resource_param` can be comma-separated to represent
         multiple :term:`Resource` of the same nature, which can all be retrieved with the same request.

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -1340,14 +1340,14 @@ class ServiceGeoserver(ServiceOWS):
     }
     """
     Allowed children resource structure for `Geoserver`.
-    
+
     .. note::
         In the context of `Geoserver`, `WPS` are applied on available resources (`WFS`, `WMS`, etc.).
-        For this reason, the :class:`models.Process` also needs to be scoped under :class:`models.Workspace` in order 
-        to grant access to those resources to work on them, but the :class:`models.Workspace` name **MUST** be in the 
+        For this reason, the :class:`models.Process` also needs to be scoped under :class:`models.Workspace` in order
+        to grant access to those resources to work on them, but the :class:`models.Workspace` name **MUST** be in the
         path (i.e.: ``identifier=<WORKSPACE>:<PROCESS_ID>`` request parameter does not work).
-        Without the :class:`models.Workspace` scope in the path, ``identifier`` parameter fails to be resolved by 
-        `Geoserver`, as if it was unspecified. Attribute :attr:`ServiceGeoserverWPS.resource_scoped` controls the 
+        Without the :class:`models.Workspace` scope in the path, ``identifier`` parameter fails to be resolved by
+        `Geoserver`, as if it was unspecified. Attribute :attr:`ServiceGeoserverWPS.resource_scoped` controls the
         behaviour of splitting the defined :attr:`resource_param` into :class:`models.Workspace` and child components.
     """
 

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -937,7 +937,7 @@ class ServiceGeoserverBase(ServiceOWS):
 
     @classproperty
     @abc.abstractmethod
-    def resource_multi(cls):  # noqa
+    def resource_multi(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> bool
         """
         Indicates if the :term:`Service` supports multiple simultaneous :term:`Resource` references.
@@ -954,7 +954,7 @@ class ServiceGeoserverBase(ServiceOWS):
 
     @classproperty
     @abc.abstractmethod
-    def resource_param(cls):  # noqa
+    def resource_param(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> Union[Str, List[Str]]
         """
         Name of the request query parameter(s) to access requested leaf children resource.
@@ -973,7 +973,7 @@ class ServiceGeoserverBase(ServiceOWS):
 
     @classproperty
     @abc.abstractmethod
-    def resource_types_permissions(cls):  # noqa
+    def resource_types_permissions(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> ResourceTypePermissions
         """
         Explicit permissions provided for resources for a given :term:`OWS` implementation.
@@ -981,7 +981,7 @@ class ServiceGeoserverBase(ServiceOWS):
         raise NotImplementedError
 
     @classproperty
-    def params_expected(cls):  # noqa
+    def params_expected(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> List[Str]
         """
         Specify typical `Geoserver` request query parameters expected for any sub-service implementation.
@@ -1472,7 +1472,7 @@ class ServiceGeoserver(ServiceGeoserverBase):
     }
 
     @classproperty
-    def service_ows_supported(cls):  # noqa
+    def service_ows_supported(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> Set[Type[ServiceOWS]]
         return set(cls.service_map.values())
 
@@ -1517,7 +1517,7 @@ class ServiceGeoserver(ServiceGeoserverBase):
         return self._config
 
     @classproperty
-    def params_expected(cls):  # noqa
+    def params_expected(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> List[Str]
         params = set()
         for svc in cls.service_ows_supported:
@@ -1528,7 +1528,7 @@ class ServiceGeoserver(ServiceGeoserverBase):
         return list(params)
 
     @classproperty
-    def permissions(cls):  # noqa
+    def permissions(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> List[Permission]
         perms = set()
         for svc in cls.service_ows_supported:
@@ -1539,7 +1539,7 @@ class ServiceGeoserver(ServiceGeoserverBase):
         return list(perms)
 
     @classproperty
-    def resource_types_permissions(cls):  # noqa
+    def resource_types_permissions(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> ResourceTypePermissions
         perms = {}  # type: ResourceTypePermissions
         for svc in cls.service_ows_supported:
@@ -1578,7 +1578,7 @@ class ServiceGeoserver(ServiceGeoserverBase):
             # since all OWS services are accessed using '/geoserver/<SERVICE>?request=...'
             # attempt to match using applicable path fragment
             svc_path = self.request.path.rsplit("/", 1)[-1].lower()
-            for svc_ows in type(self).service_ows_supported:
+            for svc_ows in type(self).service_ows_supported:  # pylint: disable=E1133,not-an-iterable
                 if svc_path == svc_ows.service_base:
                     svc = svc_ows.service_base
                     break
@@ -1590,19 +1590,19 @@ class ServiceGeoserver(ServiceGeoserverBase):
         return self._service_requested
 
     @classproperty
-    def resource_scoped(cls):  # noqa
+    def resource_scoped(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> bool
         svc = cls.service_requested()
         return svc.resource_scoped if svc else False
 
     @classproperty
-    def resource_multi(cls):  # noqa
+    def resource_multi(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> bool
         svc = cls.service_requested()
         return svc.resource_multi if svc else False
 
     @classproperty
-    def resource_param(cls):  # noqa
+    def resource_param(cls):  # noqa  # pylint: disable=E0213,no-self-argument
         # type: () -> Union[Str, List[Str]]
         svc = cls.service_requested()
         return cls.resource_param if svc else []

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -1030,6 +1030,11 @@ class ServiceAPI(ServiceInterface):
         models.Route: models.Route.permissions
     }
 
+    child_structure_allowed = {
+        models.Service: [models.Route],
+        models.Route: [models.Route],
+    }
+
     def resource_requested(self):
         # type: () -> ResourceRequested
         route_parts = self._get_request_path_parts()
@@ -1161,6 +1166,12 @@ class ServiceTHREDDS(ServiceInterface):
     resource_types_permissions = {
         models.Directory: permissions,
         models.File: permissions,
+    }
+
+    child_structure_allowed = {
+        models.Service: [models.Directory, models.File],
+        models.Directory: [models.Directory, models.File],
+        models.File: [],
     }
 
     configurable = True

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -87,7 +87,8 @@ if TYPE_CHECKING:
     AccessControlEntryType = Union[Tuple[Str, Str, Str], Str]
     AccessControlListType = List[AccessControlEntryType]
 
-    ResourceRequested = Optional[Tuple[ServiceOrResourceType, bool]]
+    TargetResourceRequested = Tuple[ServiceOrResourceType, bool]
+    MultiResourceRequested = Union[None, TargetResourceRequested, List[TargetResourceRequested]]
     PermissionRequested = Optional[Union[Permission, Collection[Permission]]]
     ResourceTypePermissions = Dict[Type[models.Resource], List[Permission]]
 

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:
 
     ResourceRequested = Optional[Tuple[ServiceOrResourceType, bool]]
     PermissionRequested = Optional[Union[Permission, Collection[Permission]]]
+    ResourceTypePermissions = Dict[Type[models.Resource], List[Permission]]
 
     # note:
     #   For all following items 'Settings' suffix refer to loaded definitions AFTER resolution.

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import math
     import typing
-    from typing import Any, AnyStr, Dict, Iterable, List, Optional, Tuple, Type, Union
+    from typing import Any, AnyStr, Collection, Dict, Iterable, List, Optional, Tuple, Type, Union
 
     import six
     from pyramid.config import Configurator
@@ -82,6 +82,9 @@ if TYPE_CHECKING:
     AnyAccessPrincipalType = Union[Str, Iterable[Str]]
     AccessControlEntryType = Union[Tuple[Str, Str, Str], Str]
     AccessControlListType = List[AccessControlEntryType]
+
+    ResourceRequested = Optional[Tuple[ServiceOrResourceType, bool]]
+    PermissionRequested = Optional[Union[Permission, Collection[Permission]]]
 
     # note:
     #   For all following items 'Settings' suffix refer to loaded definitions AFTER resolution.

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -1250,6 +1250,10 @@ a.tab:visited {
     border-color: black;
 }
 
+.input-configuration {
+
+}
+
 .current-option {
 
 }
@@ -1292,6 +1296,22 @@ table.fields-table td.add-group-fixed-width {
 
 table.fields-table input[type="radio"] {
     margin-left: 2em;
+}
+
+.service-button {
+    margin-left: 40%
+}
+
+.service-config-error {
+    margin-top: 0.25em;
+    margin-left: 0;
+    display: inline-flex;
+}
+
+.service-config-error > img {
+    width: 1em;
+    height: 1em;
+    margin: 0.1em 0.25em 0.15em 0;
 }
 
 /* ---

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -922,7 +922,6 @@ div.tree-button {
     text-align: left;
     margin-right: 0.5em;  /* spacing with disallowed text to ensure one title doesn't end flush where the next begins */
     width: 9.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-right] */
-
     /* make text >width employ an ellipsis with scroll that auto apply/remove when using it for too long titles */
     text-overflow: ellipsis;
     overflow: auto;

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -382,6 +382,12 @@ table.panel-line td {
 */
 }
 
+.panel-line-limit-size {
+    /* reduce size of the field to allow other fields to preserve 'Edit' button closer to their value
+       in case the large value contents within this field makes the table column very wide */
+    max-width: 1em;
+}
+
 .panel-line-checkbox {
     padding-top: 0.1em;
     display: inline-block;

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -922,6 +922,7 @@ div.tree-button {
     text-align: left;
     margin-right: 0.5em;  /* spacing with disallowed text to ensure one title doesn't end flush where the next begins */
     width: 9.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-right] */
+
     /* make text >width employ an ellipsis with scroll that auto apply/remove when using it for too long titles */
     text-overflow: ellipsis;
     overflow: auto;

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -1299,7 +1299,7 @@ table.fields-table input[type="radio"] {
 }
 
 .service-button {
-    margin-left: 40%
+    margin-left: 40%;
 }
 
 .service-config-error {

--- a/magpie/ui/management/templates/add_service.mako
+++ b/magpie/ui/management/templates/add_service.mako
@@ -9,14 +9,17 @@
 <h1>Add Service</h1>
 
 <script>
-    function updatePushPhoenixOption() {
-        let arrayServicesPhoenix = ${services_phoenix_indices};
+    function updateActiveServiceOptions() {
+        let arrayServicesPhoenix = ${services_phoenix_enabled};
+        let arrayServicesConfig = ${services_config_enabled};
         let selectedIndex = $("select[id='service_type_select'] option:selected").index();
-        let selectedEnable = (arrayServicesPhoenix[selectedIndex] == 1);
-        document.getElementById("service_push_phoenix_section").hidden = !selectedEnable;
+        let selectedPhoenixEnabled = (arrayServicesPhoenix[selectedIndex] == 1);
+        let selectedConfigEnabled = (arrayServicesConfig[selectedIndex] == 1);
+        document.getElementById("service_push_phoenix_section").hidden = !selectedPhoenixEnabled;
+        document.getElementById("service_configurable_section").hidden = !selectedConfigEnabled;
     }
     $( document ).ready(function() {
-        updatePushPhoenixOption();
+        updateActiveServiceOptions();
     });
 </script>
 
@@ -25,9 +28,12 @@
         <tr>
             <td>Service name:</td>
             <td>
-                <div class="input-container"><label>
-                <input type="text" value="" name="service_name" class="equal-width" placeholder="service">
-                </label></div>
+                <div class="input-container">
+                    <label>
+                        <input type="text" value="${service_name}"
+                               name="service_name" class="equal-width" placeholder="service">
+                    </label>
+                </div>
             </td>
             <td>
                 (unique)
@@ -36,42 +42,78 @@
         <tr>
             <td>Service url:</td>
             <td>
-                <div class="input-container"><label>
-                    <input type="url" value="" name="service_url" class="equal-width"
-                           placeholder="http://localhost:8093">
-                </label></div>
+                <div class="input-container">
+                    <label>
+                        <input type="url" value="${service_url}"
+                               name="service_url" class="equal-width"
+                               placeholder="http://localhost:8093">
+                    </label>
+                </div>
             </td>
-            <td>
-            </td>
+            <td></td>
         </tr>
         <tr><td>Service type:</td>
             <td>
                 <div class="input-container">
-                <label>
-                <select name="service_type" class="equal-width" id="service_type_select"
-                            onchange="updatePushPhoenixOption()">
-                    %for service_type in service_types:
-                        <option value="${service_type}">${service_type}</option>
-                    %endfor
-                 </select>
-                </label>
+                    <label>
+                        <select name="service_type" class="equal-width" id="service_type_select"
+                                onchange="updateActiveServiceOptions()" required>
+                            %for svc_type in service_types:
+                                <option value="${svc_type}"
+                                %if service_type == svc_type:
+                                    selected
+                                %endif
+                                >${svc_type}
+                                </option>
+                            %endfor
+                        </select>
+                    </label>
                 </div>
             </td>
-            <td>
-            </td>
+            <td></td>
         </tr>
-        <tr id="service_push_phoenix_section">
-            <td>Push to Phoenix:</td>
+    </table>
+    <table class="fields-table">  <!-- separate table to avoid moving contents in other cells above on resize -->
+        <tr id="service_configurable_section">
+            <td class="top-align">Configuration:</td>
             <td>
-                <div class="input-container"><label>
-                    <input type="checkbox" name="service_push" checked id="service_push_phoenix_checkbox">
-                </label></div>
+                <div class="input-container input-configuration">
+                    <label>
+                        <textarea rows="5" cols="1" value="" name="service_config" class="equal-width" placeholder="{}"
+                        >${service_config}</textarea>  <!-- spacing is important -->
+                    </label>
+                </div>
             </td>
-        </tr>
-        <tr>
-            <td class="centered" colspan="2">
-                <input type="submit" value="Add Service" name="register" class="button theme">
+            <td class="top-align">
+                <div>
+                    (JSON)
+                </div>
+                %if invalid_config:
+                    <div class="service-config-error">
+                        <img src="${request.static_url('magpie.ui.home:static/exclamation-circle.png')}"
+                             alt="ERROR" class="icon-error" />
+                        <div class="alert-form-text alert-form-text-error">
+                            Invalid
+                        </div>
+                    </div>
+                %endif
             </td>
         </tr>
     </table>
+    <table class="fields-table">
+        <tr id="service_push_phoenix_section">
+            <td>Push to Phoenix:</td>
+            <td>
+                <div class="input-container">
+                    <label>
+                        <input type="checkbox" name="service_push" checked id="service_push_phoenix_checkbox">
+                    </label>
+                </div>
+            </td>
+            <td></td>
+        </tr>
+    </table>
+    <div class="service-button">
+        <input type="submit" value="Add Service" name="register" class="button theme">
+    </div>
 </form>

--- a/magpie/ui/management/templates/add_service.mako
+++ b/magpie/ui/management/templates/add_service.mako
@@ -60,7 +60,7 @@
                                 onchange="updateActiveServiceOptions()" required>
                             %for svc_type in service_types:
                                 <option value="${svc_type}"
-                                %if service_type == svc_type:
+                                %if (service_type or cur_svc_type) == svc_type:
                                     selected
                                 %endif
                                 >${svc_type}

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -154,7 +154,7 @@
                             <span class="panel-entry">Permissions: </span>
                         </td>
                         <td>
-                            <div class="panel-line-entry">
+                            <div class="panel-line-entry panel-line-limit-size">
                                 %for perm in service_perm:
                                     <span class="label label-warning">${perm}</span>
                                 %endfor

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -195,14 +195,6 @@
             <div class="panel-heading subsection">
                 <div class="panel-title">Configuration</div>
             </div>
-            <div class="panel-message">
-                <img src="${request.static_url('magpie.ui.home:static/info.png')}"
-                     alt="INFO" class="icon-info alert-info" title="Service Configuration." />
-                <meta name="source" content="https://commons.wikimedia.org/wiki/File:Infobox_info_icon.svg">
-                <div class="panel-message-text">
-                    This service employs the following custom configuration.
-                </div>
-            </div>
             <div class="clear"></div>
             <div class="panel-code-language">
                 <script>

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -975,10 +975,10 @@ class ManagementViews(AdminRequests, BaseViews):
                                                     service_name=service_name,
                                                     cur_svc_type=cur_svc_type))
 
-        path = schemas.ServiceTypeResourceTypesAPI.path.format(service_type=cur_svc_type)
+        path = schemas.ResourceTypesAPI.path.format(resource_id=resource_id)
         resp = request_api(self.request, path, "GET")
         check_response(resp)
-        svc_res_types = get_json(resp)["resource_types"]
+        svc_res_types = get_json(resp)["children_resource_types"]
         data = {
             "service_name": service_name,
             "cur_svc_type": cur_svc_type,

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -498,10 +498,11 @@ class ManagementViews(AdminRequests, BaseViews):
         Get the user or group applied permissions as well as applicable permissions for corresponding services.
 
         Result is a :class:`tuple` of:
-            - combined :term:`Allowed Permissions` (*names only*) for services and their children resources.
+            - combined :term:`Allowed Permissions <Applied Permission>` (*names only*) for services and their children
+              :term:`Resources <Resource>`.
             - dictionary of key-service-name, each with recursive map value of children resource details including
-              the :term:`Applied Permissions <Applied Permission>` or :term:`Inherited Resources` for the corresponding :term:`User`
-              or :term:`Group` accordingly to specified arguments.
+              the :term:`Applied Permissions <Applied Permission>` or :term:`Inherited Resources` for the corresponding
+              :term:`User` or :term:`Group` accordingly to specified arguments.
         """
         if is_user:
             # because page can only show a single permission (per name/resource) at a time, apply resolution

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -500,7 +500,7 @@ class ManagementViews(AdminRequests, BaseViews):
         Result is a :class:`tuple` of:
             - combined :term:`Allowed Permissions` (*names only*) for services and their children resources.
             - dictionary of key-service-name, each with recursive map value of children resource details including
-              the :term:`Applied Permissions` or :term:`Inherited Resources` for the corresponding :term:`User`
+              the :term:`Applied Permissions <Applied Permission>` or :term:`Inherited Resources` for the corresponding :term:`User`
               or :term:`Group` accordingly to specified arguments.
         """
         if is_user:

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -876,9 +876,12 @@ class ManagementViews(AdminRequests, BaseViews):
                     json_config = is_json_body(service_config, return_body=True)
                     if json_config is None:
                         data.update({
+                            # forward any fields to avoid dropping values filled by user
                             "service_name": service_name,
                             "service_type": service_type,
+                            "service_url": service_url,
                             "service_config": service_config,
+                            "service_push": service_push,
                             "invalid_config": True,
                         })
                         return self.add_template_data(data)

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -888,7 +888,7 @@ class ExtendedEnum(Enum):
 
         Title use the original enum element name with capitalization considering underscores for separate words.
         """
-        return self.name.title().replace("_", "")
+        return self.name.title().replace("_", "")  # pylint: disable=E1101,no-member
 
 
 # note: must not define any enum value here to allow inheritance by subclasses

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -999,7 +999,7 @@ class SingletonMeta(type):
         return cls._instances[cls]
 
 
-class classproperty(property):
+class classproperty(property):  # pylint: disable=C0103,invalid-name
     """
     Mimics :class:`property` decorator, but applied onto ``classmethod`` in backward compatible way.
 

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -816,15 +816,15 @@ def log_exception_tween(handler, registry):  # noqa: F811
     return log_exc
 
 
-def is_json_body(body):
-    # type: (Any) -> bool
+def is_json_body(body, return_body=False):
+    # type: (Any, bool) -> bool
     if not body:
-        return False
+        return None if return_body else False
     try:
-        json.loads(body)
+        content = json.loads(body)
     except (ValueError, TypeError):
-        return False
-    return True
+        return None if return_body else False
+    return content if return_body else True
 
 
 # note: must not define any enum value here to allow inheritance by subclasses

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -997,3 +997,17 @@ class SingletonMeta(type):
         if cls not in cls._instances:
             cls._instances[cls] = super(SingletonMeta, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
+
+
+class classproperty(property):
+    """
+    Mimics :class:`property` decorator, but applied onto ``classmethod`` in backward compatible way.
+
+    .. note::
+        This decorator purposely only supports getter attribute to define unmodifiable class properties.
+
+    .. seealso::
+        https://stackoverflow.com/a/5191224
+    """
+    def __get__(self, cls, owner):  # noqa
+        return classmethod(self.fget).__get__(None, owner)()

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,7 @@
 # these are doc-only requirements
 # we actually need to install all requirements during docs build because of OpenAPI generation
 # (see 'docs/conf.py')
+cloud_sptheme
 pycodestyle==2.6.0; python_version >= "3.6"
 # sphinx-autoapi dropped 3.5 support at 1.3.0
 # latest to fullfil requirements, but that is not the main doc builder version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.19.1
+current_version = 3.20.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2555,8 +2555,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                     child-resource      <-- 2nd permission applied
 
         For each combination, there is always only one :term:`Applied Permission` for a user or group per resource in
-        the hierarchy. This makes :term:`Inherited Permissions <inherited permission>` and
-        :term:`Resolved Permissions <inherited permission>` field ``reasons`` much
+        the hierarchy. This makes :term:`Inherited Permissions <Inherited Permission>` and
+        :term:`Resolved Permissions <Inherited Permission>` field ``reasons`` much
         easier to validate as there are no intra-resource (same) permission resolution, only inter-resource (distinct)
         permission inheritance according to local-level priorities, making ``reason`` always single-entry.
         These are highlighted by the corresponding arrow comments in the code.
@@ -2721,7 +2721,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
     @runner.MAGPIE_TEST_FUNCTIONAL
     def test_GetUserResourcePermissions_EffectivePermissions_ScopedHierarchyResolution(self):
         """
-        Validates that :term:`Effective Permissions` resolution works when scoped subsets of :term:`Resource` have
+        Validates that :term:`Effective Permission` resolution works when scoped subsets of :term:`Resource` have
         alternating :term:`Applied Permissions` with opposite :class:`Access` modifiers.
 
         The resolution of permissions should consider the *closest* scope to the targeted :term:`Resource`, but still
@@ -3738,8 +3738,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
 
         .. warning::
             Group inheritance query parameter existed before ``2.0.0``, but was not producing the correct result
-            for children resources permissions (all :term:`Allowed Permissions` were returned instead of
-            user/group-specific :term:`Applied Permissions`).
+            for children resources permissions (every :term:`Allowed Permission` was returned instead of
+            user/group-specific :term:`Applied Permissions <Applied Permission>`).
         """
         utils.warn_version(self, "user service inheritance", "2.0.0", skip=True)
         resp = utils.test_request(self, "GET", "/services", headers=self.json_headers, cookies=self.cookies)
@@ -3788,8 +3788,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
 
         .. warning::
             Group inheritance query parameter existed before ``2.0.0``, but was not producing the correct result
-            for children resources permissions (all :term:`Allowed Permissions` were returned instead of
-            user/group-specific :term:`Applied Permissions`).
+            for children resources permissions (every :term:`Allowed Permission` was returned instead of
+            user/group-specific :term:`Applied Permissions <Applied Permission>`).
         """
         utils.warn_version(self, "user service inheritance", "2.0.0", skip=True)
         resp = utils.test_request(self, "GET", "/services", headers=self.json_headers, cookies=self.cookies)

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2555,7 +2555,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                     child-resource      <-- 2nd permission applied
 
         For each combination, there is always only one :term:`Applied Permission` for a user or group per resource in
-        the hierarchy. This makes :term:`Inherited Permissions` and :term:`Resolved Permissions` field ``reasons`` much
+        the hierarchy. This makes :term:`Inherited Permissions <inherited permission>` and
+        :term:`Resolved Permissions <inherited permission>` field ``reasons`` much
         easier to validate as there are no intra-resource (same) permission resolution, only inter-resource (distinct)
         permission inheritance according to local-level priorities, making ``reason`` always single-entry.
         These are highlighted by the corresponding arrow comments in the code.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -21,7 +21,15 @@ from sqlalchemy import inspect as sa_inspect
 from magpie import __meta__, models, owsrequest
 from magpie.constants import get_constant
 from magpie.permissions import Access, Permission, PermissionSet, PermissionType, Scope
-from magpie.services import ServiceAccess, ServiceAPI, ServiceGeoserverWMS, ServiceInterface, ServiceTHREDDS, ServiceWPS
+from magpie.services import (
+    ServiceAccess,
+    ServiceAPI,
+    ServiceGeoserver,
+    ServiceGeoserverWMS,
+    ServiceInterface,
+    ServiceTHREDDS,
+    ServiceWPS
+)
 from magpie.utils import CONTENT_TYPE_FORM, CONTENT_TYPE_JSON, CONTENT_TYPE_TXT_XML
 from tests import interfaces as ti
 from tests import runner, utils
@@ -979,6 +987,46 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
             corresponding resources accessed through different endpoints and formats.
         """
         raise NotImplementedError  # FIXME: see https://github.com/Ouranosinc/Magpie/issues/360
+
+    @unittest.skip("not implemented")  # FIXME: not implemented
+    @pytest.mark.skip
+    @utils.mocked_get_settings
+    def test_ServiceGeoserver_effective_permissions(self):
+        """
+        Evaluates functionality of :class:`ServiceGeoserver` against a mocked `Magpie` adapter for `Twitcher`.
+
+        The :class:`ServiceGeoserver` implementation works as a combination of many `OWS` sub-services.
+        Validate that different resource types and distinct permissions can be simultaneously applied on them.
+        Effective permissions must be resolved with the appropriate `OWS` service accordingly with request parameters.
+
+        Legend::
+
+            dp: DescribeProcess permission (WPS Process)
+            gf: GetFeature permission (WFS Layer)
+            gi: GetFeatureInfo permission (WMS Layer)
+            A: allow
+            D: deny
+            M: match        (doesn't matter because service always directly referenced)
+            R: recursive    (doesn't matter because service always directly referenced)
+
+        Permissions Applied::
+                                        user        group               effective (reason)
+            Service1                    (a-A-R)                         a-A
+                Workspace1
+                    Layer1
+                    Layer2
+                    Process1
+                    Process2
+
+            Service2                                (a-A-M)             a-A
+            Service3                    (a-D-M)                         a-D
+            Service4                                (a-D-R)             a-D
+            Service5                    (a-A-R)     (a-D-M)             a-A (user > group)
+            Service6                                                    a-D (nothing defaults like explicit deny)
+        """
+        svc_type = ServiceGeoserver.service_type
+        svc1_name = "unittest-service-geoserver-1"
+        raise NotImplementedError
 
 
 @runner.MAGPIE_TEST_LOCAL

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -197,10 +197,10 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 
         .. versionchanged:: 3.5
             User and Group permissions for ``Resource1`` and ``Resource2`` have been swapped since new priorities make
-            :term:`Direct Permissions` more important than :term:`Inherited Permissions`. The :attr:`Access.DENY` was
-            not being reverted with original definitions that assumed them to be of equal importance, and therefore
-            plain ``DENY > ALLOW`` was working. Permission on ``Resource4`` was moved from Group to User for the same
-            reason.
+            :term:`Direct Permissions <direct permission>` more important than
+            :term:`Inherited Permissions <inherited permission>`. The :attr:`Access.DENY` was not being reverted with
+            original definitions that assumed them to be of equal importance, and therefore plain ``DENY > ALLOW`` was
+            working. Permission on ``Resource4`` was moved from Group to User for the same reason.
         """
         svc_name = "unittest-service-api"
         svc_type = ServiceAPI.service_type
@@ -342,9 +342,9 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 
         .. versionchanged:: 3.5
             User and Group permissions for ``Directory1`` and ``Directory2`` have been swapped since new priorities make
-            :term:`Direct Permissions` more important than :term:`Inherited Permissions`. The :attr:`Access.DENY` was
-            not being reverted with original definitions that assumed them to be of equal importance, and therefore
-            plain ``DENY > ALLOW`` was working.
+            :term:`Direct Permissions` more important than :term:`Inherited Permissions <inherited permission>`.
+            The :attr:`Access.DENY` was not being reverted with original definitions that assumed them to be of equal
+            importance, and therefore plain ``DENY > ALLOW`` was working.
         """
         svc_type = ServiceTHREDDS.service_type
         svc1_name = "unittest-service-thredds-1"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1019,14 +1019,18 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
                                         user        group       effective (detail)
             Service1                    (gc-A-R)    (gm-D-R)    gc-A, gf-D, gi-D, gm-D
                 Workspace1              (dp-A-R)    (gf-A-R)    dp-A, gf-A, gi-D, gm-D (no match on Workspace itself)
-                    Layer1                          (gi-A-R)    dp-D, gf-A, gi-A, gm-D
-                    Layer2              (gf-D-M)    (gm-A-M)    dp-D, gf-D, gi-A, gm-A (match > recursive)
-                    Layer3              (gm-A-R)                dp-D, gf-A, gi-A, gm-A (effective user > group)
+                    Layer11                         (gi-A-R)    dp-D, gf-A, gi-A, gm-D
+                    Layer12             (gf-D-M)    (gm-A-M)    dp-D, gf-D, gi-A, gm-A (match > recursive)
+                    Layer13             (gm-A-R)                dp-D, gf-A, gi-A, gm-A (effective user > group)
                     [Layer4]                                    dp-D, gf-A, gi-D (doesn't exist, only R apply)
-                    Process1                                    dp-A, gf-D, gi-D (gf/gi don't apply on Process)
-                    Process2            (dp-D-M)                dp-D, gf-D, gi-D
-                    Process3                        (dp-D-M)    dp-A, gf-D, gi-D (effective workspace user > group)
+                    Process11                                   dp-A, gf-D, gi-D (gf/gi don't apply on Process)
+                    Process12           (dp-D-M)                dp-D, gf-D, gi-D
+                    Process13                       (dp-D-M)    dp-A, gf-D, gi-D (effective workspace user > group)
                     [Process4]                                  dp-A, gf-D, gi-D
+                Workspace2                          (gf-A-R)    dp-D, gf-A, gi-D
+                    Layer21             (gf-D-M)                dp-D, gf-D, gi-D (revoke access, user > group)
+                    Layer22                         (gf-D-M)    dp-D, gf-D, gi-D (revoke access, both groups)
+                    Layer23             (gf-A-M)    (gf-D-M)    dp-D, gf-A, gi-D (allowed access, user > group)
 
         .. note::
             Permissions that do not applied to a given sub-:term:`OWS` implementation are automatically denied.
@@ -1035,15 +1039,19 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         svc_type = ServiceGeoserver.service_type
         svc1_name = "unittest-service-geoserver-1"
         w1_name = "workspace1"
+        w2_name = "workspace2"
         wx_name = "fake-workspace"
-        l1_name = "layer1"
-        l2_name = "layer2"
-        l3_name = "layer3"
-        l4_name = "layer4"
-        p1_name = "process1"
-        p2_name = "process2"
-        p3_name = "process3"
-        p4_name = "process4"
+        l11_name = "layer11"
+        l12_name = "layer12"
+        l13_name = "layer13"
+        l14_name = "layer14"
+        l21_name = "layer21"
+        l22_name = "layer22"
+        l23_name = "layer23"
+        p11_name = "process11"
+        p12_name = "process12"
+        p13_name = "process13"
+        p14_name = "process14"
 
         utils.TestSetup.delete_TestService(self, svc1_name)
         svc1_id, w1_id = utils.TestSetup.create_TestServiceResourceTree(
@@ -1054,42 +1062,71 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         info = utils.TestSetup.create_TestResource(
             self,
             parent_resource_id=w1_id,
-            override_resource_name=l1_name,
+            override_resource_name=l11_name,
             override_resource_type=models.Layer.resource_type_name
         )
-        l1_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        l11_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
         info = utils.TestSetup.create_TestResource(
             self,
             parent_resource_id=w1_id,
-            override_resource_name=l2_name,
+            override_resource_name=l12_name,
             override_resource_type=models.Layer.resource_type_name
         )
-        l2_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        l12_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
         info = utils.TestSetup.create_TestResource(
             self,
             parent_resource_id=w1_id,
-            override_resource_name=l3_name,
+            override_resource_name=l13_name,
             override_resource_type=models.Layer.resource_type_name
         )
-        l3_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        l13_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
         info = utils.TestSetup.create_TestResource(
             self,
             parent_resource_id=w1_id,
-            override_resource_name=p2_name,
+            override_resource_name=p12_name,
             override_resource_type=models.Process.resource_type_name
         )
-        p2_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        p12_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
         info = utils.TestSetup.create_TestResource(
             self,
             parent_resource_id=w1_id,
-            override_resource_name=p3_name,
+            override_resource_name=p13_name,
             override_resource_type=models.Process.resource_type_name
         )
-        p3_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        p13_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        info = utils.TestSetup.create_TestResource(
+            self,
+            parent_resource_id=svc1_id,
+            override_resource_name=w2_name,
+            override_resource_type=models.Workspace.resource_type_name
+        )
+        w2_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        info = utils.TestSetup.create_TestResource(
+            self,
+            parent_resource_id=w2_id,
+            override_resource_name=l21_name,
+            override_resource_type=models.Layer.resource_type_name
+        )
+        l21_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        info = utils.TestSetup.create_TestResource(
+            self,
+            parent_resource_id=w2_id,
+            override_resource_name=l22_name,
+            override_resource_type=models.Layer.resource_type_name
+        )
+        l22_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
+        info = utils.TestSetup.create_TestResource(
+            self,
+            parent_resource_id=w2_id,
+            override_resource_name=l23_name,
+            override_resource_type=models.Layer.resource_type_name
+        )
+        l23_id = utils.TestSetup.get_ResourceInfo(self, info)["resource_id"]
 
         # create permissions
         gcAR = PermissionSet(Permission.GET_CAPABILITIES, Access.ALLOW, Scope.RECURSIVE)    # noqa
         gfAR = PermissionSet(Permission.GET_FEATURE, Access.ALLOW, Scope.RECURSIVE)         # noqa
+        gfAM = PermissionSet(Permission.GET_FEATURE, Access.ALLOW, Scope.MATCH)             # noqa
         gfDM = PermissionSet(Permission.GET_FEATURE, Access.DENY, Scope.MATCH)              # noqa
         giAR = PermissionSet(Permission.GET_FEATURE_INFO, Access.ALLOW, Scope.RECURSIVE)    # noqa
         gmAM = PermissionSet(Permission.GET_MAP, Access.ALLOW, Scope.MATCH)                 # noqa
@@ -1101,12 +1138,17 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=svc1_id, override_permission=gmDR)
         utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=w1_id, override_permission=gfAR)
         utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=w1_id, override_permission=dpAR)
-        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=l1_id, override_permission=giAR)
-        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=l2_id, override_permission=gfDM)
-        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=l2_id, override_permission=gmAM)
-        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=l3_id, override_permission=gmAR)
-        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=p2_id, override_permission=dpDM)
-        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=p3_id, override_permission=dpDM)
+        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=l11_id, override_permission=giAR)
+        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=l12_id, override_permission=gfDM)
+        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=l12_id, override_permission=gmAM)
+        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=l13_id, override_permission=gmAR)
+        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=p12_id, override_permission=dpDM)
+        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=p13_id, override_permission=dpDM)
+        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=w2_id, override_permission=gfAR)
+        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=l21_id, override_permission=gfDM)
+        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=l22_id, override_permission=gfDM)
+        utils.TestSetup.create_TestUserResourcePermission(self, override_resource_id=l23_id, override_permission=gfAM)
+        utils.TestSetup.create_TestGroupResourcePermission(self, override_resource_id=l23_id, override_permission=gfDM)
 
         # login test user for which the permissions were set
         self.login_test_user()
@@ -1144,20 +1186,24 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         w1_wfs_path = "{}/{}/wfs".format(svc_path, w1_name)
         w1_wms_path = "{}/{}/wms".format(svc_path, w1_name)
         w1_wps_path = "{}/{}/wps".format(svc_path, w1_name)
+        w2_wfs_path = "{}/{}/wfs".format(svc_path, w2_name)
         wx_wfs_path = "{}/{}/wfs".format(svc_path, wx_name)
         wx_wms_path = "{}/{}/wms".format(svc_path, wx_name)
         svc_wfs_path = "{}/wfs".format(svc_path)
         svc_wms_path = "{}/wms".format(svc_path)
         svc_wps_path = "{}/wps".format(svc_path)
-        wx_l1 = _scope(wx_name, l1_name)
-        w1_l1 = _scope(w1_name, l1_name)
-        w1_l2 = _scope(w1_name, l2_name)
-        w1_l3 = _scope(w1_name, l3_name)
-        w1_l4 = _scope(w1_name, l4_name)
-        w1_p1 = _scope(w1_name, p1_name)
-        w1_p2 = _scope(w1_name, p2_name)
-        w1_p3 = _scope(w1_name, p3_name)
-        w1_p4 = _scope(w1_name, p4_name)
+        wx_l1 = _scope(wx_name, l11_name)
+        w1_l1 = _scope(w1_name, l11_name)
+        w1_l2 = _scope(w1_name, l12_name)
+        w1_l3 = _scope(w1_name, l13_name)
+        w1_l4 = _scope(w1_name, l14_name)
+        w1_p1 = _scope(w1_name, p11_name)
+        w1_p2 = _scope(w1_name, p12_name)
+        w1_p3 = _scope(w1_name, p13_name)
+        w1_p4 = _scope(w1_name, p14_name)
+        w2_l1 = _scope(w2_name, l21_name)
+        w2_l2 = _scope(w2_name, l22_name)
+        w2_l3 = _scope(w2_name, l23_name)
 
         # Layer1, mismatching permission for WMS
         _test(svc_wms_path, {"request": Permission.GET_FEATURE.title, "layers": w1_l1}, allow=False)
@@ -1268,14 +1314,14 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         # valid WPS requests
         #   - Workspace only expected to work when in path because 'identifier' is not linked to workspace
         #   - Process2 is explicitly denied, so access still blocked even when resource is properly resolved.
-        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p1_name}, allow=True)
-        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p2_name}, allow=False)
-        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p3_name}, allow=True)
-        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p4_name}, allow=True)
+        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p11_name}, allow=True)
+        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p12_name}, allow=False)
+        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p13_name}, allow=True)
+        _test(w1_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p14_name}, allow=True)
         # other cases all invalid since workspace cannot be resolved
-        _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p1_name}, allow=False)
-        _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p2_name}, allow=False)
-        _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p3_name}, allow=False)
+        _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p11_name}, allow=False)
+        _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p12_name}, allow=False)
+        _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": p13_name}, allow=False)
         _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": w1_p1}, allow=False)
         _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": w1_p2}, allow=False)
         _test(svc_wps_path, {"request": Permission.DESCRIBE_PROCESS.title, "identifier": w1_p3}, allow=False)
@@ -1285,16 +1331,16 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         # validate that effective resolution considering user/group priority and recursive/match scope priority work
         _test(svc_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l1}, allow=False)
         _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l1}, allow=False)
-        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l1_name}, allow=False)
+        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l11_name}, allow=False)
         _test(svc_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l2}, allow=True)
         _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l2}, allow=True)
-        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l2_name}, allow=True)
+        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l12_name}, allow=True)
         _test(svc_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l3}, allow=True)
         _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l3}, allow=True)
-        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l3_name}, allow=True)
+        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l13_name}, allow=True)
         _test(svc_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l4}, allow=False)
         _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": w1_l4}, allow=False)
-        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l4_name}, allow=False)
+        _test(w1_wms_path, {"request": Permission.GET_MAP.title, "layers": l14_name}, allow=False)
 
         # using either the 'typename' or 'typenames' parameter lets WFS retrieve layers indistinguishably
         alt_name = "typeName"
@@ -1327,16 +1373,44 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 
         # using multiple layers at the same time should validate all of them (all or nothing access)
         # order should not matter
-        w1_l1_w1_l1 = ",".join([w1_l1, w1_l1])  # resolved as duplicate, only processed once, allowed
-        w1_l1_w1_l2 = ",".join([w1_l1, w1_l2])  # W1-L1 is allowed, but not W1-L2, so both denied
-        w1_l1_w1_l3 = ",".join([w1_l1, w1_l3])  # both are allowed, so full request allowed as well
-        w1_l2_w1_l1 = ",".join([w1_l2, w1_l1])
-        w1_l3_w1_l1 = ",".join([w1_l3, w1_l1])
-        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w1_l1_w1_l1}, allow=True)
-        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w1_l1_w1_l2}, allow=False)
-        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w1_l1_w1_l3}, allow=True)
-        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w1_l2_w1_l1}, allow=False)
-        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w1_l3_w1_l1}, allow=True)
+        l11_l11 = ",".join([w1_l1, w1_l1])  # resolved as duplicate, only processed once, allowed
+        l11_l12 = ",".join([w1_l1, w1_l2])  # W1-L1 is allowed, but not W1-L2, so both denied
+        l11_l13 = ",".join([w1_l1, w1_l3])  # both are allowed, so full request allowed as well
+        l12_l11 = ",".join([w1_l2, w1_l1])
+        l13_l11 = ",".join([w1_l3, w1_l1])
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": l11_l11}, allow=True)
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": l11_l12}, allow=False)
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": l11_l13}, allow=True)
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": l12_l11}, allow=False)
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": l13_l11}, allow=True)
+
+        # validate revoking access when explicit denies are placed under previously allowed-recursive resources
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w2_l1}, allow=False)
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w2_l2}, allow=False)
+        _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w2_l3}, allow=True)
+        _test(w2_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w2_l1}, allow=False)
+        _test(w2_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w2_l2}, allow=False)
+        _test(w2_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": w2_l3}, allow=True)
+
+        # mixing workspaces still work if only in scoped resource reference,
+        # but fail for isolated path workspace due to mismatch workspace reference in at least one case
+        #   Summary (GetFeature):
+        #       L11: A  L21: D      -> only allowed combinations are exclusively with:  [L11, L13, L23]
+        #       L12: D  L22: D      -> deny any combination when following are present: [L12, L21, L22]
+        #       L13: A  L23: A
+        for quantity in [2, 3, 4, 5]:
+            layer_permutes = itertools.permutations([w1_l1, w1_l2, w1_l3, w2_l1, w2_l2, w2_l3], quantity)
+            for layer_combo in layer_permutes:
+                query = ",".join(layer_combo)
+                allow = not any(layer_deny in layer_combo for layer_deny in [w1_l2, w2_l1, w2_l2])
+                _test(svc_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": query}, allow=allow)
+
+                # multiple layers nested under same workspace will work for request with Workspace isolated path
+                # otherwise, automatic deny regardless if they were allowed during request without workspace in path
+                allow_w1 = allow and all(layer.startswith(w1_name) for layer in layer_combo)
+                allow_w2 = allow and all(layer.startswith(w2_name) for layer in layer_combo)
+                _test(w1_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": query}, allow=allow_w1)
+                _test(w2_wfs_path, {"request": Permission.GET_FEATURE.title, "typeNames": query}, allow=allow_w2)
 
 
 @runner.MAGPIE_TEST_LOCAL

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -997,9 +997,10 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         """
         Evaluates functionality of :class:`ServiceGeoserver` against a mocked `Magpie` adapter for `Twitcher`.
 
-        The :class:`ServiceGeoserver` implementation works as a combination of many `OWS` sub-services.
+        The :class:`ServiceGeoserver` implementation works as a combination of many :term:`OWS` sub-services.
         Validate that different resource types and distinct permissions can be simultaneously applied on them.
-        Effective permissions must be resolved with the appropriate `OWS` service accordingly with request parameters.
+        Effective permissions must be resolved with the appropriate :term:`OWS` service accordingly with request
+        parameters.
 
         Legend::
 
@@ -1025,7 +1026,7 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
                     [Process3]                                  dp-A, gf-D, gi-D
 
         .. note::
-            Permissions that do not applied to a given sub-`OWS` implementation are automatically denied.
+            Permissions that do not applied to a given sub-:term:`OWS` implementation are automatically denied.
             For example, 'GetFeatureInfo' cannot be applied for a 'Process' nor can 'DescribeProcess' for a 'Layer'.
         """
         svc_type = ServiceGeoserver.service_type

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -197,8 +197,8 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 
         .. versionchanged:: 3.5
             User and Group permissions for ``Resource1`` and ``Resource2`` have been swapped since new priorities make
-            :term:`Direct Permissions <direct permission>` more important than
-            :term:`Inherited Permissions <inherited permission>`. The :attr:`Access.DENY` was not being reverted with
+            :term:`Direct Permissions <Direct Permission>` more important than
+            :term:`Inherited Permissions <Inherited Permission>`. The :attr:`Access.DENY` was not being reverted with
             original definitions that assumed them to be of equal importance, and therefore plain ``DENY > ALLOW`` was
             working. Permission on ``Resource4`` was moved from Group to User for the same reason.
         """
@@ -342,7 +342,7 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 
         .. versionchanged:: 3.5
             User and Group permissions for ``Directory1`` and ``Directory2`` have been swapped since new priorities make
-            :term:`Direct Permissions` more important than :term:`Inherited Permissions <inherited permission>`.
+            :term:`Direct Permissions` more important than :term:`Inherited Permissions <Inherited Permission>`.
             The :attr:`Access.DENY` was not being reverted with original definitions that assumed them to be of equal
             importance, and therefore plain ``DENY > ALLOW`` was working.
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1284,7 +1284,7 @@ def check_val_not_in(val, ref, msg=None):
 
 
 def check_val_type(val, ref, msg=None):
-    # type: (Any, Union[Type[Any], NullType], Optional[Str]) -> None
+    # type: (Any, Union[Type[Any], Tuple[Type[Any]], NullType], Optional[Str]) -> None
     """:raises AssertionError: if :paramref:`val` is not an instanced of :paramref:`ref`."""
     assert isinstance(val, ref), format_test_val_ref(val, repr(ref), pre="Type Fail", msg=msg)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -966,22 +966,26 @@ def test_request(test_item,             # type: AnyMagpieTestItemType
             kwargs["expect_errors"] = True
         err_code = None
         err_msg = None
+        err_exc = None
         try:
             resp = app_or_url._gen_request(method, path, **kwargs)  # pylint: disable=W0212  # noqa: W0212
         except AppError as exc:
             err_code = exc
             err_msg = str(exc)
+            err_exc = exc
         except HTTPException as exc:
             err_code = exc.status_code
             err_msg = str(exc) + str(getattr(exc, "exception", ""))
+            err_exc = exc
         except Exception as exc:
             err_code = 500
             err_msg = "Unknown: {!s}".format(exc)
+            err_exc = exc
         finally:
             if err_code:
                 info = json_msg({"path": path, "method": method, "body": _body, "headers": kwargs["headers"]})
                 result = "Request raised unexpected error: {!s}\nError: {}\nRequest:\n{}"
-                raise AssertionError(result.format(err_code, err_msg, info))
+                six.raise_from(AssertionError(result.format(err_code, err_msg, info)), err_exc)
 
         # automatically follow the redirect if any and evaluate its response
         max_redirect = kwargs.get("max_redirects", 5)


### PR DESCRIPTION
## Summary

First implementation that resolves most common use cases. 
Since the changes are already substantial, start with this version that **DOES NOT** support multiple `layers=<layer1>,<layer2>` resources. 

A subsequent PR can attempt resolution of combined resources and return only `Allow` if all resources are accessible. 
That will involve modifying the (complicated) `effective_permissions` method.

## Features / Changes

* Add missing ``ServiceWFS`` permissions according to [OGC WFS standard](https://www.ogc.org/standards/wfs).
* Add missing ``DescribeLayer`` permission to ``ServiceGeoserverWMS`` according to [GeoServer WMS implementation](https://docs.geoserver.org/latest/en/user/services/wms/reference.html).
* Add support of specific hierarchy of ``Resource`` type ``Layer`` nested under ``Workspace`` for ``ServiceGeoserverWMS``.
* Add support of ``Resource`` type ``Layer`` under ``ServiceWFS``.
* Allow ``Resource`` and ``Service`` name to contain colon (``:``) character in order to define scoped names as it is often the case for ``Layer`` names.
* Add ``child_structure_allowed`` attribute to ``Service`` implementations allowing them to define specific path-like structures of allowed ``Resource`` types hierarchies in order to control at which level and which combinations of nested ``Resource`` types are valid under their root ``Service``. When not defined under a ``Service`` implementation, any defined ``Resource`` type will remain available for creation at any level of the hierarchy, unless the corresponding ``Resource`` in the tree already defined ``child_resource_allowed = False``. This was already the original behaviour in previous versions.
* Add ``GET /resources/{id}/types`` endpoint that allows retrieval of applicable children ``Resource`` types under a given ``Resource`` considering the nested hierarchy definition of its root ``Service`` defined by the new attribute ``child_structure_allowed``.
* Add ``child_structure_allowed`` attribute to the response of ``GET /service/{name}`` endpoint.
  For backward compatibility, ``resource_types_allowed`` parameter already available in the same response will continue to report all possible ``Resource`` types *at any level* under the ``Service`` hierarchy, although not necessarily applicable as immediate child ``Resource`` under that ``Service``.
* Add ``configurable`` attribute to ``Service`` types that supports custom definitions modifying their behaviour.
* Add ``service_configurable`` to response of ``GET /service/{name}`` endpoint.
* Adjust UI to consider ``child_structure_allowed`` definitions to propose only applicable ``Resource`` types in the combobox when creating a new ``Resource`` in the tree hierarchy.
* Add UI submission field to provide ``Service`` JSON configuration at creation when supported by the type.

## Bug Fixes

* Remove invalid ``params_expected`` parameter from ``Service`` implementations (``ServiceAccess``, ``ServiceAPI``,
  ``ServiceTHREDDS``) that don't make use of it since they don't derive from ``ServiceOWS``.
* Fix base ``Permission`` definitions for all variants of `WMS` according to their reference implementations.
* Remove multiple invalid schema path definitions that are not mapped against any concrete API endpoint.
* Fix reporting of ``Service`` configuration for any type that supports it. Unless overridden during creation with a custom configuration, ``ServiceTHREDDS`` implementation would not report their default configuration and would instead return ``null``, making it difficult to know from the API if default or no configuration was being applied for a given ``Service``.
* Fix `Effective Resolution` of ``Permission`` applied for ``ServiceGeoserverWMS`` to consider ``Scope`` modifier of ``Service`` and ``Workspace`` for access to be resolved at the ``Layer`` level.