### PR TITLE
add linting rules to consider alembic migration scripts

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -55,12 +55,13 @@ confidence=
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=C0111,missing-docstring,
+        C0122,misplaced-comparison-constant,
         C0302,too-many-lines,
         C0330,bad-continuation,
         C0411,wrong-import-order,
@@ -118,7 +119,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 #msg-template=
 
 # Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio). You can also give a reporter class, e.g.
+# and MSVC (visual studio). You can also give a reporter class, e.g.
 # mypackage.mymodule.MyReporterClass.
 output-format=colorized
 
@@ -163,7 +164,10 @@ generated-members=Interface_MagpieAPI_AdminAuth.*,
                   str.value,
                   int.value,
                   UserStatuses.*.value,
-                  magpie.permissions.Permission
+                  magpie.permissions.Permission,
+                  alembic.op,
+                  alembic.op.*,
+                  alembic.context
 # note: 'str.value' is flagged by Enum members defined with strings
 
 # Tells whether missing members accessed in mixin class should be ignored. A
@@ -199,7 +203,9 @@ ignored-classes=optparse.Values,
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=magpie.definitions.*_definitions
+ignored-modules=magpie.definitions.*_definitions,
+                alembic.op,
+                alembic.context
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.
@@ -408,9 +414,12 @@ method-naming-style=snake_case
 # Naming style matching correct module names.
 module-naming-style=snake_case
 
-# Regular expression matching correct module names. Overrides module-naming-
-# style.
-#module-rgx=
+# Regular expression matching correct module names. Overrides module-naming-style.
+# Allow module prefixed by "YYYY-MM-DD_<hash>_" for alembic migration revisions.
+# Otherwise, normal snake-case naming is expected, considering dunder modules (__init__, __meta__).
+# Portion of snake-case must be at least 2 characters, starting and finishing with a lowercase letter,
+# allowing numbers and underscores in between. Number is allowed at the end as well.
+module-rgx=(?:(?P<revision>([0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9-a-f]{11,12}_)?(?P<snake>(?=[a-z])[a-z0-9_]+[a-z0-9])|(?P<dunder>__(?=[a-z])[a-z0-9_]+[a-z]__)))$
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Update linting configuration rules to validate all migration scripts employed by ``alembic``.
+* Apply applicable linting fixes over ``alembic`` migration scripts.
 
 .. _changes_3.22.0:
 

--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ check-lint-only: mkdir-reports		## run linting code style checks
 			--load-plugins pylint_quotes \
 			--rcfile="$(APP_ROOT)/.pylintrc" \
 			--reports y \
-			"$(APP_ROOT)/$(APP_NAME)" "$(APP_ROOT)/docs" "$(APP_ROOT)/tests" \
+			"$(APP_ROOT)/$(APP_NAME)" "$(APP_ROOT)/$(APP_NAME)/alembic" "$(APP_ROOT)/docs" "$(APP_ROOT)/tests" \
 		1> >(tee "$(REPORTS_DIR)/check-lint.txt")'
 
 .PHONY: check-security-only

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -160,7 +160,10 @@ qualname = magpie
 formatter = generic
 
 [logger_sqlalchemy]
-level = INFO
+# "level = DEBUG"   logs SQL queries, transactions and results
+# "level = INFO"    logs SQL queries (data can be identified from query field values)
+# "level = WARN"    logs neither (recommended for production systems, avoid anything below unless for dev/debug system)
+level = WARN
 handlers =
 qualname = sqlalchemy.engine
 formatter = generic

--- a/magpie/alembic/script.py.mako
+++ b/magpie/alembic/script.py.mako
@@ -1,5 +1,5 @@
 """
-${message}
+${message.title()}
 
 Revision ID: ${up_revision}
 Revises: ${down_revision | comma,n}
@@ -9,11 +9,28 @@ Create Date: ${create_date}
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = ${repr(up_revision)}
-down_revision = ${repr(down_revision)}
-branch_labels = ${repr(branch_labels)}
-depends_on = ${repr(depends_on)}
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+%if revision:
+revision = "${revision}"
+%else:
+revision = None
+%endif
+%if down_revision:
+down_revision = "${down_revision}"
+%else:
+down_revision = None
+%endif
+%if branch_labels:
+branch_labels = "${branch_labels}"
+%else:
+branch_labels = None
+%endif
+%if depends_one:
+depends_on = "${depends_on}"
+%else:
+depends_on = None
+%endif
 
 
 def upgrade():

--- a/magpie/alembic/versions/2011-11-10_24ab8d11f014_external_identities.py
+++ b/magpie/alembic/versions/2011-11-10_24ab8d11f014_external_identities.py
@@ -1,5 +1,5 @@
 """
-add external identity tables.
+Add external identity tables.
 
 Revision ID: 24ab8d11f014
 Revises: 2bb1ba973f0b
@@ -10,27 +10,28 @@ from __future__ import unicode_literals
 import sqlalchemy as sa  # noqa: F401
 from alembic import op  # noqa: F401
 
-# downgrade revision identifier, used by Alembic.
-revision = '24ab8d11f014'
-down_revision = '2bb1ba973f0b'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "24ab8d11f014"
+down_revision = "2bb1ba973f0b"
 
 
 def upgrade():
-    op.create_table('external_identities',
-                    sa.Column('external_id', sa.Unicode(255), primary_key=True),
-                    sa.Column('external_user_name', sa.Unicode(50), default=''),
-                    sa.Column('local_user_name', sa.Unicode(50),
-                              sa.ForeignKey('users.user_name',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+    op.create_table("external_identities",
+                    sa.Column("external_id", sa.Unicode(255), primary_key=True),
+                    sa.Column("external_user_name", sa.Unicode(50), default=""),
+                    sa.Column("local_user_name", sa.Unicode(50),
+                              sa.ForeignKey("users.user_name",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True),
-                    sa.Column('provider_name', sa.Unicode(50), default='',
+                    sa.Column("provider_name", sa.Unicode(50), default="",
                               primary_key=True),
-                    sa.Column('access_token', sa.Unicode(255), default=''),
-                    sa.Column('alt_token', sa.Unicode(255), default=''),
-                    sa.Column('token_secret', sa.Unicode(255), default='')
+                    sa.Column("access_token", sa.Unicode(255), default=""),
+                    sa.Column("alt_token", sa.Unicode(255), default=""),
+                    sa.Column("token_secret", sa.Unicode(255), default="")
                     )
 
 
 def downgrade():
-    op.drop_table('external_identities')
+    op.drop_table("external_identities")

--- a/magpie/alembic/versions/2011-11-10_24da162a54f1_ensure_service_root_is_none.py
+++ b/magpie/alembic/versions/2011-11-10_24da162a54f1_ensure_service_root_is_none.py
@@ -1,5 +1,5 @@
 """
-ensure_service_root_is_none.
+Ensure_service_root_is_none.
 
 Revision ID: 24da162a54f1
 Revises: 03b54feffe45
@@ -8,22 +8,22 @@ Create Date: 2019-11-06 16:26:56.898075
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = '24da162a54f1'
-down_revision = '03b54feffe45'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "24da162a54f1"
+down_revision = "03b54feffe45"
 branch_labels = None
 depends_on = None
 
 resources = sa.table(
-    "resources", 
-    sa.column("root_service_id", sa.Integer), 
-    sa.column("resource_id", sa.Integer), 
+    "resources",
+    sa.column("root_service_id", sa.Integer),
+    sa.column("resource_id", sa.Integer),
     sa.column("parent_id", sa.Integer)
 )
 
 
 def upgrade():
-    # pylint: disable=no-member
     op.execute(resources.
                update().
                where(resources.c.resource_id == resources.c.root_service_id).
@@ -32,7 +32,6 @@ def upgrade():
 
 
 def downgrade():
-    # pylint: disable=no-member
     op.execute(resources.
                update().
                where(resources.c.root_service_id.is_(None)).

--- a/magpie/alembic/versions/2011-11-10_2bb1ba973f0b_initial_structure.py
+++ b/magpie/alembic/versions/2011-11-10_2bb1ba973f0b_initial_structure.py
@@ -1,5 +1,5 @@
 """
-initial table layout.
+Initial table layout.
 
 Revision ID: 2bb1ba973f0b
 Revises: None
@@ -10,110 +10,111 @@ from __future__ import unicode_literals
 import sqlalchemy as sa
 from alembic import op
 
-# downgrade revision identifier, used by Alembic.
-revision = '2bb1ba973f0b'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "2bb1ba973f0b"
 down_revision = None
 
 
 def upgrade():
-    op.create_table('groups',
-                    sa.Column('id', sa.Integer, primary_key=True,
+    op.create_table("groups",
+                    sa.Column("id", sa.Integer, primary_key=True,
                               autoincrement=True),
-                    sa.Column('group_name', sa.Unicode(50), unique=True),
-                    sa.Column('description', sa.Text()),
-                    sa.Column('member_count', sa.Integer, nullable=False,
+                    sa.Column("group_name", sa.Unicode(50), unique=True),
+                    sa.Column("description", sa.Text()),
+                    sa.Column("member_count", sa.Integer, nullable=False,
                               default=0)
                     )
-    op.create_table('groups_permissions',
-                    sa.Column('group_name', sa.Unicode(50),
-                              sa.ForeignKey('groups.group_name',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+    op.create_table("groups_permissions",
+                    sa.Column("group_name", sa.Unicode(50),
+                              sa.ForeignKey("groups.group_name",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True),
-                    sa.Column('perm_name', sa.Unicode(30), primary_key=True)
+                    sa.Column("perm_name", sa.Unicode(30), primary_key=True)
                     )
 
-    op.create_table('users',
-                    sa.Column('id', sa.Integer, primary_key=True,
+    op.create_table("users",
+                    sa.Column("id", sa.Integer, primary_key=True,
                               autoincrement=True),
-                    sa.Column('user_name', sa.Unicode(30), unique=True),
-                    sa.Column('user_password', sa.Unicode(40)),
-                    sa.Column('email', sa.Unicode(100), nullable=False,
+                    sa.Column("user_name", sa.Unicode(30), unique=True),
+                    sa.Column("user_password", sa.Unicode(40)),
+                    sa.Column("email", sa.Unicode(100), nullable=False,
                               unique=False),
-                    sa.Column('status', sa.SmallInteger(), nullable=False),
-                    sa.Column('security_code', sa.Unicode(40),
-                              default='default'),
-                    sa.Column('last_login_date', sa.TIMESTAMP(timezone=False),
+                    sa.Column("status", sa.SmallInteger(), nullable=False),
+                    sa.Column("security_code", sa.Unicode(40),
+                              default="default"),
+                    sa.Column("last_login_date", sa.TIMESTAMP(timezone=False),
                               default=sa.sql.func.now(),
                               server_default=sa.func.now()
                               )
                     )
 
-    op.create_table('users_permissions',
-                    sa.Column('user_name', sa.Unicode(50),
-                              sa.ForeignKey('users.user_name',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+    op.create_table("users_permissions",
+                    sa.Column("user_name", sa.Unicode(50),
+                              sa.ForeignKey("users.user_name",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True),
-                    sa.Column('perm_name', sa.Unicode(30), primary_key=True)
+                    sa.Column("perm_name", sa.Unicode(30), primary_key=True)
                     )
 
-    op.create_table('users_groups',
-                    sa.Column('group_name', sa.Unicode(50),
-                              sa.ForeignKey('groups.group_name',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+    op.create_table("users_groups",
+                    sa.Column("group_name", sa.Unicode(50),
+                              sa.ForeignKey("groups.group_name",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True),
-                    sa.Column('user_name', sa.Unicode(30),
-                              sa.ForeignKey('users.user_name',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+                    sa.Column("user_name", sa.Unicode(30),
+                              sa.ForeignKey("users.user_name",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True)
                     )
 
-    op.create_table('resources',
-                    sa.Column('resource_id', sa.BigInteger(), primary_key=True,
+    op.create_table("resources",
+                    sa.Column("resource_id", sa.BigInteger(), primary_key=True,
                               nullable=False, autoincrement=True),
-                    sa.Column('resource_name', sa.Unicode(100), nullable=False),
-                    sa.Column('resource_type', sa.Unicode(30), nullable=False),
-                    sa.Column('owner_group_name', sa.Unicode(50),
-                              sa.ForeignKey('groups.group_name',
-                                            onupdate='CASCADE',
-                                            ondelete='SET NULL')),
-                    sa.Column('owner_user_name', sa.Unicode(30),
-                              sa.ForeignKey('users.user_name',
-                                            onupdate='CASCADE',
-                                            ondelete='SET NULL'))
+                    sa.Column("resource_name", sa.Unicode(100), nullable=False),
+                    sa.Column("resource_type", sa.Unicode(30), nullable=False),
+                    sa.Column("owner_group_name", sa.Unicode(50),
+                              sa.ForeignKey("groups.group_name",
+                                            onupdate="CASCADE",
+                                            ondelete="SET NULL")),
+                    sa.Column("owner_user_name", sa.Unicode(30),
+                              sa.ForeignKey("users.user_name",
+                                            onupdate="CASCADE",
+                                            ondelete="SET NULL"))
                     )
 
-    op.create_table('groups_resources_permissions',
-                    sa.Column('group_name', sa.Unicode(50),
-                              sa.ForeignKey('groups.group_name',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+    op.create_table("groups_resources_permissions",
+                    sa.Column("group_name", sa.Unicode(50),
+                              sa.ForeignKey("groups.group_name",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True),
-                    sa.Column('resource_id', sa.BigInteger(),
-                              sa.ForeignKey('resources.resource_id',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+                    sa.Column("resource_id", sa.BigInteger(),
+                              sa.ForeignKey("resources.resource_id",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True,
                               autoincrement=False),
-                    sa.Column('perm_name', sa.Unicode(50), primary_key=True)
+                    sa.Column("perm_name", sa.Unicode(50), primary_key=True)
                     )
 
-    op.create_table('users_resources_permissions',
-                    sa.Column('user_name', sa.Unicode(50),
-                              sa.ForeignKey('users.user_name',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+    op.create_table("users_resources_permissions",
+                    sa.Column("user_name", sa.Unicode(50),
+                              sa.ForeignKey("users.user_name",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True),
-                    sa.Column('resource_id', sa.BigInteger(),
-                              sa.ForeignKey('resources.resource_id',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE'),
+                    sa.Column("resource_id", sa.BigInteger(),
+                              sa.ForeignKey("resources.resource_id",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE"),
                               primary_key=True,
                               autoincrement=False),
-                    sa.Column('perm_name', sa.Unicode(50), primary_key=True)
+                    sa.Column("perm_name", sa.Unicode(50), primary_key=True)
                     )
 
 

--- a/magpie/alembic/versions/2011-11-11_5c84d7260c5_add_parent_id.py
+++ b/magpie/alembic/versions/2011-11-11_5c84d7260c5_add_parent_id.py
@@ -1,5 +1,5 @@
 """
-add id/parent id to resource structure.
+Add id/parent id to resource structure.
 
 Revision ID: 5c84d7260c5
 Revises: 24ab8d11f014
@@ -10,7 +10,8 @@ from __future__ import unicode_literals
 import sqlalchemy as sa  # noqa: F401
 from alembic import op  # noqa: F401
 
-# downgrade revision identifier, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "5c84d7260c5"
 down_revision = "24ab8d11f014"
 

--- a/magpie/alembic/versions/2011-12-20_46a9c4fb9560_pass_col_sizes.py
+++ b/magpie/alembic/versions/2011-12-20_46a9c4fb9560_pass_col_sizes.py
@@ -1,5 +1,5 @@
 """
-make password hash field bigger.
+Make password hash field longer.
 
 Revision ID: 46a9c4fb9560
 Revises: 5c84d7260c5
@@ -10,15 +10,16 @@ from __future__ import unicode_literals
 import sqlalchemy as sa
 from alembic import op
 
-# downgrade revision identifier, used by Alembic.
-revision = '46a9c4fb9560'
-down_revision = '5c84d7260c5'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "46a9c4fb9560"
+down_revision = "5c84d7260c5"
 
 
 def upgrade():
-    op.alter_column('users', 'user_password',
+    op.alter_column("users", "user_password",
                     type_=sa.Unicode(256), existing_type=sa.Unicode(40))
-    op.alter_column('users', 'security_code',
+    op.alter_column("users", "security_code",
                     type_=sa.Unicode(256), existing_type=sa.Unicode(40))
 
 

--- a/magpie/alembic/versions/2012-02-13_264049f80948_create_ordering_column.py
+++ b/magpie/alembic/versions/2012-02-13_264049f80948_create_ordering_column.py
@@ -1,5 +1,5 @@
 """
-create ordering column.
+Create ordering column.
 
 Revision ID: 264049f80948
 Revises: 46a9c4fb9560
@@ -10,7 +10,8 @@ from __future__ import unicode_literals
 import sqlalchemy as sa  # noqa: F401
 from alembic import op  # noqa: F401
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "264049f80948"
 down_revision = "46a9c4fb9560"
 

--- a/magpie/alembic/versions/2012-02-19_2d472fe79b95_bigger_identity_data.py
+++ b/magpie/alembic/versions/2012-02-19_2d472fe79b95_bigger_identity_data.py
@@ -1,5 +1,5 @@
 """
-bigger identity datatypes.
+Bigger identity datatypes.
 
 Revision ID: 2d472fe79b95
 Revises: 264049f80948
@@ -10,16 +10,17 @@ from __future__ import unicode_literals
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = '2d472fe79b95'
-down_revision = '264049f80948'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "2d472fe79b95"
+down_revision = "264049f80948"
 
 
 def upgrade():
-    op.alter_column('external_identities', 'external_id',
+    op.alter_column("external_identities", "external_id",
                     type_=sa.Unicode(255), existing_type=sa.Unicode(50),
                     nullable=False)
-    op.alter_column('external_identities', 'external_user_name',
+    op.alter_column("external_identities", "external_user_name",
                     type_=sa.Unicode(255), existing_type=sa.Unicode(50))
 
 

--- a/magpie/alembic/versions/2012-03-10_54d08f9adc8c_add_registered_date.py
+++ b/magpie/alembic/versions/2012-03-10_54d08f9adc8c_add_registered_date.py
@@ -1,5 +1,5 @@
 """
-add registered_date to user.
+Add registered_date to user.
 
 Revision ID: 54d08f9adc8c
 Revises: 2d472fe79b95
@@ -12,20 +12,21 @@ from alembic import op
 from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.postgresql.base import PGDialect
 
-# revision identifiers, used by Alembic.
-revision = '54d08f9adc8c'
-down_revision = '2d472fe79b95'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "54d08f9adc8c"
+down_revision = "2d472fe79b95"
 
 
 def upgrade():
     c = get_context()
     if isinstance(c.connection.engine.dialect, PGDialect):
-        op.add_column('users', sa.Column('registered_date',
+        op.add_column("users", sa.Column("registered_date",
                                          sa.TIMESTAMP(timezone=False),
                                          default=sa.sql.func.now(),
                                          server_default=sa.func.now()))
     else:
-        op.add_column('users', sa.Column('registered_date',
+        op.add_column("users", sa.Column("registered_date",
                                          sa.TIMESTAMP(timezone=False),
                                          default=sa.sql.func.now()))
 

--- a/magpie/alembic/versions/2012-06-05_53927300c277_change_primary_key_sizes.py
+++ b/magpie/alembic/versions/2012-06-05_53927300c277_change_primary_key_sizes.py
@@ -1,5 +1,5 @@
 """
-change primary key sizes.
+Change primary key sizes.
 
 Revision ID: 53927300c277
 Revises: 54d08f9adc8c
@@ -13,7 +13,8 @@ from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.engine.reflection import Inspector
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "53927300c277"
 down_revision = "54d08f9adc8c"
 

--- a/magpie/alembic/versions/2012-06-27_3cfc41c4a5f0_groups_pkey_change.py
+++ b/magpie/alembic/versions/2012-06-27_3cfc41c4a5f0_groups_pkey_change.py
@@ -1,5 +1,5 @@
 """
-groups pkey change.
+Groups pkey change.
 
 Revision ID: 3cfc41c4a5f0
 Revises: 53927300c277
@@ -13,47 +13,46 @@ from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.engine.reflection import Inspector
 
-# revision identifiers, used by Alembic.
-revision = '3cfc41c4a5f0'
-down_revision = '53927300c277'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "3cfc41c4a5f0"
+down_revision = "53927300c277"
 
 
 def upgrade():
     c = get_context()
     if isinstance(c.connection.engine.dialect, MySQLDialect):
         insp = Inspector.from_engine(c.connection.engine)
-        for t in ['groups_permissions', 'groups_resources_permissions',
-                  'users_groups', 'resources']:
-            for constraint in insp.get_foreign_keys(t):
-                if constraint['referred_columns'] == ['group_name']:
-                    op.drop_constraint(constraint['name'], t,
-                                       type='foreignkey')
+        for table in ["groups_permissions", "groups_resources_permissions", "users_groups", "resources"]:
+            for constraint in insp.get_foreign_keys(table):
+                if constraint["referred_columns"] == ["group_name"]:
+                    op.drop_constraint(constraint["name"], table, type="foreignkey")
 
-    op.drop_column('groups', 'id')
-    op.alter_column('groups', 'group_name',
+    op.drop_column("groups", "id")
+    op.alter_column("groups", "group_name",
                     type_=sa.Unicode(128),
                     existing_type=sa.Unicode(50),
                     )
-    op.create_primary_key('groups_pkey', 'groups', cols=['group_name'])
+    op.create_primary_key("groups_pkey", "groups", cols=["group_name"])
 
     if isinstance(c.connection.engine.dialect, MySQLDialect):
-        op.create_foreign_key(None, 'groups_permissions', 'groups',
-                              remote_cols=['group_name'],
-                              local_cols=['group_name'], onupdate='CASCADE',
-                              ondelete='CASCADE')
-        op.create_foreign_key(None, 'groups_resources_permissions', 'groups',
-                              remote_cols=['group_name'],
-                              local_cols=['group_name'], onupdate='CASCADE',
-                              ondelete='CASCADE')
-        op.create_foreign_key(None, 'users_groups', 'groups',
-                              remote_cols=['group_name'],
-                              local_cols=['group_name'], onupdate='CASCADE',
-                              ondelete='CASCADE')
-        op.create_foreign_key(None, 'resources', 'groups',
-                              remote_cols=['group_name'],
-                              local_cols=['owner_group_name'],
-                              onupdate='CASCADE',
-                              ondelete='SET NULL')
+        op.create_foreign_key(None, "groups_permissions", "groups",
+                              remote_cols=["group_name"],
+                              local_cols=["group_name"], onupdate="CASCADE",
+                              ondelete="CASCADE")
+        op.create_foreign_key(None, "groups_resources_permissions", "groups",
+                              remote_cols=["group_name"],
+                              local_cols=["group_name"], onupdate="CASCADE",
+                              ondelete="CASCADE")
+        op.create_foreign_key(None, "users_groups", "groups",
+                              remote_cols=["group_name"],
+                              local_cols=["group_name"], onupdate="CASCADE",
+                              ondelete="CASCADE")
+        op.create_foreign_key(None, "resources", "groups",
+                              remote_cols=["group_name"],
+                              local_cols=["owner_group_name"],
+                              onupdate="CASCADE",
+                              ondelete="SET NULL")
 
 
 def downgrade():

--- a/magpie/alembic/versions/2012-06-27_4c10d97c509_add_index_to_resourc.py
+++ b/magpie/alembic/versions/2012-06-27_4c10d97c509_add_index_to_resourc.py
@@ -1,5 +1,5 @@
 """
-add index to resources.
+Add index to resources.
 
 Revision ID: 4c10d97c509
 Revises: 3cfc41c4a5f0
@@ -9,14 +9,15 @@ from __future__ import unicode_literals
 
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = '4c10d97c509'
-down_revision = '3cfc41c4a5f0'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "4c10d97c509"
+down_revision = "3cfc41c4a5f0"
 
 
 def upgrade():
-    op.create_index('owner_user_name_ix', 'resources', ['owner_user_name'])
-    op.create_index('owner_group_name_ix', 'resources', ['owner_group_name'])
+    op.create_index("owner_user_name_ix", "resources", ["owner_user_name"])
+    op.create_index("owner_group_name_ix", "resources", ["owner_group_name"])
 
 
 def downgrade():

--- a/magpie/alembic/versions/2012-07-07_20671b28c538_change_all_linking_k.py
+++ b/magpie/alembic/versions/2012-07-07_20671b28c538_change_all_linking_k.py
@@ -1,5 +1,5 @@
 """
-change all linking keys from chars to id's.
+Change all linking keys from chars to id's.
 
 Revision ID: 20671b28c538
 Revises: 4c10d97c509
@@ -13,7 +13,8 @@ from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.engine.reflection import Inspector
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "20671b28c538"
 down_revision = "4c10d97c509"
 

--- a/magpie/alembic/versions/2012-07-09_439766f6104d_add_lower_indexes.py
+++ b/magpie/alembic/versions/2012-07-09_439766f6104d_add_lower_indexes.py
@@ -1,5 +1,5 @@
 """
-add lower() indexes to pg.
+Add lower() indexes to pg.
 
 Revision ID: 439766f6104d
 Revises: 20671b28c538
@@ -11,7 +11,8 @@ from alembic import op
 from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.postgresql.base import PGDialect
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "439766f6104d"
 down_revision = "20671b28c538"
 

--- a/magpie/alembic/versions/2015-06-13_438c27ec1c9_normalize_constraint_and_key_names.py
+++ b/magpie/alembic/versions/2015-06-13_438c27ec1c9_normalize_constraint_and_key_names.py
@@ -1,5 +1,5 @@
 """
-normalize constraint and key names correct keys for pre 0.5.6 naming convention.
+Normalize constraint and key names correct keys for pre 0.5.6 naming convention.
 
 Revision ID: 438c27ec1c9
 Revises: 439766f6104d
@@ -12,7 +12,8 @@ from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.engine.reflection import Inspector
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "438c27ec1c9"
 down_revision = "439766f6104d"
 

--- a/magpie/alembic/versions/2015-06-14_13391c68750_add_security_code_date.py
+++ b/magpie/alembic/versions/2015-06-14_13391c68750_add_security_code_date.py
@@ -1,5 +1,5 @@
 """
-add security_code_date.
+Add security_code_date.
 
 Revision ID: 13391c68750
 Revises: 438c27ec1c9
@@ -10,14 +10,15 @@ from __future__ import unicode_literals
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = '13391c68750'
-down_revision = '438c27ec1c9'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "13391c68750"
+down_revision = "438c27ec1c9"
 
 
 def upgrade():
-    op.add_column('users', sa.Column('security_code_date', sa.DateTime(),
-                                     server_default='2000-01-01 01:01'))
+    op.add_column("users", sa.Column("security_code_date", sa.DateTime(),
+                                     server_default="2000-01-01 01:01"))
 
 
 def downgrade():

--- a/magpie/alembic/versions/2016-04-02_57bbf0c387c_add_local_user_id.py
+++ b/magpie/alembic/versions/2016-04-02_57bbf0c387c_add_local_user_id.py
@@ -1,5 +1,5 @@
 """
-add local_user_id.
+Add local_user_id.
 
 Revision ID: 57bbf0c387c
 Revises: 13391c68750
@@ -11,38 +11,34 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import table
 
-# revision identifiers, used by Alembic.
-revision = '57bbf0c387c'
-down_revision = '13391c68750'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "57bbf0c387c"
+down_revision = "13391c68750"
 
 
 def upgrade():
     conn = op.get_bind()
-    op.add_column('external_identities', sa.Column('local_user_id',
-                                                   sa.Integer()))
+    op.add_column("external_identities", sa.Column("local_user_id", sa.Integer()))
 
-    external_identities_t = table('external_identities',
-                                  sa.Column('local_user_name', sa.Unicode(50)),
-                                  sa.Column('local_user_id', sa.Integer))
-    users_t = table('users',
-                    sa.Column('user_name', sa.Unicode(50)),
-                    sa.Column('id', sa.Integer))
+    external_identities_t = table("external_identities",
+                                  sa.Column("local_user_name", sa.Unicode(50)),
+                                  sa.Column("local_user_id", sa.Integer))
+    users_t = table("users",
+                    sa.Column("user_name", sa.Unicode(50)),
+                    sa.Column("id", sa.Integer))
 
-    stmt = external_identities_t.update().values(local_user_id=users_t.c.id). \
-        where(users_t.c.user_name == external_identities_t.c.local_user_name)
+    stmt = external_identities_t.update().values(local_user_id=users_t.c.id).where(
+        users_t.c.user_name == external_identities_t.c.local_user_name
+    )
     conn.execute(stmt)
-    op.drop_constraint('pk_external_identities', 'external_identities',
-                       type='primary')
-    op.drop_constraint('fk_external_identities_local_user_name_users',
-                       'external_identities', type='foreignkey')
-    op.drop_column('external_identities', 'local_user_name')
-    op.create_primary_key('pk_external_identities', 'external_identities',
-                          cols=['external_id', 'local_user_id',
-                                'provider_name'])
-    op.create_foreign_key(None, 'external_identities', 'users',
-                          remote_cols=['id'],
-                          local_cols=['local_user_id'], onupdate='CASCADE',
-                          ondelete='CASCADE')
+    op.drop_constraint("pk_external_identities", "external_identities", type="primary")
+    op.drop_constraint("fk_external_identities_local_user_name_users", "external_identities", type="foreignkey")
+    op.drop_column("external_identities", "local_user_name")
+    op.create_primary_key("pk_external_identities", "external_identities",
+                          cols=["external_id", "local_user_id", "provider_name"])
+    op.create_foreign_key(None, "external_identities", "users",
+                          remote_cols=["id"], local_cols=["local_user_id"], onupdate="CASCADE", ondelete="CASCADE")
 
 
 def downgrade():

--- a/magpie/alembic/versions/2016-05-05_b5e6dd3449dd_increase_field_sizes.py
+++ b/magpie/alembic/versions/2016-05-05_b5e6dd3449dd_increase_field_sizes.py
@@ -1,5 +1,5 @@
 """
-increase user and token field sized.
+Increase user and token field sized.
 
 Revision ID: b5e6dd3449dd
 Revises: 57bbf0c387c
@@ -10,7 +10,8 @@ from __future__ import unicode_literals
 import sqlalchemy as sa  # noqa: F401
 from alembic import op  # noqa: F401
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "b5e6dd3449dd"
 down_revision = "57bbf0c387c"
 

--- a/magpie/alembic/versions/2017-07-21_0974132183ad_alter_user.py
+++ b/magpie/alembic/versions/2017-07-21_0974132183ad_alter_user.py
@@ -1,5 +1,5 @@
 """
-alter user.
+Alter user.
 
 Revision ID: 0974132183ad
 Revises:
@@ -8,17 +8,18 @@ Create Date: 2017-07-21 18:40:24.918345
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = '0974132183ad'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "0974132183ad"
 down_revision = None
 branch_labels = None
-depends_on = '2bb1ba973f0b'
+depends_on = "2bb1ba973f0b"
 
 
 def upgrade():
-    op.add_column('users', sa.Column('openid', sa.Unicode(128), unique=True))
-    op.add_column('users', sa.Column('credential', sa.Unicode(128), unique=True))
-    op.add_column('users', sa.Column('cert_expires', sa.TIMESTAMP(timezone=False),
+    op.add_column("users", sa.Column("openid", sa.Unicode(128), unique=True))
+    op.add_column("users", sa.Column("credential", sa.Unicode(128), unique=True))
+    op.add_column("users", sa.Column("cert_expires", sa.TIMESTAMP(timezone=False),
                                      default=sa.sql.func.now(), server_default=sa.func.now()))
 
 

--- a/magpie/alembic/versions/2017-07-21_ddb788864221_add_service_as_resource.py
+++ b/magpie/alembic/versions/2017-07-21_ddb788864221_add_service_as_resource.py
@@ -8,23 +8,24 @@ Create Date: 2017-07-21 18:44:53.429481
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = 'ddb788864221'
-down_revision = '0974132183ad'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "ddb788864221"
+down_revision = "0974132183ad"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.create_table('services',
-                    sa.Column('resource_id',
+    op.create_table("services",
+                    sa.Column("resource_id",
                               sa.Integer(),
-                              sa.ForeignKey('resources.resource_id',
-                                            onupdate='CASCADE',
-                                            ondelete='CASCADE', ),
+                              sa.ForeignKey("resources.resource_id",
+                                            onupdate="CASCADE",
+                                            ondelete="CASCADE", ),
                               primary_key=True),
-                    sa.Column('type', sa.UnicodeText(), unique=False),
-                    sa.Column('url', sa.UnicodeText(), unique=False))
+                    sa.Column("type", sa.UnicodeText(), unique=False),
+                    sa.Column("url", sa.UnicodeText(), unique=False))
 
 
 def downgrade():

--- a/magpie/alembic/versions/2018-05-23_2a6c63397399_separate_personal_standard_groups.py
+++ b/magpie/alembic/versions/2018-05-23_2a6c63397399_separate_personal_standard_groups.py
@@ -1,5 +1,5 @@
 """
-separate personal standard groups.
+Separate personal standard groups.
 
 Revision ID: 2a6c63397399
 Revises: 9fd4589cc82c
@@ -14,17 +14,18 @@ from sqlalchemy.orm.session import sessionmaker
 
 Session = sessionmaker()
 
-# revision identifiers, used by Alembic.
-revision = '2a6c63397399'
-down_revision = '9fd4589cc82c'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "2a6c63397399"
+down_revision = "9fd4589cc82c"
 branch_labels = None
 depends_on = None
 
 # OLD/NEW values must be different
-OLD_GROUP_USERS = 'user'
-NEW_GROUP_USERS = 'users'
-OLD_GROUP_ADMIN = 'admin'
-NEW_GROUP_ADMIN = 'administrators'
+OLD_GROUP_USERS = "user"
+NEW_GROUP_USERS = "users"
+OLD_GROUP_ADMIN = "admin"
+NEW_GROUP_ADMIN = "administrators"
 OLD_USER_USERS = OLD_GROUP_USERS
 OLD_USER_ADMIN = OLD_GROUP_ADMIN
 
@@ -111,8 +112,7 @@ def downgrade_migrate(old_group, old_user, new_group, old_name, db_session):
 
     if old_group is None:
         # create missing group
-        old_group = Group(group_name=old_name)   # noqa
-        db_session.add(old_group)
+        db_session.execute(groups.insert().value(group_name=old_name, member_count=0))
     if old_group is not None and new_group is not None:
         # transfer user-group references
         all_usr_grp = db_session.execute(sa.select(users_groups))
@@ -149,8 +149,8 @@ def clean_user_groups(db_session):
     all_groups = db_session.execute(sa.select([groups]))
     all_usr_grp = db_session.execute(sa.select([users_groups]))
 
-    all_usr_dict = dict([(usr.id, usr.user_name) for usr in all_users])
-    all_grp_dict = dict([(grp.id, grp.group_name) for grp in all_groups])
+    all_usr_dict = {usr.id: usr.user_name for usr in all_users}
+    all_grp_dict = {grp.id: grp.group_name for grp in all_groups}
 
     for usr_grp in all_usr_grp:
         # delete any missing user/group references (pointing to nothing...)

--- a/magpie/alembic/versions/2018-05-23_9fd4589cc82c_merge_heads_b5e6_and_ddb7.py
+++ b/magpie/alembic/versions/2018-05-23_9fd4589cc82c_merge_heads_b5e6_and_ddb7.py
@@ -1,14 +1,15 @@
 """
-merge heads b5e6 and ddb7.
+Merge heads b5e6 and ddb7.
 
 Revision ID: 9fd4589cc82c
 Revises: b5e6dd3449dd, ddb788864221
 Create Date: 2018-05-23 17:17:01.347552
 """
 
-# revision identifiers, used by Alembic.
-revision = '9fd4589cc82c'
-down_revision = (u'b5e6dd3449dd', 'ddb788864221')
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "9fd4589cc82c"
+down_revision = ("b5e6dd3449dd", "ddb788864221")
 branch_labels = None
 depends_on = None
 

--- a/magpie/alembic/versions/2018-05-29_5e7b5346c330_remove_obsolete_personal_groups.py
+++ b/magpie/alembic/versions/2018-05-29_5e7b5346c330_remove_obsolete_personal_groups.py
@@ -1,5 +1,5 @@
 """
-remove obsolete personal groups.
+Remove obsolete personal groups.
 
 Revision ID: 5e7b5346c330
 Revises: 2a6c63397399
@@ -22,11 +22,12 @@ root_dir = os.path.dirname(root_dir)    # magpie
 root_dir = os.path.dirname(root_dir)    # root
 sys.path.insert(0, root_dir)
 
-from magpie.constants import get_constant  # isort:skip # noqa: E402
+from magpie.constants import get_constant  # isort:skip # pylint: disable=C0413 # noqa: E402
 
 Session = sessionmaker()
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "5e7b5346c330"
 down_revision = "2a6c63397399"
 branch_labels = None

--- a/magpie/alembic/versions/2018-05-30_ae1a3c8c7860_transfer_group_users_admins_users.py
+++ b/magpie/alembic/versions/2018-05-30_ae1a3c8c7860_transfer_group_users_admins_users.py
@@ -1,5 +1,5 @@
 """
-transfer group users-admins users.
+Transfer group users-admins users.
 
 Revision ID: ae1a3c8c7860
 Revises: 5e7b5346c330
@@ -21,7 +21,8 @@ NEW_GROUP_USERS = "users"
 OLD_GROUP_ADMIN = "admin"
 NEW_GROUP_ADMIN = "administrators"
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "ae1a3c8c7860"
 down_revision = "5e7b5346c330"
 branch_labels = None
@@ -67,7 +68,6 @@ def upgrade():
 
                 # create new group if missing
                 if not new_group:
-                    new_group = Group(group_name=new_group_name)  # noqa
                     session.execute(groups.insert().value(group_name=new_group_name, member_count=0))
                     query = sa.select([groups]).where(groups.c.group_name == new_group_name)
                     new_group = session.execute(query).fetchone()

--- a/magpie/alembic/versions/2018-06-04_a395ef9d3fe6_reference_root_service.py
+++ b/magpie/alembic/versions/2018-06-04_a395ef9d3fe6_reference_root_service.py
@@ -1,5 +1,5 @@
 """
-reference root service.
+Reference root service.
 
 Revision ID: a395ef9d3fe6
 Revises: ae1a3c8c7860
@@ -12,7 +12,8 @@ from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.orm.session import sessionmaker
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "a395ef9d3fe6"
 down_revision = "ae1a3c8c7860"
 branch_labels = None

--- a/magpie/alembic/versions/2018-06-20_c352a98d570e_project_api_route_resource.py
+++ b/magpie/alembic/versions/2018-06-20_c352a98d570e_project_api_route_resource.py
@@ -1,5 +1,5 @@
 """
-project-api route resource.
+Add project-api route resource.
 
 Revision ID: c352a98d570e
 Revises: a395ef9d3fe6
@@ -7,11 +7,12 @@ Create Date: 2018-06-20 13:31:55.666240
 """
 import sqlalchemy as sa
 from alembic import op
-from alembic.context import get_context
+from alembic.context import get_context  # noqa: F401
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.orm.session import sessionmaker
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "c352a98d570e"
 down_revision = "a395ef9d3fe6"
 branch_labels = None

--- a/magpie/alembic/versions/2018-09-24_73b872478d87_add_resource_label.py
+++ b/magpie/alembic/versions/2018-09-24_73b872478d87_add_resource_label.py
@@ -1,5 +1,5 @@
 """
-add resource_display_name column.
+Add resource_display_name column.
 
 Revision ID: 73b872478d87
 Revises: d01af1f2e445
@@ -8,18 +8,19 @@ Create Date: 2018-09-24 11:29:38.108819
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
-revision = '73b872478d87'
-down_revision = '73639c63c4fc'
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "73b872478d87"
+down_revision = "73639c63c4fc"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('resources', sa.Column('resource_display_name', sa.Unicode(100), nullable=True))
-    op.add_column('remote_resources', sa.Column('resource_display_name', sa.Unicode(100), nullable=True))
+    op.add_column("resources", sa.Column("resource_display_name", sa.Unicode(100), nullable=True))
+    op.add_column("remote_resources", sa.Column("resource_display_name", sa.Unicode(100), nullable=True))
 
 
 def downgrade():
-    op.drop_column('resources', 'resource_display_name')
-    op.drop_column('remote_resources', 'resource_display_name')
+    op.drop_column("resources", "resource_display_name")
+    op.drop_column("remote_resources", "resource_display_name")

--- a/magpie/alembic/versions/2018-09-27_73639c63c4fc_unified_api_service.py
+++ b/magpie/alembic/versions/2018-09-27_73639c63c4fc_unified_api_service.py
@@ -15,7 +15,8 @@ from sqlalchemy.sql import table
 
 Session = sessionmaker()
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "73639c63c4fc"
 down_revision = "d01af1f2e445"
 branch_labels = None

--- a/magpie/alembic/versions/2018-19-11_d01af1f2e445_create_remote_sync_tables.py
+++ b/magpie/alembic/versions/2018-19-11_d01af1f2e445_create_remote_sync_tables.py
@@ -12,7 +12,8 @@ from sqlalchemy.orm.session import sessionmaker
 Session = sessionmaker()
 
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "d01af1f2e445"
 down_revision = "c352a98d570e"
 branch_labels = None

--- a/magpie/alembic/versions/2019-08-23_03b54feffe45_ensure_anonymous_group_applied_to_users.py
+++ b/magpie/alembic/versions/2019-08-23_03b54feffe45_ensure_anonymous_group_applied_to_users.py
@@ -21,7 +21,7 @@ root_dir = os.path.dirname(root_dir)    # magpie
 root_dir = os.path.dirname(root_dir)    # root
 sys.path.insert(0, root_dir)
 
-from magpie.constants import get_constant  # isort:skip # noqa: E402
+from magpie.constants import get_constant  # isort:skip # pylint: disable=C0413 # noqa: E402
 
 Session = sessionmaker()
 
@@ -43,7 +43,8 @@ users_groups = sa.table(
 )
 
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "03b54feffe45"
 down_revision = "73b872478d87"
 branch_labels = None

--- a/magpie/alembic/versions/2020-07-23_b739afcc91db_add_discoverable_groups.py
+++ b/magpie/alembic/versions/2020-07-23_b739afcc91db_add_discoverable_groups.py
@@ -8,7 +8,8 @@ Create Date: 2020-07-23 15:54:22.850077
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "b739afcc91db"
 down_revision = "24da162a54f1"
 branch_labels = None

--- a/magpie/alembic/versions/2020-09-22_a2a039e2cff5_explicit_permission_names.py
+++ b/magpie/alembic/versions/2020-09-22_a2a039e2cff5_explicit_permission_names.py
@@ -16,7 +16,8 @@ from sqlalchemy.orm.session import sessionmaker
 from ziggurat_foundations.models.services.group_resource_permission import GroupResourcePermissionService
 from ziggurat_foundations.models.services.user_resource_permission import UserResourcePermissionService
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "a2a039e2cff5"
 down_revision = "b739afcc91db"
 branch_labels = None
@@ -31,7 +32,7 @@ root_dir = os.path.dirname(root_dir)  # magpie
 root_dir = os.path.dirname(root_dir)  # root
 sys.path.insert(0, root_dir)
 
-from magpie.permissions import PermissionSet, Scope  # isort:skip # noqa: E402
+from magpie.permissions import PermissionSet, Scope  # isort:skip # pylint: disable=C0413 # noqa: E402
 
 
 def upgrade():

--- a/magpie/alembic/versions/2020-10-13_5f2648b8ff49_resource_type_process.py
+++ b/magpie/alembic/versions/2020-10-13_5f2648b8ff49_resource_type_process.py
@@ -12,7 +12,8 @@ from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.orm.session import sessionmaker
 from ziggurat_foundations.models.services.resource import ResourceService
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "5f2648b8ff49"
 down_revision = "a2a039e2cff5"
 branch_labels = None

--- a/magpie/alembic/versions/2020-10-28_9b8e5d37f684_thredds_browse_for_read_resources.py
+++ b/magpie/alembic/versions/2020-10-28_9b8e5d37f684_thredds_browse_for_read_resources.py
@@ -18,7 +18,8 @@ from sqlalchemy.orm.session import sessionmaker
 from ziggurat_foundations.models.services.group_resource_permission import GroupResourcePermissionService
 from ziggurat_foundations.models.services.user_resource_permission import UserResourcePermissionService
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "9b8e5d37f684"
 down_revision = "5f2648b8ff49"
 branch_labels = None

--- a/magpie/alembic/versions/2020-11-20_cfe64807c143_add_service_custom_configuration_field.py
+++ b/magpie/alembic/versions/2020-11-20_cfe64807c143_add_service_custom_configuration_field.py
@@ -9,7 +9,8 @@ Create Date: 2020-11-20 15:05:10.353336
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "cfe64807c143"
 down_revision = "9b8e5d37f684"
 branch_labels = None

--- a/magpie/alembic/versions/2021-01-04_954a9d7fe740_temporary_url_table.py
+++ b/magpie/alembic/versions/2021-01-04_954a9d7fe740_temporary_url_table.py
@@ -13,7 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "954a9d7fe740"
 down_revision = "cfe64807c143"
 branch_labels = None

--- a/magpie/alembic/versions/2021-04-16_dea413e13a8a_pending_users_and_statuses.py
+++ b/magpie/alembic/versions/2021-04-16_dea413e13a8a_pending_users_and_statuses.py
@@ -11,10 +11,10 @@ import datetime
 
 import sqlalchemy as sa
 from alembic import op
-from alembic.context import get_context  # noqa: F401
 from sqlalchemy.orm.session import sessionmaker
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "dea413e13a8a"
 down_revision = "954a9d7fe740"
 branch_labels = None

--- a/magpie/alembic/versions/2021-04-19_00c617174e54_unique_user_emails.py
+++ b/magpie/alembic/versions/2021-04-19_00c617174e54_unique_user_emails.py
@@ -8,7 +8,8 @@ Create Date: 2021-04-19 12:45:55.439916
 
 from alembic import op
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "00c617174e54"
 down_revision = "dea413e13a8a"
 branch_labels = None

--- a/magpie/alembic/versions/2021-04-27_35e98bdc8aed_token_operation_ref_pending_user.py
+++ b/magpie/alembic/versions/2021-04-27_35e98bdc8aed_token_operation_ref_pending_user.py
@@ -9,7 +9,8 @@ Create Date: 2021-04-27 18:58:34.606126
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "35e98bdc8aed"
 down_revision = "00c617174e54"
 branch_labels = None

--- a/magpie/alembic/versions/2021-06-09_cb92ff1f81bb_add_group_terms.py
+++ b/magpie/alembic/versions/2021-06-09_cb92ff1f81bb_add_group_terms.py
@@ -1,5 +1,5 @@
 """
-add group terms
+Add group terms
 
 Revision ID: cb92ff1f81bb
 Revises: 35e98bdc8aed
@@ -9,7 +9,8 @@ Create Date: 2021-06-09 14:18:32.777082
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "cb92ff1f81bb"
 down_revision = "35e98bdc8aed"
 branch_labels = None

--- a/magpie/alembic/versions/2022-03-04_0c6269f410cd_move_anonymous_user_to_group_perms.py
+++ b/magpie/alembic/versions/2022-03-04_0c6269f410cd_move_anonymous_user_to_group_perms.py
@@ -8,12 +8,12 @@ Create Date: 2022-03-04 23:13:39.987696
 
 import sqlalchemy as sa
 from alembic import op
-from alembic.context import get_context  # noqa: F401
 from sqlalchemy.orm.session import sessionmaker
 
 from magpie.constants import get_constant  # isort:skip # noqa: E402
 
-# revision identifiers, used by Alembic.
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
 revision = "0c6269f410cd"
 down_revision = "cb92ff1f81bb"
 branch_labels = None

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -4649,7 +4649,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/users/{}/groups".format(anon)
         data = {"group_name": self.test_group_name}
         resp = utils.test_request(self, "POST", path, data=data, expect_errors=True,
-                                  headers=self.test_headers, cookies=self.test_cookies)
+                                  headers=self.json_headers, cookies=self.cookies)
         body = utils.check_response_basic_info(resp, expected_method="POST", expected_code=403)
         utils.check_val_is_in("anonymous", body["detail"].lower())
 
@@ -4821,7 +4821,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         anon_grp = get_constant("MAGPIE_ANONYMOUS_GROUP")
         path = "/users/{}/groups/{}".format(anon_usr, anon_grp)
         resp = utils.test_request(self, "DELETE", path, expect_errors=True,
-                                  headers=self.test_headers, cookies=self.test_cookies)
+                                  headers=self.json_headers, cookies=self.cookies)
         body = utils.check_response_basic_info(resp, expected_method="DELETE", expected_code=403)
         utils.check_val_is_in("anonymous", body["detail"].lower())
 


### PR DESCRIPTION
## Context

All linting checks were skipped for `alembic` items due to explicit directory paths provided in Makefile, and because https://github.com/Ouranosinc/Magpie/tree/master/magpie/alembic is technically not a module (no `__init__.py`), and therefore was not verified by `pylint`. On the other hand, Codacy's PyLint was picking it up (somehow?), which was always generating many linting errors only on that side, and never fixed locally.

These should be resolved once and for all, both for local checks and remote Codacy tests.

![image](https://user-images.githubusercontent.com/19194484/157766603-877ae621-3e99-4370-abdc-21c9460a4de9.png)


## Changes

* Update linting configuration rules to validate all migration scripts employed by ``alembic``.
* Apply applicable linting fixes over ``alembic`` migration scripts.
