### PR TITLE
fix alignment of permission title/combobox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,7 +56,8 @@ Bug Fixes
   for a given ``Service``.
 * Fix `Effective Resolution` of ``Permission`` applied for ``ServiceGeoserverWMS`` to consider ``Scope`` modifier
   of ``Service`` and ``Workspace`` for access to be resolved at the ``Layer`` level.
-* Fix UI alignment of permission titles with their corresponding permission selectors.
+* Fix UI alignment of permission titles with their corresponding permission selectors
+  (relates to `#498 <https://github.com/Ouranosinc/Magpie/issues/498>`_).
 
 `3.20.1 <https://github.com/Ouranosinc/Magpie/tree/3.20.1>`_ (2022-01-19)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ Features / Changes
   to multiple items simultaneously. An example of this is the comma-separated list of ``Layer`` defined by ``typeNames``
   of new ``ServiceGeoserverWMS`` implementation. Access is granted if the ``User`` has access to **ALL** ``Resource``
   resolved from parsing the request.
+* Add auto-restore of previous scroll position in UI page following submitted form.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
@@ -55,6 +56,7 @@ Bug Fixes
   for a given ``Service``.
 * Fix `Effective Resolution` of ``Permission`` applied for ``ServiceGeoserverWMS`` to consider ``Scope`` modifier
   of ``Service`` and ``Workspace`` for access to be resolved at the ``Layer`` level.
+* Fix UI alignment of permission titles with their corresponding permission selectors.
 
 `3.20.1 <https://github.com/Ouranosinc/Magpie/tree/3.20.1>`_ (2022-01-19)
 ------------------------------------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ Features / Changes
   of new ``ServiceGeoserverWMS`` implementation. Access is granted if the ``User`` has access to **ALL** ``Resource``
   resolved from parsing the request.
 * Add auto-restore of previous scroll position in UI page following submitted form.
+* Add UI tooltip `Resource` ID to elements rendered in the ``Service`` and ``Permission`` hierarchy trees
+  (relates to `#335 <https://github.com/Ouranosinc/Magpie/issues/335>`_).
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -921,17 +921,25 @@ div.tree-button {
 }
 
 .permission-title {
+    /* make text >width employ an ellipsis with scroll that auto apply/remove when using it for too long titles */
+    text-overflow: ellipsis;
+    overflow: auto;
+    text-align: left;
+}
+
+.permission-cell {
     /* ensure that sufficient space is provided to fit all possible permission-name side-by-side
        align with combobox and checkbox, must include both their respective width
     */
     float: right;
-    text-align: left;
-    margin-right: 0.5em;  /* spacing with disallowed text to ensure one title doesn't end flush where the next begins */
-    width: 9.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-right] */
+    margin-left: 0.5em;  /* spacing with disallowed text to ensure one title doesn't end flush where the next begins */
+    width: 9.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-left] */
 
-    /* make text >width employ an ellipsis with scroll that auto apply/remove when using it for too long titles */
-    text-overflow: ellipsis;
-    overflow: auto;
+    display: inline-flex;
+    flex-wrap: nowrap;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: flex-start;
 }
 
 .permission-title-effective {
@@ -940,15 +948,12 @@ div.tree-button {
 }
 
 .permission-entry {
-    float: right;
     text-align: left;
     margin-top: 0.05em;
-    margin-right: 0.5em;    /* must be included in 'permission-title' width */
 }
 
 .permission-checkbox {
     width: 1.5em;
-    float: right;
     text-align: left;
     margin-top: 0.1em;
     margin-right: 0;        /* must be included in 'permission-title' width, affects width of 'permission-effective' */

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -973,6 +973,34 @@ div.tree-button {
     display: none;
 }
 
+.tooltip-container {
+}
+
+.tooltip-container .tooltip-value {
+    border-bottom: 1px dotted black;
+}
+
+.tooltip-container .tooltip-text {
+    visibility: hidden;
+    text-align: center;
+    background-color: black;
+    color: white;
+    border-radius: 5px;
+    padding: 2px 4px;
+    opacity: 70%;
+    width: max-content;
+    /* position */
+    position: absolute;
+    z-index: 1;
+    margin-left: 0.5em;
+    margin-bottom: 1em;
+    margin-top: -0.1em;
+}
+
+.tooltip-container:hover .tooltip-text {
+    visibility: visible;
+}
+
 /* --- Header breadcrumb --- */
 
 ul.breadcrumb {

--- a/magpie/ui/home/templates/restore_scroll.js
+++ b/magpie/ui/home/templates/restore_scroll.js
@@ -1,0 +1,11 @@
+document.addEventListener("DOMContentLoaded", function (event) {
+    let pos = sessionStorage.getItem('scroll-position');
+    if (pos) {
+        window.scrollTo(0, pos);
+        sessionStorage.removeItem('scroll-position');
+    }
+});
+
+window.addEventListener("beforeunload", function (e) {
+    sessionStorage.setItem('scroll-position', window.scrollY);
+});

--- a/magpie/ui/home/templates/template.mako
+++ b/magpie/ui/home/templates/template.mako
@@ -19,6 +19,9 @@
     <script type="text/javascript">
         <%include file="magpie.ui.management:templates/tree_scripts.js"/>
     </script>
+    <script type="text/javascript">
+        <%include file="magpie.ui.home:templates/restore_scroll.js"/>
+    </script>
     <!-- needs more work, some elements should be static such as resource-names -->
     <!--
     <script type="text/javascript">

--- a/magpie/ui/management/templates/add_service.mako
+++ b/magpie/ui/management/templates/add_service.mako
@@ -18,7 +18,7 @@
         document.getElementById("service_push_phoenix_section").hidden = !selectedPhoenixEnabled;
         document.getElementById("service_configurable_section").hidden = !selectedConfigEnabled;
     }
-    $( document ).ready(function() {
+    $(document).ready(function() {
         updateActiveServiceOptions();
     });
 </script>

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -246,9 +246,11 @@
 <%def name="render_item(key, value, level)">
     <div class="tree-item-value collapsible-tree-item">
         <span class="tree-item-label label label-info">${value["resource_type"]}</span>
-        <div class="tree-key">
-            ${value.get('resource_display_name', key)}
+        <div class="tree-key tooltip-container">
+            <span class="tooltip-value">${value.get('resource_display_name', key)}</span>
+            <span class="tooltip-text">Resource: ${value["id"]}</span>
         </div>
+
     </div>
     <div class="tree-item-buttons">
         <form id="resource_${value['id']}" action="${request.path}" method="post">

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -48,9 +48,9 @@
                 %for perm_name in permission_titles:
                     <div
                     %if inherit_groups_permissions:
-                        class="permission-title permission-title-effective"
+                        class="permission-cell permission-title permission-title-effective"
                     %else:
-                        class="permission-title"
+                        class="permission-cell permission-title"
                     %endif
                     >${perm_name}</div>
                 %endfor
@@ -98,7 +98,7 @@
 
 <!-- renders the permission selector for a single resource/permission combination -->
 <%def name="render_resource_permissions_entry(permission_name, resource_info)">
-    <div class="permission-entry">
+    <div class="permission-cell permission-entry">
         <label for="combobox_permission_resource_${resource_info['id']}">
         <select name="permission_resource_${resource_info['id']}"
                 id="combobox_permission_resource_${resource_info['id']}"

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -67,8 +67,9 @@
 <%def name="render_resource_permissions_item(key, value, level)">
     <div class="tree-item-value collapsible-tree-item">
         <span class="tree-item-label label label-info">${value["resource_type"]}</span>
-        <div class="tree-key">
-            ${value.get('resource_display_name', key)}
+        <div class="tree-key tooltip-container">
+            <span class="tooltip-value">${value.get('resource_display_name', key)}</span>
+            <span class="tooltip-text">Resource: ${value["id"]}</span>
         </div>
     </div>
     %for perm_name in permissions:
@@ -120,8 +121,10 @@
                 %endfor
             %endfor
         </select>
+
+        <!-- previous state of existing permissions to detect removal of permission vs already blank selectors -->
         %for perm_name in resource_info["permission_names"]:
-        <input type="hidden" name="resource_${resource_info['id']}" value="${perm_name}">
+            <input type="hidden" name="resource_${resource_info['id']}" value="${perm_name}">
         %endfor
         </label>
 


### PR DESCRIPTION
## Changes / Fixes

* Add auto-restore of previous scroll position in UI page following submitted form.
* Add UI tooltip `Resource` ID to elements rendered in the ``Service`` and ``Permission`` hierarchy trees
  (relates to #335).
* Fix UI alignment of permission titles with their corresponding permission selectors
  (relates to #498).