### PR TITLE
Permissions patch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add ``PATCH /permissions`` endpoint that updates permissions and creates related resources if necessary.
+* ``permissions.cfg`` now supports a new format for the ``type`` parameter, using multiple types separated
+  by a slash character, matching each type with each resource found in the ``resource`` parameter.
+
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Update linting configuration rules to validate all migration scripts employed by ``alembic``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Add ``PATCH /permissions`` endpoint that updates permissions and creates related resources if necessary.
-* ``permissions.cfg`` now supports a new format for the ``type`` parameter, using multiple types separated
+* Add support of new format for ``permissions.cfg`` for the ``type`` parameter, using multiple types separated
   by a slash character, matching each type with each resource found in the ``resource`` parameter.
 
 .. _changes_3.23.0:

--- a/config/permissions.cfg
+++ b/config/permissions.cfg
@@ -14,6 +14,8 @@
 #   service:              service name to receive the permission (directly on it if no 'resource' mentioned, must exist)
 #   resource:  (optional) tree path of the service's resource (ex: /res1/sub-res2/sub-sub-res3)
 #   type:      (optional) resource type employed in case of ambiguity between multiple choices (depends on service type)
+#                         can either be a single type, or a full path of resource types corresponding to the types of each
+#                         resource found in the path of the 'resource' parameter (ex: /directory/directory/file)
 #   user:                 user for which to apply the modification of permission (skip if omitted or None)
 #   group:                group for which to apply the modification of permission (skip if omitted or None)
 #   permission:           name or object of the permission to be applied (see 'magpie.permissions' for supported values)

--- a/magpie/api/management/resource/__init__.py
+++ b/magpie/api/management/resource/__init__.py
@@ -7,6 +7,7 @@ LOGGER = get_logger(__name__)
 def includeme(config):
     LOGGER.info("Adding API resource...")
     # Add all the rest api routes
+    config.add_route(**s.service_api_route_info(s.PermissionsAPI))
     config.add_route(**s.service_api_route_info(s.ResourcesAPI))
     config.add_route(**s.service_api_route_info(s.ResourceAPI))
     config.add_route(**s.service_api_route_info(s.ResourcePermissionsAPI))

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -192,6 +192,7 @@ def update_permissions(request):
     # Reformat permissions for function
     permissions_cfg = {"permissions": []}
     resource_full_path = ""
+    resource_full_type = ""
     for i, entry in enumerate(permissions):
         resource_name = entry.get("resource_name")
         resource_type = entry.get("resource_type")
@@ -211,6 +212,10 @@ def update_permissions(request):
             service_name = resource_name
         else:
             resource_full_path += "/" + resource_name
+            # Other resources must not be services
+            ax.verify_param(resource_type, not_equal=True, param_compare="service",
+                            http_error=HTTPBadRequest, msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
+            resource_full_type += "/" + resource_type
         if permission:
             # Check that a user and/or a group is defined
             ax.verify_param(bool(user or group), is_true=True,
@@ -218,7 +223,7 @@ def update_permissions(request):
             cfg_entry = {
                 "service": service_name,
                 "resource": resource_full_path,
-                "type": resource_type,
+                "type": resource_type if resource_type == "service" else resource_full_type,
                 "permission": permission,
                 "action": action
             }

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -181,11 +181,13 @@ def update_permissions(request):
         # Check if user/group exists for each permission found
         if "permission" in entry.keys() and entry["permission"]:
             if "user" in entry.keys():
-                if not UserService.by_user_name(entry["user"], db_session=request.db):
-                    raise RuntimeError(f"User {entry['user']} not found in the database.")
+                ax.verify_param(UserService.by_user_name(entry["user"], db_session=request.db),
+                                not_none=True, http_error=HTTPBadRequest,
+                                msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
             if "group" in entry.keys():
-                if not GroupService.by_group_name(entry["group"], db_session=request.db):
-                    raise RuntimeError(f"Group {entry['group']} not found in the database.")
+                ax.verify_param(GroupService.by_group_name(entry["group"], db_session=request.db),
+                                not_none=True, http_error=HTTPBadRequest,
+                                msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
 
     # Reformat permissions config
     permissions_cfg = {"permissions": []}

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -235,6 +235,7 @@ def update_permissions(request):
             permissions_cfg["permissions"].append(cfg_entry)
 
     # Apply permission update
-    magpie_register_permissions_from_config(permissions_config=permissions_cfg, db_session=request.db)
+    magpie_register_permissions_from_config(permissions_config=permissions_cfg, db_session=request.db,
+                                            raise_errors=True)
 
     return ax.valid_http(http_success=HTTPOk, detail=s.Permissions_PATCH_OkResponseSchema.description)

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -1,4 +1,4 @@
-from pyramid.httpexceptions import HTTPBadRequest, HTTPConflict, HTTPForbidden, HTTPInternalServerError, HTTPNotFound, HTTPOk
+from pyramid.httpexceptions import HTTPBadRequest, HTTPConflict, HTTPForbidden, HTTPInternalServerError, HTTPOk
 from pyramid.settings import asbool
 from pyramid.view import view_config
 from ziggurat_foundations.models.services.group import GroupService
@@ -13,7 +13,7 @@ from magpie.api.management.resource import resource_utils as ru
 from magpie.api.management.service.service_formats import format_service_resources
 from magpie.api.management.service.service_utils import get_services_by_type
 from magpie.permissions import PermissionType, format_permissions
-from magpie.register import sync_services_phoenix, magpie_register_permissions_from_config
+from magpie.register import magpie_register_permissions_from_config, sync_services_phoenix
 from magpie.services import SERVICE_TYPE_DICT, get_resource_child_allowed
 
 
@@ -207,19 +207,19 @@ def update_permissions(request):
                         http_error=HTTPBadRequest, msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
         if i == 0:
             # First resource must be a service
-            ax.verify_param(resource_type, is_equal=True, param_compare="service",
-                            http_error=HTTPBadRequest, msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
+            ax.verify_param(resource_type, is_equal=True, param_compare="service", http_error=HTTPBadRequest,
+                            msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
             service_name = resource_name
         else:
             resource_full_path += "/" + resource_name
             # Other resources must not be services
-            ax.verify_param(resource_type, not_equal=True, param_compare="service",
-                            http_error=HTTPBadRequest, msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
+            ax.verify_param(resource_type, not_equal=True, param_compare="service", http_error=HTTPBadRequest,
+                            msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
             resource_full_type += "/" + resource_type
         if permission:
             # Check that a user and/or a group is defined
-            ax.verify_param(bool(user or group), is_true=True,
-                            http_error=HTTPBadRequest, msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
+            ax.verify_param(bool(user or group), is_true=True, http_error=HTTPBadRequest,
+                            msg_on_fail=s.Permissions_PATCH_BadRequestResponseSchema.description)
             cfg_entry = {
                 "service": service_name,
                 "resource": resource_full_path,

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -247,7 +247,9 @@ def update_permissions(request):
             permissions_cfg["permissions"].append(cfg_entry)
 
     # Apply permission update
-    magpie_register_permissions_from_config(permissions_config=permissions_cfg, db_session=request.db,
-                                            raise_errors=True)
+    ax.evaluate_call(
+        lambda: magpie_register_permissions_from_config(
+            permissions_config=permissions_cfg, db_session=request.db, raise_errors=True),
+        http_error=HTTPBadRequest, msg_on_fail="Failed to update requested permissions.")
 
     return ax.valid_http(http_success=HTTPOk, detail=s.Permissions_PATCH_OkResponseSchema.description)

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -226,7 +226,7 @@ def update_permissions(request):
     """
     permissions = ar.get_value_multiformat_body_checked(request, "permissions", check_type=list)
     ax.verify_param(permissions, not_none=True, not_empty=True, http_error=HTTPBadRequest,
-                    msg_on_fail="No permissions to update (empty `permissions` parameter.)")
+                    msg_on_fail="No permissions to update (empty `permissions` parameter).")
 
     required_users = set()
     required_groups = set()
@@ -235,13 +235,13 @@ def update_permissions(request):
         ax.verify_param(entry, is_type=True, param_compare=dict, http_error=HTTPBadRequest,
                         msg_on_fail="Permission entry should be of `dict` type, but type `{}` was found instead".format(
                             type(entry)),
-                        content={"param_content": entry})
+                        param_content={"value": entry})
         if "permission" in entry and entry["permission"]:
             user = entry.get("user")
             group = entry.get("group")
             ax.verify_param(bool(user or group), is_true=True, http_error=HTTPBadRequest,
                             msg_on_fail="No user or group defined with the permission to update.",
-                            content={"param_content": entry})
+                            param_content={"value": entry})
             has_permission_to_update = True
             if user:
                 required_users.add(user)
@@ -259,8 +259,8 @@ def update_permissions(request):
                         msg_on_fail="Permission's group `{}` could not be found in the database.".format(group_name))
 
     ax.verify_param(has_permission_to_update, is_true=True, http_error=HTTPBadRequest,
-                    msg_on_fail="No permissions to update (none of the input entries has a defined permission.)",
-                    content={"param_content": permissions})
+                    msg_on_fail="No permissions to update (none of the input entries has a defined permission).",
+                    param_content={"value": permissions})
 
     # Reformat permissions config
     permissions_cfg = {"permissions": []}
@@ -276,21 +276,21 @@ def update_permissions(request):
 
         ax.verify_param(resource_name, not_none=True, not_empty=True, http_error=HTTPBadRequest,
                         msg_on_fail="Missing `resource_name` parameter for permissions update.",
-                        content={"param_content": entry})
+                        param_name="resource_name", param_content={"value": entry})
         ax.verify_param(resource_type, not_none=True, not_empty=True, http_error=HTTPBadRequest,
                         msg_on_fail="Missing `resource_type` parameter for permissions update.",
-                        content={"param_content": entry})
+                        param_name="resource_type", param_content={"value": entry})
         if i == 0:
             ax.verify_param(resource_type, is_equal=True, param_compare="service", http_error=HTTPBadRequest,
                             msg_on_fail="First resource in the permissions list should have a `service` type but has "
                                         "a `{}` type instead.".format(resource_type),
-                            content={"param_content": entry})
+                            param_name="resource_type", param_content={"value": entry})
             service_name = resource_name
         else:
             resource_full_path += "/" + resource_name
             ax.verify_param(resource_type, not_equal=True, param_compare="service", http_error=HTTPBadRequest,
                             msg_on_fail="Only the first resource in the permissions list should be of `service` type.",
-                            content={"param_content": entry})
+                            param_name="resource_type", param_content={"value": entry})
             resource_full_type += "/" + resource_type
         if permission:
             cfg_entry = {

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -828,7 +828,7 @@ class Permissions_PATCH_OkResponseSchema(BaseResponseSchemaAPI):
 
 
 class Permissions_PATCH_BadRequestResponseSchema(BaseResponseSchemaAPI):
-    description = "Missing parameters to update permissions or parameters do not provide any modification."
+    description = "Missing or invalid parameters for permissions update."
     body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
 
 

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -783,20 +783,30 @@ class PermissionNameListSchema(colander.SequenceSchema):
 class PermissionPatchObjectSchema(colander.MappingSchema):
     resource_name = colander.SchemaNode(
         colander.String(),
-        description="Name of the resource to create."
+        description="Name of the resource associated with the permission. This resource will be created if missing."
     )
     resource_type = colander.SchemaNode(
         colander.String(),
-        description="Type of the resource",
+        description="Type of the resource. The first resource must be of the `service` type, and children "
+                    "resources must have a relevant resource type that is not of the `service` type.",
         example="service"
     )
 
-    user = UserNameParameter
-    user.missing = colander.drop
+    user = colander.SchemaNode(
+        colander.String(),
+        description="Registered local user associated with the permission.",
+        example="toto",
+        missing=colander.drop
+    )
+    group = colander.SchemaNode(
+        colander.String(),
+        description="Registered user group associated with the permission.",
+        example="users",
+        missing=colander.drop
+    )
 
-    group = GroupNameParameter
-    group.missing = colander.drop
-
+    # FIXME: support oneOf(string, object), permission can actually be either a string or a PermissionObjectSchema(dict)
+    # Currently not possible to have multiple type options with colander.
     permission = PermissionObjectSchema(
         missing=colander.drop
     )
@@ -806,7 +816,7 @@ class PermissionPatchObjectSchema(colander.MappingSchema):
         description="Action to apply on the permission.",
         example="create",
         default="create",
-        validator=colander.OneOf(["create", "delete"])
+        validator=colander.OneOf(["create", "remove"])
     )
 
 

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -751,7 +751,7 @@ def _parse_resource_path(permission_config_entry,   # type: PermissionConfigItem
             resource_list = resource_path.split("/")
             if len(resource_type_list) == 1:
                 # if only one type specified, assume every path of the resource uses the same resource type
-                resource_type_list = resource_type_list[0] * len(resource_list)
+                resource_type_list = resource_type_list * len(resource_list)
             if len(resource_list) != len(resource_type_list):
                 raise RegistrationConfigurationError("Invalid resource type found in configuration : "
                                                      f"{permission_config_entry.get('type')}")

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -706,7 +706,7 @@ def _log_permission(message, permission_index, trail=", skipping...", detail=Non
     LOGGER.log(level, "%s [permission #%d]%s%s", message, permission_index, permission, trail)
 
     if raise_errors:
-        raise HTTPBadRequest(f"{message} [permission #{permission_index}]{permission}{trail}")
+        raise HTTPBadRequest("{} [permission #{}]{}{}".format(message, permission_index, permission, trail))
 
 
 def _use_request(cookies_or_session):
@@ -753,8 +753,8 @@ def _parse_resource_path(permission_config_entry,   # type: PermissionConfigItem
                 # if only one type specified, assume every path of the resource uses the same resource type
                 resource_type_list = resource_type_list * len(resource_list)
             if len(resource_list) != len(resource_type_list):
-                raise RegistrationConfigurationError("Invalid resource type found in configuration : "
-                                                     f"{permission_config_entry.get('type')}")
+                raise RegistrationConfigurationError("Invalid resource type found in configuration : " +
+                                                     permission_config_entry.get('type'))
 
             res_path = None
             if _use_request(cookies_or_session):

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -703,11 +703,11 @@ def _handle_permission(message, permission_index, trail=", skipping...", detail=
     """
     trail = "{}\nDetail: [{!s}]".format(trail, detail) if detail else (trail or "")
     permission = " [{!s}]".format(permission) if permission else ""
-    LOGGER.log(level, "%s [permission #%d]%s%s", message, permission_index, permission, trail)
+    msg = "{} [permission #{}]{}{}".format(message, permission_index, permission, trail)
+    LOGGER.log(level, msg)
 
     if raise_errors:
-        raise RegistrationConfigurationError(
-            "{} [permission #{}]{}{}".format(message, permission_index, permission, trail))
+        raise RegistrationConfigurationError(msg)
 
 
 def _use_request(cookies_or_session):

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -11,7 +11,7 @@ import requests
 import six
 import transaction
 import yaml
-from pyramid.httpexceptions import HTTPException
+from pyramid.httpexceptions import HTTPBadRequest, HTTPException
 from sqlalchemy.orm.session import Session
 from ziggurat_foundations.models.services.group import GroupService
 from ziggurat_foundations.models.services.resource import ResourceService
@@ -673,7 +673,8 @@ def magpie_register_services_from_config(service_config_path, push_to_phoenix=Fa
     return merged_service_configs
 
 
-def _log_permission(message, permission_index, trail=", skipping...", detail=None, permission=None, level=logging.WARN):
+def _log_permission(message, permission_index, trail=", skipping...", detail=None, permission=None, level=logging.WARN,
+                    raise_errors=False):
     # type: (Str, int, Str, Optional[Str], Optional[Str], Union[Str, int]) -> None
     """
     Logs a message related to a 'permission' entry.
@@ -695,6 +696,7 @@ def _log_permission(message, permission_index, trail=", skipping...", detail=Non
     :param detail: additional details appended after the trailing message after moving to another line.
     :param permission: permission name to log just before the trailing message.
     :param level: logging level (default: ``logging.WARN``)
+    :param raise_errors: raises errors related to permissions, instead of just logging the info.
 
     .. seealso::
         `magpie/config/permissions.cfg`
@@ -702,6 +704,9 @@ def _log_permission(message, permission_index, trail=", skipping...", detail=Non
     trail = "{}\nDetail: [{!s}]".format(trail, detail) if detail else (trail or "")
     permission = " [{!s}]".format(permission) if permission else ""
     LOGGER.log(level, "%s [permission #%d]%s%s", message, permission_index, permission, trail)
+
+    if raise_errors:
+        raise HTTPBadRequest(f"{message} [permission #{permission_index}]{permission}{trail}")
 
 
 def _use_request(cookies_or_session):
@@ -712,7 +717,8 @@ def _parse_resource_path(permission_config_entry,   # type: PermissionConfigItem
                          entry_index,               # type: int
                          service_info,              # type: JSON
                          cookies_or_session=None,   # type: CookiesOrSessionType
-                         magpie_url=None,           # type: Optional[Str]
+                         magpie_url=None,           # type: Optional[Str],
+                         raise_errors=False         # type: bool
                          ):                         # type: (...) -> Tuple[Optional[int], bool]
     """
     Parses the `resource` field of a permission config entry and retrieves the final resource id. Creates missing
@@ -774,19 +780,19 @@ def _parse_resource_path(permission_config_entry,   # type: PermissionConfigItem
                 svc_res_types = SERVICE_TYPE_DICT[svc_type].resource_type_names
                 type_count = len(svc_res_types)
                 if type_count == 0:
-                    _log_permission("Cannot generate resource", entry_index,
+                    _log_permission("Cannot generate resource", entry_index, raise_errors=raise_errors,
                                     detail="Service [{!s}] of type [{!s}] doesn't allows any sub-resource types. "
                                            .format(svc_name, svc_type))
                     raise RegistrationConfigurationError("Invalid resource not allowed to apply permission.")
                 if type_count != 1 and not (isinstance(resource_type, six.string_types) and resource_type):
-                    _log_permission("Cannot automatically generate resource", entry_index,
+                    _log_permission("Cannot automatically generate resource", entry_index, raise_errors=raise_errors,
                                     detail="Service [{!s}] of type [{!s}] allows more than 1 sub-resource types ({}). "
                                            "Type must be explicitly specified for auto-creation. "
                                            "Available choices are: {}"
                                            .format(svc_name, svc_type, type_count, svc_res_types))
                     raise RegistrationConfigurationError("Missing resource 'type' to apply permission.")
                 if type_count != 1 and resource_type not in svc_res_types:
-                    _log_permission("Cannot generate resource", entry_index,
+                    _log_permission("Cannot generate resource", entry_index, raise_errors=raise_errors,
                                     detail="Service [{!s}] of type [{!s}] allows more than 1 sub-resource types ({}). "
                                            "Specified type [{!s}] doesn't match any of the allowed resource types. "
                                            "Available choices are: {}"
@@ -808,10 +814,10 @@ def _parse_resource_path(permission_config_entry,   # type: PermissionConfigItem
                 raise RegistrationConfigurationError("Could not extract child resource from resource path.")
         except HTTPException as exc:
             detail = "{} ({}), {!s}".format(type(exc).__name__, exc.code, exc)
-            _log_permission("Failed resources parsing.", entry_index, detail=detail)
+            _log_permission("Failed resources parsing.", entry_index, detail=detail, raise_errors=raise_errors)
             return None, False
         except Exception as exc:
-            _log_permission("Failed resources parsing.", entry_index, detail=repr(exc))
+            _log_permission("Failed resources parsing.", entry_index, detail=repr(exc), raise_errors=raise_errors)
             return None, False
     return resource, True
 
@@ -823,6 +829,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
                             magpie_url,                 # type: Str
                             users,                      # type: UsersSettings
                             groups,                     # type: GroupsSettings
+                            raise_errors=False,         # type: bool
                             ):                          # type: (...) -> None
     """
     Applies the single permission entry retrieved from the permission configuration.
@@ -909,7 +916,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
                 from magpie.api.management.group.group_utils import create_group
                 return create_group(**grp_data)
 
-    def _validate_response(operation, is_create, item_type="Permission"):
+    def _validate_response(operation, is_create, item_type="Permission", raise_errors=False):
         """
         Validate action/operation applied and handles raised ``HTTPException`` as returned response.
         """
@@ -927,20 +934,24 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
         # validation according to status code returned
         if is_create:
             if _resp.status_code in [200, 201]:  # update/create
-                _log_permission("{} successfully created.".format(item_type), entry_index, level=logging.INFO, trail="")
+                _log_permission("{} successfully created.".format(item_type), entry_index, level=logging.INFO, trail="",
+                                raise_errors=False)
             elif _resp.status_code == 409:
-                _log_permission("{} already exists.".format(item_type), entry_index, level=logging.INFO)
+                _log_permission("{} already exists.".format(item_type), entry_index, level=logging.INFO,
+                                raise_errors=False)
             else:
                 _log_permission("Unknown response [{}]".format(_resp.status_code), entry_index,
-                                permission=permission_config_entry, level=logging.ERROR)
+                                permission=permission_config_entry, level=logging.ERROR, raise_errors=raise_errors)
         else:
             if _resp.status_code == 200:
-                _log_permission("{} successfully removed.".format(item_type), entry_index, level=logging.INFO, trail="")
+                _log_permission("{} successfully removed.".format(item_type), entry_index, level=logging.INFO, trail="",
+                                raise_errors=False)
             elif _resp.status_code == 404:
-                _log_permission("{} already removed.".format(item_type), entry_index, level=logging.INFO)
+                _log_permission("{} already removed.".format(item_type), entry_index, level=logging.INFO,
+                                raise_errors=False)
             else:
                 _log_permission("Unknown response [{}]".format(_resp.status_code), entry_index,
-                                permission=permission_config_entry, level=logging.ERROR)
+                                permission=permission_config_entry, level=logging.ERROR, raise_errors=raise_errors)
 
     create_perm = permission_config_entry["action"] == "create"
     perm_def = permission_config_entry["permission"]  # name or object
@@ -949,17 +960,17 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
     perm = PermissionSet(perm_def)
 
     # process groups first as they can be referenced by user definitions
-    _validate_response(lambda: _apply_profile(None, grp_name), is_create=True)
-    _validate_response(lambda: _apply_profile(usr_name, None), is_create=True)
+    _validate_response(lambda: _apply_profile(None, grp_name), is_create=True, raise_errors=raise_errors)
+    _validate_response(lambda: _apply_profile(usr_name, None), is_create=True, raise_errors=raise_errors)
     if _use_request(cookies_or_session):
-        _validate_response(lambda: _apply_request(None, grp_name), is_create=create_perm)
-        _validate_response(lambda: _apply_request(usr_name, None), is_create=create_perm)
+        _validate_response(lambda: _apply_request(None, grp_name), is_create=create_perm, raise_errors=raise_errors)
+        _validate_response(lambda: _apply_request(usr_name, None), is_create=create_perm, raise_errors=raise_errors)
     else:
-        _validate_response(lambda: _apply_session(None, grp_name), is_create=create_perm)
-        _validate_response(lambda: _apply_session(usr_name, None), is_create=create_perm)
+        _validate_response(lambda: _apply_session(None, grp_name), is_create=create_perm, raise_errors=raise_errors)
+        _validate_response(lambda: _apply_session(usr_name, None), is_create=create_perm, raise_errors=raise_errors)
 
 
-def magpie_register_permissions_from_config(permissions_config, magpie_url=None, db_session=None):
+def magpie_register_permissions_from_config(permissions_config, magpie_url=None, db_session=None, raise_errors=False):
     # type: (Union[Str, PermissionsConfig], Optional[Str], Optional[Session]) -> None
     """
     Applies `permissions` specified in configuration(s) defined as file, directory with files or literal configuration.
@@ -967,6 +978,7 @@ def magpie_register_permissions_from_config(permissions_config, magpie_url=None,
     :param permissions_config: file/dir path to `permissions` config or JSON/YAML equivalent pre-loaded.
     :param magpie_url: URL to magpie instance (when using requests; default: `magpie.url` from this app's config).
     :param db_session: db session to use instead of requests to directly create/remove permissions with config.
+    :param raise_errors: raises errors related to permissions, instead of just logging the info.
 
     .. seealso::
         `magpie/config/permissions.cfg` for specific parameters and operational details.
@@ -996,7 +1008,7 @@ def magpie_register_permissions_from_config(permissions_config, magpie_url=None,
         groups_settings = _resolve_config_registry(groups, "name") or {}
     for i, perms in enumerate(permissions):
         LOGGER.info("Processing permissions from configuration (%s/%s).", i + 1, perms_cfg_count)
-        _process_permissions(perms, magpie_url, cookies_or_session, users_settings, groups_settings)
+        _process_permissions(perms, magpie_url, cookies_or_session, users_settings, groups_settings, raise_errors)
     LOGGER.info("All permissions processed.")
 
 
@@ -1025,7 +1037,7 @@ def _resolve_config_registry(config_files, key):
     return config_map
 
 
-def _process_permissions(permissions, magpie_url, cookies_or_session, users=None, groups=None):
+def _process_permissions(permissions, magpie_url, cookies_or_session, users=None, groups=None, raise_errors=False):
     # type: (PermissionsConfig, Str, Session, Optional[UsersSettings], Optional[GroupsSettings]) -> None
     """
     Processes a single `permissions` configuration.
@@ -1040,25 +1052,25 @@ def _process_permissions(permissions, magpie_url, cookies_or_session, users=None
     for i, perm_cfg in enumerate(permissions):
         # parameter validation
         if not isinstance(perm_cfg, dict) or not all(f in perm_cfg for f in ["permission", "service"]):
-            _log_permission("Invalid permission format for [{!s}]".format(perm_cfg), i)
+            _log_permission("Invalid permission format for [{!s}]".format(perm_cfg), i, raise_errors=raise_errors)
             continue
         try:
             perm = PermissionSet(perm_cfg["permission"])
         except (ValueError, TypeError):
             perm = None
         if not perm:
-            _log_permission("Unknown permission [{!s}]".format(perm_cfg["permission"]), i)
+            _log_permission("Unknown permission [{!s}]".format(perm_cfg["permission"]), i, raise_errors=raise_errors)
             continue
         usr_name = perm_cfg.get("user")
         grp_name = perm_cfg.get("group")
         if not any([usr_name, grp_name]):
-            _log_permission("Missing required user and/or group field.", i)
+            _log_permission("Missing required user and/or group field.", i, raise_errors=raise_errors)
             continue
         if "action" not in perm_cfg:
-            _log_permission("Unspecified action", i, trail="using default (create)...")
+            _log_permission("Unspecified action", i, trail="using default (create)...", raise_errors=raise_errors)
             perm_cfg["action"] = "create"
         if perm_cfg["action"] not in ["create", "remove"]:
-            _log_permission("Unknown action [{!s}]".format(perm_cfg["action"]), i)
+            _log_permission("Unknown action [{!s}]".format(perm_cfg["action"]), i, raise_errors=raise_errors)
             continue
 
         # retrieve service for permissions validation
@@ -1067,24 +1079,27 @@ def _process_permissions(permissions, magpie_url, cookies_or_session, users=None
             svc_path = magpie_url + ServiceAPI.path.format(service_name=svc_name)
             svc_resp = requests.get(svc_path, cookies=cookies_or_session)
             if svc_resp.status_code != 200:
-                _log_permission("Unknown service [{!s}]".format(svc_name), i)
+                _log_permission("Unknown service [{!s}]".format(svc_name), i, raise_errors=raise_errors)
                 continue
             service_info = get_json(svc_resp)[svc_name]
         else:
             transaction.commit()    # force any pending transaction to be applied to find possible dependencies
             svc = models.Service.by_service_name(svc_name, db_session=cookies_or_session)
             if not svc:
-                _log_permission("Unknown service [{!s}]. Can't edit permissions without service.".format(svc_name), i)
+                _log_permission("Unknown service [{!s}]. Can't edit permissions without service.".format(svc_name), i,
+                                raise_errors=raise_errors)
                 continue
             from magpie.api.management.service.service_formats import format_service
             service_info = format_service(svc)
 
         # apply permission config
-        resource_id, found = _parse_resource_path(perm_cfg, i, service_info, cookies_or_session, magpie_url)
+        resource_id, found = _parse_resource_path(perm_cfg, i, service_info, cookies_or_session, magpie_url,
+                                                  raise_errors)
         if found:
             if not resource_id:
                 resource_id = service_info["resource_id"]
-            _apply_permission_entry(perm_cfg, i, resource_id, cookies_or_session, magpie_url, users, groups)
+            _apply_permission_entry(perm_cfg, i, resource_id, cookies_or_session, magpie_url, users, groups,
+                                    raise_errors)
 
     if not _use_request(cookies_or_session):
         transaction.commit()

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -754,7 +754,7 @@ def _parse_resource_path(permission_config_entry,   # type: PermissionConfigItem
                 resource_type_list = resource_type_list * len(resource_list)
             if len(resource_list) != len(resource_type_list):
                 raise RegistrationConfigurationError("Invalid resource type found in configuration : " +
-                                                     permission_config_entry.get('type'))
+                                                     permission_config_entry.get("type"))
 
             res_path = None
             if _use_request(cookies_or_session):

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2420,7 +2420,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
             """
             Utility function that checks if resource and permissions found in data were succesfully create/removed.
             """
-            path = f"/services/{self.test_service_name}/resources"
+            path = "/services/{}/resources".format(self.test_service_name)
             resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
             resources = utils.check_response_basic_info(resp)[self.test_service_name]["resources"]
 
@@ -2433,14 +2433,14 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                 if perm_entry.get("permission"):
                     perm = perm_entry["permission"]
                     if isinstance(perm, dict):
-                        perm = f"{perm['name']}-{perm['access']}-{perm['scope']}"
+                        perm = "{}-{}-{}".format(perm['name'], perm['access'], perm['scope'])
                     check_paths = []
                     if perm_entry.get("user"):
                         check_paths.append(
-                            f"/users/{self.test_user_name}/resources/{target_res['resource_id']}/permissions")
+                            "/users/{}/resources/{}/permissions".format(self.test_user_name, target_res['resource_id']))
                     if perm_entry.get("group"):
-                        check_paths.append(
-                            f"/groups/{self.test_group_name}/resources/{target_res['resource_id']}/permissions")
+                        check_paths.append("/groups/{}/resources/{}/permissions".format(
+                            self.test_group_name, target_res['resource_id']))
                     for path in check_paths:
                         resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
                         body = utils.check_response_basic_info(resp)

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2432,13 +2432,15 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
 
                 if perm_entry.get("permission"):
                     perm = perm_entry["permission"]
-                    if type(perm) is dict:
+                    if isinstance(perm, dict):
                         perm = f"{perm['name']}-{perm['access']}-{perm['scope']}"
                     check_paths = []
                     if perm_entry.get("user"):
-                        check_paths.append(f"/users/{self.test_user_name}/resources/{target_res['resource_id']}/permissions")
+                        check_paths.append(
+                            f"/users/{self.test_user_name}/resources/{target_res['resource_id']}/permissions")
                     if perm_entry.get("group"):
-                        check_paths.append(f"/groups/{self.test_group_name}/resources/{target_res['resource_id']}/permissions")
+                        check_paths.append(
+                            f"/groups/{self.test_group_name}/resources/{target_res['resource_id']}/permissions")
                     for path in check_paths:
                         resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
                         body = utils.check_response_basic_info(resp)

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2292,8 +2292,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                 {
                     "resource_name": resource_names[1],
                     "resource_type": "directory",
-                    # "permission": "browse",
-                    # "group": self.test_group_name
+                    "permission": "browse",
+                    "group": self.test_group_name
                 },
                 {
                     "resource_name": resource_names[2],
@@ -2303,7 +2303,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                         "access": "deny",
                         "scope": "match"
                     },
-                    "user": self.test_user_name
+                    "user": "blarg"#self.test_user_name
                 }
             ]
         }

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2501,7 +2501,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/permissions"
         resp = utils.test_request(self, "PATCH", path, headers=self.json_headers, expect_errors=True,
                                   cookies=self.cookies, json=data)
-        utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        body = utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        utils.check_error_param_structure(body)
 
         # Test with invalid user
         data = {
@@ -2517,7 +2518,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/permissions"
         resp = utils.test_request(self, "PATCH", path, headers=self.json_headers, expect_errors=True,
                                   cookies=self.cookies, json=data)
-        utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        body = utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        utils.check_error_param_structure(body)
 
     @runner.MAGPIE_TEST_PERMISSIONS
     def test_PatchPermissions_InvalidResourceType(self):
@@ -2533,7 +2535,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/permissions"
         resp = utils.test_request(self, "PATCH", path, headers=self.json_headers, expect_errors=True,
                                   cookies=self.cookies, json=data)
-        utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        body = utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        utils.check_error_param_structure(body, param_value=data["permissions"])
 
         # Test with invalid resource
         data = {
@@ -2552,7 +2555,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/permissions"
         resp = utils.test_request(self, "PATCH", path, headers=self.json_headers, expect_errors=True,
                                   cookies=self.cookies, json=data)
-        utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        body = utils.check_response_basic_info(resp, 400, expected_method="PATCH")
+        utils.check_error_param_structure(body, param_value=data["permissions"])
 
     def create_validate_permissions(self,
                                     test_user_name,                     # type: Str

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2416,7 +2416,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                                   cookies=self.cookies, json=data)
         utils.check_response_basic_info(resp, 200, expected_method="PATCH")
 
-        def check_permissions(data):
+        def check_permissions(permissions_data):
             """
             Utility function that checks if resource and permissions found in data were succesfully create/removed.
             """
@@ -2424,7 +2424,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
             resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
             resources = utils.check_response_basic_info(resp)[self.test_service_name]["resources"]
 
-            for perm_entry in data["permissions"][1:]:  # skip first resource, which is the service
+            for perm_entry in permissions_data["permissions"][1:]:  # skip first resource, which is the service
                 target_res = [res for res in resources.values() if res["resource_name"] == perm_entry["resource_name"]]
                 # target resource should exist
                 assert len(target_res) == 1

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2433,14 +2433,14 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                 if perm_entry.get("permission"):
                     perm = perm_entry["permission"]
                     if isinstance(perm, dict):
-                        perm = "{}-{}-{}".format(perm['name'], perm['access'], perm['scope'])
+                        perm = "{}-{}-{}".format(perm["name"], perm["access"], perm["scope"])
                     check_paths = []
                     if perm_entry.get("user"):
                         check_paths.append(
-                            "/users/{}/resources/{}/permissions".format(self.test_user_name, target_res['resource_id']))
+                            "/users/{}/resources/{}/permissions".format(self.test_user_name, target_res["resource_id"]))
                     if perm_entry.get("group"):
                         check_paths.append("/groups/{}/resources/{}/permissions".format(
-                            self.test_group_name, target_res['resource_id']))
+                            self.test_group_name, target_res["resource_id"]))
                     for path in check_paths:
                         resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
                         body = utils.check_response_basic_info(resp)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -531,12 +531,12 @@ def test_register_process_permissions_from_multiple_files():
     expect_users = {"usr1": cfg1["users"][0], "usr2": cfg1["users"][1], "usr3": cfg2["users"][0]}
     expect_groups = {"grp1": cfg1["groups"][0], "grp2": cfg1["groups"][1]}
 
-    perms, _, _, users, groups = mock_process_perms.call_args_list[0].args
+    perms, _, _, users, groups, _ = mock_process_perms.call_args_list[0].args
     assert perms == cfg1["permissions"]
     assert users == expect_users
     assert groups == expect_groups
 
-    perms, _, _, users, groups = mock_process_perms.call_args_list[1].args
+    perms, _, _, users, groups, _ = mock_process_perms.call_args_list[1].args
     assert perms == cfg2["permissions"]
     assert users == expect_users
     assert groups == expect_groups


### PR DESCRIPTION
Content of this PR :

* Add ``PATCH /permissions`` endpoint that updates permissions and creates related resources if necessary.
* ``permissions.cfg`` now supports a new format for the ``type`` parameter, using multiple types separated
  by a slash character, matching each type with each resource found in the ``resource`` parameter.