### PR TITLE
forbid anonymous user res/svc perm create/edit/update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Features / Changes
   be converted automatically to the corresponding ``MAGPIE_ANONYMOUS_GROUP`` with database migration at application
   startup. If a conflict occurs, the existing ``Permission`` for ``MAGPIE_ANONYMOUS_GROUP`` will be prioritized and
   the one for ``MAGPIE_ANONYMOUS_USER`` will be dropped.
+* Ignore any explicit entry in ``permissions.cfg`` (or any of its variants) that attempts to create or delete
+  any ``Permission`` for ``MAGPIE_ANONYMOUS_USER``.
 * Update UI to better represent disallowed operations for ``MAGPIE_ANONYMOUS_USER``.
 
 Bug Fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,14 +15,19 @@ Features / Changes
   supports it, for the ``MAGPIE_ANONYMOUS_USER``, for a ``Service`` registered at startup from a definition retrieved
   from ``providers.cfg`` configuration file. Platforms that desire to maintain a similar auto-creation of the public
   ``Permission`` should consider instead defining an entry in ``permissions.cfg`` for the targeted ``Service``.
+* Forbid the creation, edition or deletion of any ``Permission`` onto a ``Service`` or ``Resource`` associated
+  to ``MAGPIE_ANONYMOUS_USER``. Any such erroneous ``Permission`` that could already existing in the database will
+  be converted automatically to the corresponding ``MAGPIE_ANONYMOUS_GROUP`` with database migration at application
+  startup. If a conflict occurs, the existing ``Permission`` for ``MAGPIE_ANONYMOUS_GROUP`` will be prioritized and
+  the one for ``MAGPIE_ANONYMOUS_USER`` will be dropped.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * When the option is provided to auto-create ``GetCapabilities`` on a ``Service`` that supports it, the ``Permission``
   is now applied onto ``MAGPIE_ANONYMOUS_GROUP`` instead of ``MAGPIE_ANONYMOUS_USER``, as it was originally intended
-  and documented in function parameters. User ``MAGPIE_ANONYMOUS_USER`` is not accessible from the API, which caused
-  the auto-creation of allowed ``GetCapabilities`` to be impossible to remove. Given ``User``-level permission has
-  an higher priority in resolution order than ``Group``-level, it was also impossible to revert it with ``deny``.
+  and documented in function parameters. User ``MAGPIE_ANONYMOUS_USER`` will not be accessible from the API, which
+  would cause auto-creation of allowed ``GetCapabilities`` to be impossible to remove. Given ``User``-level permission
+  has an higher priority in resolution order than ``Group``-level, it was also impossible to revert it with ``deny``.
 * Fix missing link to *OpenAPI Specification* in generated `ReadTheDocs` TOC.
 
 .. _changes_3.21.0:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Features / Changes
   be converted automatically to the corresponding ``MAGPIE_ANONYMOUS_GROUP`` with database migration at application
   startup. If a conflict occurs, the existing ``Permission`` for ``MAGPIE_ANONYMOUS_GROUP`` will be prioritized and
   the one for ``MAGPIE_ANONYMOUS_USER`` will be dropped.
+* Update UI to better represent disallowed operations for ``MAGPIE_ANONYMOUS_USER``.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -279,6 +279,11 @@ but the same person wouldn't retain access to the same resources anymore as soon
 (login). That :term:`User` would have the impression that its access rights are lowered although they should
 naturally expect increased privileges after authenticating itself.
 
+.. versionchanged:: 3.22
+    Starting with this version, modifications to :py:data:`magpie.constants.MAGPIE_ANONYMOUS_USER` itself, or any
+    :term:`Service`, :term:`Resource` or :term:`Permission` with references to that *special* :term:`User` will be
+    explicitly forbidden by the :term:`API` to avoid above mentioned ambiguities.
+
 Special :term:`User` :py:data:`magpie.constants.MAGPIE_ANONYMOUS_USER` is available only for evaluation purpose of
 :term:`Public`-only :term:`Permission` applied to :term:`Service` and :term:`Resource`, but is technically not required
 to execute `Magpie` application. Effectively, when the active session corresponds to unauthenticated

--- a/magpie/alembic/versions/2022-03-04_0c6269f410cd_move_anonymous_user_to_group_perms_.py
+++ b/magpie/alembic/versions/2022-03-04_0c6269f410cd_move_anonymous_user_to_group_perms_.py
@@ -1,0 +1,62 @@
+"""
+Move anonymous user to anonymous group permissions.
+
+Revision ID: 0c6269f410cd
+Revises: cb92ff1f81bb
+Create Date: 2022-03-04 23:13:39.987696
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from alembic.context import get_context  # noqa: F401
+from sqlalchemy.orm.session import sessionmaker
+
+from magpie.constants import get_constant  # isort:skip # noqa: E402
+
+# revision identifiers, used by Alembic.
+revision = "0c6269f410cd"
+down_revision = "cb92ff1f81bb"
+branch_labels = None
+depends_on = None
+
+Session = sessionmaker()
+groups = sa.table(
+    "groups",
+    sa.column("id", sa.Integer),
+    sa.column("group_name", sa.String),
+)
+users = sa.table(
+    "users",
+    sa.column("id", sa.Integer),
+    sa.column("user_name", sa.String),
+)
+grp_res_perms = sa.table(
+    "groups_resources_permissions",
+    sa.column("group_id", sa.Integer),
+    sa.column("resource_id", sa.String),
+    sa.column("perm_name", sa.Integer)
+)
+usr_res_perms = sa.table(
+    "users_resources_permissions",
+    sa.column("user_id", sa.Integer),
+    sa.column("resource_id", sa.String),
+    sa.column("perm_name", sa.Integer)
+)
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    anon_usr = session.execute(sa.select([users]).where(users.c.user_name == get_constant("MAGPIE_ANONYMOUS_USER")))
+    anon_grp = session.execute(sa.select([groups]).where(groups.c.group_name == get_constant("MAGPIE_ANONYMOUS_GROUP")))
+    anon_usr_res_perms = session.execute(sa.select([usr_res_perms]).where(usr_res_perms.user_id == anon_usr.id))
+    anon_grp_res_perms = session.execute(sa.select([grp_res_perms]).where(grp_res_perms.group_id == anon_grp.id))
+    for urp in anon_usr_res_perms:
+        # prioritize existing permission on group over user, regardless of permission name
+        if not any(grp.resource_id == urp.resource_id for grp in anon_grp_res_perms):
+            sa.insert(grp_res_perms, (anon_grp.id, urp.resource_id, urp.perm_name))
+        session.delete(urp)
+    session.commit()
+
+
+def downgrade():
+    pass  # nothing to do, having anonymous group permissions is still valid

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -72,6 +72,7 @@ def update_user_view(request):
     Update user information by user name.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     new_user_name = ar.get_multiformat_body(request, "user_name", default=user.user_name)
     new_email = ar.get_multiformat_body(request, "email", default=user.email)
     new_password = ar.get_multiformat_body(request, "password", default=user.user_password)
@@ -103,10 +104,7 @@ def delete_user_view(request):
     Delete a user by name.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
-    ax.verify_param(user.user_name, not_in=True, with_param=False,  # avoid leaking username details
-                    param_compare=[get_constant("MAGPIE_ADMIN_USER", request),
-                                   get_constant("MAGPIE_ANONYMOUS_USER", request)],
-                    http_error=HTTPForbidden, msg_on_fail=s.User_DELETE_ForbiddenResponseSchema.description)
+    uu.check_user_editable(user, request)
     ax.evaluate_call(lambda: request.db.delete(user), fallback=lambda: request.db.rollback(),
                      http_error=HTTPForbidden, msg_on_fail=s.User_DELETE_ForbiddenResponseSchema.description)
 
@@ -149,7 +147,7 @@ def assign_user_group_view(request):
     Assign a user to a group.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
-
+    uu.check_user_editable(user, request)
     group_name = ar.get_value_multiformat_body_checked(request, "group_name")
     group = ax.evaluate_call(lambda: GroupService.by_group_name(group_name, db_session=request.db),
                              fallback=lambda: request.db.rollback(), http_error=HTTPForbidden,
@@ -169,6 +167,7 @@ def delete_user_group_view(request):
     Removes a user from a group.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     group = ar.get_group_matchdict_checked(request)
     uu.delete_user_group(user, group, request.db)
     return ax.valid_http(http_success=HTTPOk, detail=s.UserGroup_DELETE_OkResponseSchema.description)
@@ -272,6 +271,7 @@ def create_user_resource_permissions_view(request):
     Create a permission on specific resource for a user.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     resource = ar.get_resource_matchdict_checked(request)
     permission = ar.get_permission_multiformat_body_checked(request, resource)
     return uu.create_user_resource_permission_response(user, resource, permission, request.db, overwrite=False)
@@ -291,6 +291,7 @@ def replace_user_resource_permissions_view(request):
     Can be used to adjust permission modifiers.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     resource = ar.get_resource_matchdict_checked(request)
     permission = ar.get_permission_multiformat_body_checked(request, resource)
     return uu.create_user_resource_permission_response(user, resource, permission, request.db, overwrite=True)
@@ -308,6 +309,7 @@ def delete_user_resource_permissions_view(request):
     Delete a permission from a specific resource for a user (not including his groups permissions).
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     resource = ar.get_resource_matchdict_checked(request)
     permission = ar.get_permission_multiformat_body_checked(request, resource)
     return uu.delete_user_resource_permission_response(user, resource, permission, request.db)
@@ -325,6 +327,7 @@ def delete_user_resource_permission_name_view(request):
     Delete a permission by name from a resource for a user (not including his groups permissions).
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     resource = ar.get_resource_matchdict_checked(request)
     permission = ar.get_permission_matchdict_checked(request, resource)
     return uu.delete_user_resource_permission_response(user, resource, permission, request.db)
@@ -397,6 +400,7 @@ def create_user_service_permissions_view(request):
     Create a permission on a service for a user.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     service = ar.get_service_matchdict_checked(request)
     permission = ar.get_permission_multiformat_body_checked(request, service)
     return uu.create_user_resource_permission_response(user, service, permission, request.db, overwrite=False)
@@ -416,6 +420,7 @@ def replace_user_service_permissions_view(request):
     Can be used to adjust permission modifiers.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     service = ar.get_service_matchdict_checked(request)
     permission = ar.get_permission_multiformat_body_checked(request, service)
     return uu.create_user_resource_permission_response(user, service, permission, request.db, overwrite=True)
@@ -433,6 +438,7 @@ def delete_user_service_permissions_view(request):
     Delete a permission from a service for a user (not including his groups permissions).
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     service = ar.get_service_matchdict_checked(request)
     permission = ar.get_permission_multiformat_body_checked(request, service)
     return uu.delete_user_resource_permission_response(user, service, permission, request.db)
@@ -450,6 +456,7 @@ def delete_user_service_permission_name_view(request):
     Delete a permission by name from a service for a user (not including his groups permissions).
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
+    uu.check_user_editable(user, request)
     service = ar.get_service_matchdict_checked(request)
     permission = ar.get_permission_matchdict_checked(request, service)
     return uu.delete_user_resource_permission_response(user, service, permission, request.db)

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -105,6 +105,10 @@ def delete_user_view(request):
     """
     user = ar.get_user_matchdict_checked_or_logged(request)
     uu.check_user_editable(user, request)
+    ax.verify_param(user.user_name, not_equal=True, with_param=False,  # avoid leaking username details
+                    param_compare=get_constant("MAGPIE_ADMIN_USER", request),
+                    http_error=HTTPForbidden, msg_on_fail=s.User_DELETE_ForbiddenResponseSchema.description)
+
     ax.evaluate_call(lambda: request.db.delete(user), fallback=lambda: request.db.rollback(),
                      http_error=HTTPForbidden, msg_on_fail=s.User_DELETE_ForbiddenResponseSchema.description)
 

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1969,7 +1969,7 @@ class User_GET_OkResponseSchema(BaseResponseSchemaAPI):
 
 
 class User_CheckAnonymous_ForbiddenResponseSchema(BaseResponseSchemaAPI):
-    description = "Anonymous user query refused by db."
+    description = "Anonymous user refused for this operation."
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -1023,6 +1023,7 @@ def _process_permissions(permissions, magpie_url, cookies_or_session, users=None
         LOGGER.warning("Permissions configuration are empty.")
         return
 
+    anon_user = get_constant("MAGPIE_ANONYMOUS_USER")
     perm_count = len(permissions)
     LOGGER.log(logging.INFO if perm_count else logging.WARNING,
                "Found %s permissions to evaluate from configuration.", perm_count)
@@ -1042,6 +1043,9 @@ def _process_permissions(permissions, magpie_url, cookies_or_session, users=None
         grp_name = perm_cfg.get("group")
         if not any([usr_name, grp_name]):
             _log_permission("Missing required user and/or group field.", i)
+            continue
+        if usr_name == anon_user:
+            _log_permission("Skipping forbidden user permission (reserved special user: {}).".format(anon_user), i)
             continue
         if "action" not in perm_cfg:
             _log_permission("Unspecified action", i, trail="using default (create)...")

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -247,7 +247,7 @@ ${membership_alerts.edit_membership_alerts()}
                 %if group in own_groups:
                    checked
                 %endif
-                %if group in MAGPIE_FIXED_GROUP_MEMBERSHIPS:
+                %if group in MAGPIE_FIXED_GROUP_MEMBERSHIPS or user_name in MAGPIE_FIXED_USERS_REFS:
                    disabled
                 %else:
                    onchange="document.getElementById('edit_membership').submit()"

--- a/magpie/ui/management/templates/tree_scripts.mako
+++ b/magpie/ui/management/templates/tree_scripts.mako
@@ -31,7 +31,7 @@
     <form id="resources_permissions" action="${request.path}" method="post">
         <div class="permission-apply-container">
             <input type="submit" name="edit_permissions" value="Apply Permissions" title="Apply the permission changes"
-                %if inherit_groups_permissions:
+                %if inherit_groups_permissions or user_name in MAGPIE_FIXED_USERS_REFS:
                     disabled
                     class="button theme disabled"
                 %else:
@@ -110,7 +110,7 @@
         <label for="combobox_permission_resource_${resource_info['id']}">
         <select name="permission_resource_${resource_info['id']}"
                 id="combobox_permission_resource_${resource_info['id']}"
-            %if inherit_groups_permissions:
+            %if inherit_groups_permissions or user_name in MAGPIE_FIXED_USERS_REFS:
                 disabled
                 class="permission-combobox disabled"
             %else:

--- a/magpie/ui/management/templates/view_users.mako
+++ b/magpie/ui/management/templates/view_users.mako
@@ -50,7 +50,13 @@
                 %if user_name in users_pending:
                     <input type="submit" value="View" name="view-pending" class="list-button button theme">
                 %else:
-                    <input type="submit" value="Edit" name="edit" class="list-button button theme">
+                    <input type="submit" name="edit" class="list-button button theme"
+                    %if user_name in MAGPIE_FIXED_USERS and user_name in MAGPIE_FIXED_USERS_REFS:
+                        value="View"
+                    %else:
+                        value="Edit"
+                    %endif
+                    >
                 %endif
                 <input value="Delete"
                     %if user_name in MAGPIE_FIXED_USERS:

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -563,7 +563,14 @@ class ManagementViews(AdminRequests, BaseViews):
     def edit_group(self):
         group_name = self.request.matchdict["group_name"]
         cur_svc_type = self.request.matchdict["cur_svc_type"]
-        group_info = {"edit_mode": "no_edit", "group_name": group_name, "cur_svc_type": cur_svc_type}
+        group_info = {
+            "edit_mode": "no_edit",
+            "group_name": group_name,
+            "cur_svc_type": cur_svc_type,
+            # user not used, but avoid error when checking against
+            # MAGPIE_FIXED_USERS_REFS since using same tree-view script
+            "user_name": None,
+        }
         error_message = ""
         edit_grp_users_info = {}
 

--- a/magpie/ui/utils.py
+++ b/magpie/ui/utils.py
@@ -178,11 +178,41 @@ class BaseViews(object):
     Base methods for Magpie UI pages.
     """
     MAGPIE_FIXED_GROUP_MEMBERSHIPS = []
+    """
+    Special :term:`Group` memberships that cannot be edited.
+    """
+
     MAGPIE_FIXED_GROUP_EDITS = []
+    """
+    Special :term:`Group` details that cannot be edited.
+    """
+
     MAGPIE_FIXED_USERS = []
-    MAGPIE_USER_PWD_LOCKED = []  # used when user self-edit itself but is not supported since disabled
+    """
+    Special :term:`User` details that cannot be edited.
+    """
+
+    MAGPIE_FIXED_USERS_REFS = []
+    """
+    Special :term:`User` that cannot have any relationship edited.
+     
+    This includes both :term:`Group` memberships and :term:`Permission` references.
+    """
+
+    MAGPIE_USER_PWD_LOCKED = []
+    """
+    Special :term:`User` that *could* self-edit themselves, but is disabled since conflicting with other policies.
+    """
+
     MAGPIE_USER_PWD_DISABLED = []
+    """
+    Special :term:`User` where password cannot be edited (managed by `Magpie` configuration settings).
+    """
+
     MAGPIE_ANONYMOUS_GROUP = None
+    """
+    Reference to :py:data:`magpie.constants.MAGPIE_ANONYMOUS_GROUP` for convenience in UI pages.
+    """
 
     def __init__(self, request):
         self.request = request
@@ -192,11 +222,12 @@ class BaseViews(object):
 
         anonym_grp = get_constant("MAGPIE_ANONYMOUS_GROUP", settings_container=self.request)
         admin_grp = get_constant("MAGPIE_ADMIN_GROUP", settings_container=self.request)
-        self.__class__.MAGPIE_FIXED_GROUP_MEMBERSHIPS = [anonym_grp]  # special groups membership that cannot be edited
-        self.__class__.MAGPIE_FIXED_GROUP_EDITS = [anonym_grp, admin_grp]  # special groups that cannot be edited
+        self.__class__.MAGPIE_FIXED_GROUP_MEMBERSHIPS = [anonym_grp]
+        self.__class__.MAGPIE_FIXED_GROUP_EDITS = [anonym_grp, admin_grp]
         # special users that cannot be deleted
         anonym_usr = get_constant("MAGPIE_ANONYMOUS_USER", self.request)
         admin_usr = get_constant("MAGPIE_ADMIN_USER", self.request)
+        self.__class__.MAGPIE_FIXED_USERS_REFS = [anonym_usr]
         self.__class__.MAGPIE_FIXED_USERS = [admin_usr, anonym_usr]
         self.__class__.MAGPIE_USER_PWD_LOCKED = [admin_usr]
         self.__class__.MAGPIE_USER_PWD_DISABLED = [anonym_usr, admin_usr]
@@ -225,6 +256,7 @@ class BaseViews(object):
         all_data.setdefault("MAGPIE_FIXED_GROUP_MEMBERSHIPS", self.MAGPIE_FIXED_GROUP_MEMBERSHIPS)
         all_data.setdefault("MAGPIE_FIXED_GROUP_EDITS", self.MAGPIE_FIXED_GROUP_EDITS)
         all_data.setdefault("MAGPIE_FIXED_USERS", self.MAGPIE_FIXED_USERS)
+        all_data.setdefault("MAGPIE_FIXED_USERS_REFS", self.MAGPIE_FIXED_USERS_REFS)
         all_data.setdefault("MAGPIE_USER_PWD_LOCKED", self.MAGPIE_USER_PWD_LOCKED)
         all_data.setdefault("MAGPIE_USER_PWD_DISABLED", self.MAGPIE_USER_PWD_DISABLED)
         all_data.setdefault("MAGPIE_USER_REGISTRATION_ENABLED", self.MAGPIE_USER_REGISTRATION_ENABLED)


### PR DESCRIPTION
## Context

Follow up PR from #507 
Make sure `MAGPIE_ANONYMOUS_USER` is not editable in any way.

## Changes

* Forbid the creation, edition or deletion of any ``Permission`` onto a ``Service`` or ``Resource`` associated
  to ``MAGPIE_ANONYMOUS_USER``. Any such erroneous ``Permission`` that could already existing in the database will
  be converted automatically to the corresponding ``MAGPIE_ANONYMOUS_GROUP`` with database migration at application
  startup. If a conflict occurs, the existing ``Permission`` for ``MAGPIE_ANONYMOUS_GROUP`` will be prioritized and
  the one for ``MAGPIE_ANONYMOUS_USER`` will be dropped.
* Ignore any explicit entry in ``permissions.cfg`` (or any of its variants) that attempts to create or delete
  any ``Permission`` for ``MAGPIE_ANONYMOUS_USER``.
* Update UI to better represent disallowed operations for ``MAGPIE_ANONYMOUS_USER``.
