### PR TITLE
fix display of permission comboboxes with scrollable columns across lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,9 @@ Features / Changes
 * Add auto-restore of previous scroll position in UI page following submitted form.
 * Add UI tooltip `Resource` ID to elements rendered in the ``Service`` and ``Permission`` hierarchy trees
   (relates to `#335 <https://github.com/Ouranosinc/Magpie/issues/335>`_).
+* Add UI horizontal multi-scroll (all tree lines simultaneously) of ``Permission`` selectors when there are more that
+  can fit naturally within the tab view for a given ``Service`` type
+  (relates to `#498 <https://github.com/Ouranosinc/Magpie/issues/498>`_).
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ install-npm:    		## install npm package manager if it cannot be found
 		echo "Binary package manager npm not found. Attempting to install it."; \
 		apt-get install npm \
 	)
-	@[ `npm ls 2>/dev/null | grep stylelint-config-standard | wc -l` = 1 ] || ( \
+	@[ `npm ls -only dev -depth 0 2>/dev/null | grep -V "UNMET" | grep stylelint-config-standard | wc -l` = 1 ] || ( \
 		echo "Install required libraries for style checks." && \
 		npm install stylelint@13.13.1 stylelint-config-standard@22.0.0 --save-dev \
 	)

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -1022,7 +1022,7 @@ class ServiceGeoserverBase(ServiceOWS):
                     values.append(value)
             return values
         name = fully_qualified_name(self)
-        raise NotImplementedError(f"Missing or invalid requested 'resource_param' in service: {name}")
+        raise NotImplementedError("Missing or invalid requested 'resource_param' in service: {}".format(name))
 
     def resource_requested(self):
         # type: () -> MultiResourceRequested

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -965,6 +965,7 @@ div.tree-button {
     margin-left: 0.5em;  /* spacing with disallowed text to ensure one title doesn't end flush where the next begins */
     width: 10.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-left] */
 
+    /* position */
     display: inline-flex;
     flex-wrap: nowrap;
     flex-direction: row;
@@ -1021,6 +1022,7 @@ div.tree-button {
     padding: 2px 4px;
     opacity: 70%;
     width: max-content;
+
     /* position */
     position: absolute;
     z-index: 1;

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -901,6 +901,9 @@ table.simple-list input[type="submit"] {
     position: absolute;
 }
 
+.tree-key-value {
+}
+
 .tree-item {
     display: inline-block;
     vertical-align: middle;

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -780,8 +780,8 @@ table.simple-list input[type="submit"] {
 }
 
 .tree-header {
-    padding: 1em 0 0;
     font-weight: bold;
+    padding: 1em 0 2.5em;
 }
 
 .tree .collapsible {
@@ -865,8 +865,8 @@ table.simple-list input[type="submit"] {
 
 .tree-line-key-container {
     margin-left: 0;
-    margin-right: auto;
-    width: 20%;
+    margin-right: 20em;
+    /*width: 20%;*/
 }
 
 .tree-line-fill-container {
@@ -874,24 +874,51 @@ table.simple-list input[type="submit"] {
     margin-right: 0;
     width: 10%;*/
     width: max-content;
-    margin-right: 0;
-    margin-left: auto;
+    margin-right: auto;
+    margin-left: 0;
 }
 
 .tree-line-item-container {
     /*margin-left: auto;
     margin-right: 0;
     width: 75%;*/
-    margin-right: 0;
+    /*margin-right: 0;
     width: max-content;
     max-width: 70%;
-    overflow-x: auto;
+    /*overflow-x: auto;*/
+    /*
     white-space: nowrap;
     display: inline-block;
+    left: 40em;
+    position: absolute;
+    */
+
+    margin-right: 0;
+    width: max-content;
+    max-width: 65%;
+    /*overflow-x: hidden;*/
+    white-space: nowrap;
+    display: inline-block;
+    left: 40em;
+    position: absolute;
 }
 
 .tree-line-item-container-scrollable {
     /*width: 120%;*/
+    /*max-width: 80%;
+    overflow-x: auto;
+    position: relative;
+    display: flex;
+    justify-content: flex-start;*/
+    overflow-x: hidden;
+    position: relative;
+    max-width: 100%;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.tree-line-scroll-visible {
+    overflow-x: auto;
 }
 
 .tree-key {

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -866,50 +866,25 @@ table.simple-list input[type="submit"] {
 .tree-line-key-container {
     margin-left: 0;
     margin-right: 20em;
-    /*width: 20%;*/
 }
 
 .tree-line-fill-container {
-    /*margin-left: auto;
-    margin-right: 0;
-    width: 10%;*/
     width: max-content;
     margin-right: auto;
     margin-left: 0;
 }
 
 .tree-line-item-container {
-    /*margin-left: auto;
-    margin-right: 0;
-    width: 75%;*/
-    /*margin-right: 0;
-    width: max-content;
-    max-width: 70%;
-    /*overflow-x: auto;*/
-    /*
-    white-space: nowrap;
-    display: inline-block;
-    left: 40em;
-    position: absolute;
-    */
-
     margin-right: 0;
     width: max-content;
-    max-width: 65%;
-    /*overflow-x: hidden;*/
     white-space: nowrap;
     display: inline-block;
-    left: 40em;
     position: absolute;
+    max-width: 55%;
+    right: 6em;  /* page border + tab panel border */
 }
 
 .tree-line-item-container-scrollable {
-    /*width: 120%;*/
-    /*max-width: 80%;
-    overflow-x: auto;
-    position: relative;
-    display: flex;
-    justify-content: flex-start;*/
     overflow-x: hidden;
     position: relative;
     max-width: 100%;
@@ -922,17 +897,12 @@ table.simple-list input[type="submit"] {
 }
 
 .tree-key {
-    /* display: block;
-    float: left; */
     display: inline-block;
     position: absolute;
 }
 
 .tree-item {
-    /* display: block;
-    float: right; */
     display: inline-block;
-    width: 100%;
     vertical-align: middle;
 }
 

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -962,9 +962,8 @@ div.tree-button {
     /* ensure that sufficient space is provided to fit all possible permission-name side-by-side
        align with combobox and checkbox, must include both their respective width
     */
-    /*float: right;*/
     margin-left: 0.5em;  /* spacing with disallowed text to ensure one title doesn't end flush where the next begins */
-    width: 9.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-left] */
+    width: 10.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-left] */
 
     display: inline-flex;
     flex-wrap: nowrap;
@@ -997,6 +996,8 @@ div.tree-button {
     border-radius: 3px;
     border-width: 1px;
     border-style: solid;
+    width: 100%;    /* use as much space as available in 'permission-entry' excluding space for 'permission-checkbox' */
+    margin-right: 5em;  /* value must be "big enough" to push checkbox right as much as possible, but < cell width */
 }
 
 /* Hide arrow icon in IE browsers */

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -848,7 +848,10 @@ table.simple-list input[type="submit"] {
 }
 
 .tree-line {
-    display: block;
+    display: inline-flex;
+    width: 100%;
+    flex-wrap: nowrap;
+    justify-content: space-between;
 }
 
 .collapsible-tree-item {
@@ -858,6 +861,37 @@ table.simple-list input[type="submit"] {
     /* this ensures that element is on top to capture the click event to toggle collapsed/expanded
        must be applied in combination to 'position' attribute */
     z-index: 10;
+}
+
+.tree-line-key-container {
+    margin-left: 0;
+    margin-right: auto;
+    width: 20%;
+}
+
+.tree-line-fill-container {
+    /*margin-left: auto;
+    margin-right: 0;
+    width: 10%;*/
+    width: max-content;
+    margin-right: 0;
+    margin-left: auto;
+}
+
+.tree-line-item-container {
+    /*margin-left: auto;
+    margin-right: 0;
+    width: 75%;*/
+    margin-right: 0;
+    width: max-content;
+    max-width: 70%;
+    overflow-x: auto;
+    white-space: nowrap;
+    display: inline-block;
+}
+
+.tree-line-item-container-scrollable {
+    /*width: 120%;*/
 }
 
 .tree-key {
@@ -931,7 +965,7 @@ div.tree-button {
     /* ensure that sufficient space is provided to fit all possible permission-name side-by-side
        align with combobox and checkbox, must include both their respective width
     */
-    float: right;
+    /*float: right;*/
     margin-left: 0.5em;  /* spacing with disallowed text to ensure one title doesn't end flush where the next begins */
     width: 9.5em;   /* [width = <desired-width> + permission-entry.width + permission-checkbox.width - margin-left] */
 

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -247,7 +247,7 @@
     <div class="tree-item-value collapsible-tree-item">
         <span class="tree-item-label label label-info">${value["resource_type"]}</span>
         <div class="tree-key tooltip-container">
-            <span class="tooltip-value">${value.get('resource_display_name', key)}</span>
+            <span class="tooltip-value tree-key-value">${value.get('resource_display_name', key)}</span>
             <span class="tooltip-text">Resource: ${value["id"]}</span>
         </div>
 

--- a/magpie/ui/management/templates/tree_scripts.js
+++ b/magpie/ui/management/templates/tree_scripts.js
@@ -14,4 +14,11 @@ $(document).ready(function() {
 
     $(".collapsible-tree-item").on("click", toggle)
     $(".collapsible-marker").on("click", toggle)
-})
+});
+
+
+$(document).ready(function() {
+    /* Scrolls all permission selectors horizontally along with their corresponding titles */
+    let container = $(".tree-line-item-container");
+    container.scrollLeft($(this).scrollLeft());
+});

--- a/magpie/ui/management/templates/tree_scripts.js
+++ b/magpie/ui/management/templates/tree_scripts.js
@@ -17,8 +17,13 @@ $(document).ready(function() {
 });
 
 
+/*
+    https://stackoverflow.com/questions/22863324/scroll-multiple-div-at-the-same-time/22863448
+*/
 $(document).ready(function() {
     /* Scrolls all permission selectors horizontally along with their corresponding titles */
     let container = $(".tree-line-item-container");
-    container.scrollLeft($(this).scrollLeft());
+    container.scroll(function () {
+        container.scrollLeft($(this).scrollLeft());
+    });
 });

--- a/magpie/ui/management/templates/tree_scripts.js
+++ b/magpie/ui/management/templates/tree_scripts.js
@@ -22,7 +22,7 @@ $(document).ready(function() {
 */
 $(document).ready(function() {
     /* Scrolls all permission selectors horizontally along with their corresponding titles */
-    let container = $(".tree-line-item-container");
+    let container = $(".tree-line-item-container-scrollable");
     container.scroll(function () {
         container.scrollLeft($(this).scrollLeft());
     });

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -69,7 +69,7 @@
     <div class="tree-line-key-container tree-item-value collapsible-tree-item">
         <span class="tree-item-label label label-info">${value["resource_type"]}</span>
         <div class="tree-key tooltip-container">
-            <span class="tooltip-value">${value.get('resource_display_name', key)}</span>
+            <span class="tooltip-value tree-key-value">${value.get('resource_display_name', key)}</span>
             <span class="tooltip-text">Resource: ${value["id"]}</span>
         </div>
     </div>

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -14,9 +14,7 @@
         <li class="no-child" id="${tree[key]['id']}">
         %endif
             <div class="tree-line">
-                <div class="tree-item">
-                    ${item_renderer(key, tree[key], level)}
-                </div>
+                ${item_renderer(key, tree[key], level)}
             </div>
             <div class="clear underline"></div>
             %if tree[key]["children"]:
@@ -43,17 +41,20 @@
         </div>
 
         <div class="tree-header">
-            <div class="tree-key">Resources</div>
-            <div class="tree-item">
-                %for perm_name in permission_titles:
-                    <div
-                    %if inherit_groups_permissions:
-                        class="permission-cell permission-title permission-title-effective"
-                    %else:
-                        class="permission-cell permission-title"
-                    %endif
-                    >${perm_name}</div>
-                %endfor
+            <div class="tree-line-key-container tree-key">Resources</div>
+            <div class="tree-line-fill-container"><!-- --></div>
+            <div class="tree-line-item-container tree-item">
+                <div class="tree-line-item-container-scrollable">
+                    %for perm_name in permission_titles:
+                        <div
+                        %if inherit_groups_permissions:
+                            class="permission-cell permission-title permission-title-effective"
+                        %else:
+                            class="permission-cell permission-title"
+                        %endif
+                        >${perm_name}</div>
+                    %endfor
+                </div>
             </div>
         </div>
         <div class="tree">
@@ -65,34 +66,40 @@
 
 <!-- renders a single resource line in the tree with applicable permission selectors for it -->
 <%def name="render_resource_permissions_item(key, value, level)">
-    <div class="tree-item-value collapsible-tree-item">
+    <div class="tree-line-key-container tree-item-value collapsible-tree-item">
         <span class="tree-item-label label label-info">${value["resource_type"]}</span>
         <div class="tree-key tooltip-container">
             <span class="tooltip-value">${value.get('resource_display_name', key)}</span>
             <span class="tooltip-text">Resource: ${value["id"]}</span>
         </div>
     </div>
-    %for perm_name in permissions:
-        ${render_resource_permissions_entry(perm_name, value)}
-    %endfor
-    %if not value.get("matches_remote", True):
+    <div class="tree-line-fill-container">
+        %if not value.get("matches_remote", True):
+            <div class="tree-button">
+                <input type="submit" class="button-warning" value="Clean" name="clean_resource">
+            </div>
+            <p class="tree-item-message">
+                <img title="This resource is absent from the remote server." class="icon-warning"
+                     src="${request.static_url('magpie.ui.home:static/exclamation-triangle.png')}" alt="WARNING" />
+            </p>
+        %endif
         <div class="tree-button">
-            <input type="submit" class="button-warning" value="Clean" name="clean_resource">
+        %if level == 0:
+            <form id="resource_${value['id']}_${value.get('remote_id', '')}" action="${request.path}" method="post">
+                <input type="submit" class="tree-button goto-service theme" value="Edit Service" name="goto_service">
+                <input type="hidden" value="${value['id']}" name="resource_id">
+                <input type="hidden" value="${value.get('remote_id', '')}" name="remote_id">
+                <input type="hidden" value="${value.get('matches_remote', '')}" name="matches_remote">
+            </form>
+        %endif
         </div>
-        <p class="tree-item-message">
-            <img title="This resource is absent from the remote server." class="icon-warning"
-                 src="${request.static_url('magpie.ui.home:static/exclamation-triangle.png')}" alt="WARNING" />
-        </p>
-    %endif
-    <div class="tree-button">
-    %if level == 0:
-        <form id="resource_${value['id']}_${value.get('remote_id', '')}" action="${request.path}" method="post">
-            <input type="submit" class="tree-button goto-service theme" value="Edit Service" name="goto_service">
-            <input type="hidden" value="${value['id']}" name="resource_id">
-            <input type="hidden" value="${value.get('remote_id', '')}" name="remote_id">
-            <input type="hidden" value="${value.get('matches_remote', '')}" name="matches_remote">
-        </form>
-    %endif
+    </div>
+    <div class="tree-line-item-container">
+        <div class="tree-line-item-container-scrollable">
+            %for perm_name in permissions:
+                ${render_resource_permissions_entry(perm_name, value)}
+            %endfor
+        </div>
     </div>
 </%def>
 

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -44,7 +44,7 @@
             <div class="tree-line-key-container tree-key">Resources</div>
             <div class="tree-line-fill-container"><!-- --></div>
             <div class="tree-line-item-container tree-item">
-                <div class="tree-line-item-container-scrollable">
+                <div class="tree-line-item-container-scrollable tree-line-scroll-visible">
                     %for perm_name in permission_titles:
                         <div
                         %if inherit_groups_permissions:

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -530,9 +530,7 @@ class ManagementViews(AdminRequests, BaseViews):
         for svc in resp_available_svc_types:
             perm_names = {perm["name"] for perm in resp_available_svc_types[svc]["permissions"]}
             resources_permission_names.update(perm_names)
-        # NOTE:
-        #  inverse sort so that displayed permissions are sorted, since added from right to left in tree view
-        resources_permission_names = sorted(resources_permission_names, reverse=True)
+        resources_permission_names = sorted(resources_permission_names)
 
         resources = OrderedDict()
         for service in sorted(services):


### PR DESCRIPTION
When permissions cannot fit in view, an horizontal scrollbar appears under the permission titles. 
Scrolling it moves all the selector boxes across all lines in the tree view accordingly.



## Changes

* Add UI horizontal multi-scroll (all tree lines simultaneously) of ``Permission`` selectors when there are more that
  can fit naturally within the tab view for a given ``Service`` type  (relates to #498).
* Widen permission "columns" for more permission titles to fit.
  The permission titles can still auto-scroll as well in cases were the permission name is just unreasonably long.
  The chosen dimension is the best trade-off of showing as must titles completely vs making the boxes too wide, needing extra scrolling to display all of them.

## Fixes

* minor fixes related to linting

## Results Preview

### When there are too many permissions to display at once

![image](https://user-images.githubusercontent.com/19194484/152027463-ee82a638-f975-4a25-b56f-05698a2a0f4a.png)

### When space is sufficient

![image](https://user-images.githubusercontent.com/19194484/152027496-0d98b8ab-f67b-44dc-a511-3975f0101ecb.png)

![image](https://user-images.githubusercontent.com/19194484/152027506-0fd06877-3668-472b-9a68-009060163efc.png)

