### PR TITLE
query params for listing resources by parents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
+* Add ``parents``, ``flatten`` and ``invert`` query parameters for request ``GET /resources/{id}`` allowing listing
+  of the hierarchy of *parent* resources leading down to that requested ``Resource``, rather than listing all possible
+  *children* resources branches under it. Combined with the ``flatten`` and/or ``invert`` parameters, the representation
+  format and order of returned resources can also be adjusted.
 * Refactor `OpenAPI` schema definitions for query parameters to ensure proper names are reused across endpoints.
 
 Bug Fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Refactor `OpenAPI` schema definitions for query parameters to ensure proper names are reused across endpoints.
+
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Update linting configuration rules to validate all migration scripts employed by ``alembic``.

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -46,6 +46,7 @@ def get_resource_view(request):
     """
     resource = ar.get_resource_matchdict_checked(request)
     parents = asbool(ar.get_query_param(request, ["parents", "parent"], False))
+    flatten = False
     if parents:
         flatten = asbool(ar.get_query_param(request, ["flatten", "flattened", "list"], False))
         invert = asbool(ar.get_query_param(request, ["invert", "inverted"], False))
@@ -93,7 +94,8 @@ def get_resource_view(request):
             fallback=lambda: request.db.rollback(), http_error=HTTPInternalServerError,
             msg_on_fail=s.Resource_GET_InternalServerErrorResponseSchema.description,
             content={"resource": rf.format_resource(resource, basic_info=False)})
-    return ax.valid_http(http_success=HTTPOk, content={"resource": res_json},
+    res_key = "resources" if flatten else "resource"
+    return ax.valid_http(http_success=HTTPOk, content={res_key: res_json},
                          detail=s.Resource_GET_OkResponseSchema.description)
 
 

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from pyramid.httpexceptions import HTTPBadRequest, HTTPConflict, HTTPForbidden, HTTPInternalServerError, HTTPOk
 from pyramid.settings import asbool
 from pyramid.view import view_config
@@ -13,6 +15,9 @@ from magpie.api.management.service.service_utils import get_services_by_type
 from magpie.permissions import PermissionType, format_permissions
 from magpie.register import sync_services_phoenix
 from magpie.services import SERVICE_TYPE_DICT, get_resource_child_allowed
+
+if TYPE_CHECKING:
+    from magpie.typedefs import NestingKeyType
 
 
 @s.ResourcesAPI.get(tags=[s.ResourcesTag], response_schemas=s.Resources_GET_responses)
@@ -40,10 +45,54 @@ def get_resource_view(request):
     Get resource information.
     """
     resource = ar.get_resource_matchdict_checked(request)
-    res_json = ax.evaluate_call(lambda: rf.format_resource_with_children(resource, db_session=request.db),
-                                fallback=lambda: request.db.rollback(), http_error=HTTPInternalServerError,
-                                msg_on_fail=s.Resource_GET_InternalServerErrorResponseSchema.description,
-                                content={"resource": rf.format_resource(resource, basic_info=False)})
+    parents = asbool(ar.get_query_param(request, ["parents", "parent"], False))
+    if parents:
+        flatten = asbool(ar.get_query_param(request, ["flatten", "flattened", "list"], False))
+        invert = asbool(ar.get_query_param(request, ["invert", "inverted"], False))
+        # listing as "requested-ressource -> ... -> root-service"
+        res_parents = ax.evaluate_call(lambda: ru.get_resource_parents(resource, db_session=request.db),
+                                       fallback=lambda: request.db.rollback(), http_error=HTTPInternalServerError,
+                                       msg_on_fail=s.Resource_GET_InternalServerErrorResponseSchema.description,
+                                       content={"resource": rf.format_resource(resource, basic_info=False)})
+
+        # When using nested objects, top-most is handled differently because of normal children hierarchy
+        # in order to report the service details. When using listing, they are all processed the same way.
+        if invert:
+            # listing of parents, but inverted to obtain "root-service -> ... -> requested-ressource"
+            # therefore, nested items are back to being children once again
+            nesting = "children"  # type: NestingKeyType
+            top_res = res_parents[-1]  # service
+            sub_res = reversed(res_parents[:-1])
+        else:
+            nesting = "parent"
+            top_res = res_parents[0]
+            sub_res = res_parents[1:]
+        if flatten:
+            res_json = ax.evaluate_call(
+                lambda: rf.format_resources_listed(res_parents, db_session=request.db),
+                fallback=lambda: request.db.rollback(), http_error=HTTPInternalServerError,
+                msg_on_fail=s.Resource_GET_InternalServerErrorResponseSchema.description,
+                content={"resource": rf.format_resource(resource, basic_info=False)})
+        else:
+            res_nested = {}  # nest resources bottom-up
+            for parent_res in reversed(list(sub_res)):  # in case reverse the reversed list... avoid error
+                res_nested = {parent_res.resource_id: {"node": parent_res, "children": res_nested}}
+            res_json = ax.evaluate_call(
+                lambda: rf.format_resources_nested(top_res, res_nested, nesting_key=nesting, db_session=request.db),
+                fallback=lambda: request.db.rollback(), http_error=HTTPInternalServerError,
+                msg_on_fail=s.Resource_GET_InternalServerErrorResponseSchema.description,
+                content={"resource": rf.format_resource(resource, basic_info=False)})
+    else:
+        res_children = ax.evaluate_call(
+            lambda: ru.get_resource_children(resource, request.db),
+            fallback=lambda: request.db.rollback(), http_error=HTTPInternalServerError,
+            msg_on_fail=s.Resource_GET_InternalServerErrorResponseSchema.description,
+            content={"resource": rf.format_resource(resource, basic_info=False)})
+        res_json = ax.evaluate_call(
+            lambda: rf.format_resources_nested(resource, res_children, nesting_key="children", db_session=request.db),
+            fallback=lambda: request.db.rollback(), http_error=HTTPInternalServerError,
+            msg_on_fail=s.Resource_GET_InternalServerErrorResponseSchema.description,
+            content={"resource": rf.format_resource(resource, basic_info=False)})
     return ax.valid_http(http_success=HTTPOk, content={"resource": res_json},
                          detail=s.Resource_GET_OkResponseSchema.description)
 

--- a/magpie/api/management/service/service_views.py
+++ b/magpie/api/management/service/service_views.py
@@ -69,7 +69,7 @@ def get_services_runner(request):
     and query parameters.
     """
     service_type_filter = request.matchdict.get("service_type")  # no check because None/empty is for 'all services'
-    services_as_list = asbool(ar.get_query_param(request, ["flatten", "list"], False))
+    services_as_list = asbool(ar.get_query_param(request, ["flatten", "flattened", "list"], False))
     known_service_types = list(SERVICE_TYPE_DICT)
 
     # using '/services?type={}' query (allow many, no error if unknown)

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -352,7 +352,7 @@ def get_user_services_view(request):
     cascade_resources = asbool(ar.get_query_param(request, "cascade"))
     inherit_groups_perms = asbool(ar.get_query_param(request, ["inherit", "inherited"]))
     resolve_groups_perms = asbool(ar.get_query_param(request, ["resolve", "resolved"]))
-    format_as_list = asbool(ar.get_query_param(request, ["flatten", "list"]))
+    format_as_list = asbool(ar.get_query_param(request, ["flatten", "flattened", "list"]))
     service_types = ar.get_query_param(request, ["type", "types"], default="")
     service_types = su.filter_service_types(service_types)  # don't use default service types to populate response
 

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -516,21 +516,21 @@ class QueryFilterResources(colander.MappingSchema):
 
 class QueryParentResources(colander.MappingSchema):
     parents = colander.SchemaNode(
-        colander.Boolean(), name="parent", default=False, missing=colander.drop,
+        colander.Boolean(), name="parents", default=False, missing=colander.drop,
         description=(
             "Obtain parent resources of the requested resource by ID instead of its children hierarchy. "
-            "The requested resource by ID will be the top-most object with nested 'parents' field "
+            "The requested resource by ID will be the top-most object with nested 'parent' field "
             "(instead of 'children' when 'parents=false') going all the way down to the root service of that resource. "
             "Contrary to children hierarchy representation that can branch out over multiple children resources, "
             "parent resources are guaranteed to have a single branch (each resource can only have one parent). "
             "For this reason, it is possible to combine this parameter with 'flatten' and 'invert' to list resources "
-            "in different orders and formats. These other queries are ignored when 'parents=false'."
+            "in a different order and/or format. These other queries are ignored when 'parents=false'."
         )
     )
     flatten = colander.SchemaNode(
         colander.Boolean(), name="flatten", default=False, missing=colander.drop,
         description=(
-            "Only when 'parents=true', returns elements as a flattened list of JSON objects instead of default "
+            "Applies only when 'parents=true'. Returns elements as a flattened list of JSON objects instead of default "
             "response format as nested objects with resource ID keys and parent resource definitions under them. "
             "Can be combined with 'invert' query to reverse the order of resource items in the returned list."
         )
@@ -538,14 +538,14 @@ class QueryParentResources(colander.MappingSchema):
     invert = colander.SchemaNode(
         colander.Boolean(), name="invert", default=False, missing=colander.drop,
         description=(
-            "Only when 'parents=true', returns elements in the inverse order, going from top-most service "
-            "down to the requested resource by ID listing all its intermediate children. This is different "
-            "than 'parents=false' where the complete children hierarchy *under the requested resource ID* are "
-            "returned, with all possible branches. When this option combined with 'parent', only the resources "
-            "on the specific branch linking the root service to the requested resource by ID are returned instead "
-            "of the full hierarchy, effectively returning the resource hierarchy *above the requested resource ID*. "
-            "Note that for this reason, the requested resource will always be the last/deepest item returned, even "
-            "if it does have children resources in reality."
+            "Applies only when 'parents=true'. Returns elements in the inverse order, going from top-most service "
+            "down to (at most) the requested resource by ID listing all its intermediate children. This is different "
+            "than using 'parents=false' where the complete children hierarchy *under the requested resource ID* are "
+            "returned, with all possible branches. When this option is combined with 'parent', only the resources "
+            "on the specific branch directly linking the root service to the requested resource by ID are returned "
+            "instead of the full hierarchy, effectively only returning the resource "
+            "hierarchy *above the requested resource ID*. Note that for this reason, the requested resource will "
+            "always be the last/deepest item returned, even if it could have more children resources in reality. "
             "Can be combined with 'flatten' query to obtain a list instead of nested objects."
         )
     )
@@ -1155,6 +1155,7 @@ class Resource_MatchDictCheck_BadRequestResponseSchema(BaseResponseSchemaAPI):
 
 class Resource_GET_ResponseBodySchema(BaseResponseBodySchema):
     # FIXME: OneOf required for alternatives (keys "parents" instead of "children", list representation)
+    #       When using list, 'resources' is used since many are under the same array field.
     resource = Resource_ParentResourceWithChildrenContainerBodySchema()
 
 

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
         from typing import TypedDict  # pylint: disable=E0611,no-name-in-module
     else:
         from typing_extensions import TypedDict  # noqa
+    if hasattr(typing, "Literal"):
+        from typing import Literal  # pylint: disable=E0611,no-name-in-module
+    else:
+        from typing_extensions import Literal  # noqa
 
     # pylint: disable=W0611,unused-import  # following definitions provided to be employed elsewhere in the code
 
@@ -63,17 +67,22 @@ if TYPE_CHECKING:
     BaseJSON = Union[AnyValue, List["JSON"], Dict[AnyKey, "JSON"]]
     JSON = Union[Dict[Str, Union[BaseJSON, "JSON"]], List[BaseJSON]]
 
-    # recursive nodes structure employed by functions for listing children resources hierarchy
-    # {<res-id>: {"node": <res>, "children": {<res-id>: ... }}
-    ChildrenResourceNodes = Dict[int, Dict[Str, Union[models.Resource, "ChildrenResourceNodes"]]]
-    ResourcePermissionMap = Dict[int, List[PermissionSet]]  # raw mapping of permission-names applied per resource ID
-
     GroupPriority = Union[int, Type[math.inf]]
     UserServicesType = Union[Dict[Str, Dict[Str, Any]], List[Dict[Str, Any]]]
     ServiceOrResourceType = Union[models.Service, models.Resource]
     PermissionDict = TypedDict("PermissionDict",
                                {"name": Str, "access": Optional[Str], "scope": Optional[Str],
                                 "type": Optional[Str], "reason": Optional[Str]}, total=False)
+    # recursive nodes structure employed by functions for listing children resources hierarchy
+    # {<res-id>: {"node": <res>, "children": {<res-id>: ... }}
+    NestedResourceNodes = Dict[int, "ResourceNode"]
+    ResourceNode = TypedDict("ResourceNode", {
+        "node": ServiceOrResourceType,
+        "children": NestedResourceNodes
+    }, total=True)
+    ResourcePermissionMap = Dict[int, List[PermissionSet]]  # raw mapping of permission-names applied per resource ID
+    NestingKeyType = Literal["children", "parent"]
+
     AnyZigguratPermissionType = Union[
         models.GroupPermission,
         models.UserPermission,


### PR DESCRIPTION
## Changes
* Add ``parents``, ``flatten`` and ``invert`` query parameters for request ``GET /resources/{id}`` allowing listing
  of the hierarchy of *parent* resources leading down to that requested ``Resource``, rather than listing all possible
  *children* resources branches under it. Combined with the ``flatten`` and/or ``invert`` parameters, the representation
  format and order of returned resources can also be adjusted.
* Refactor `OpenAPI` schema definitions for query parameters to ensure proper names are reused across endpoints.

Resolves [DAC-458](https://www.crim.ca/jira/browse/DAC-458)