### PR TITLE
MagpieAdapter request/response hooks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,7 @@ jobs:
           hash -r
           env | sort
       - name: Run Tests
-        run: make stop ${{ matrix.test-case }}
+        run: make stop ${{ matrix.test-case }} TEST_LOG_LEVEL=WARNING
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
         if: ${{ success() && matrix.test-case == 'coverage' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,8 +113,9 @@ jobs:
         run: |
           hash -r
           env | sort
+      # run '-only' test variations since dependencies are preinstalled, skip some resolution time
       - name: Run Tests
-        run: ${{ matrix.test-option }} make stop ${{ matrix.test-case }}
+        run: ${{ matrix.test-option }} make stop ${{ matrix.test-case }}-only
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
         if: ${{ success() && matrix.test-case == 'coverage' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
         python-version: ["3.6", "3.7", "3.8"]
         allow-failure: [false]
         test-case: [test-local]
+        # can use below option to set environment variables or makefile settings applied during test execution
         test-option: [""]
         include:
           # linter tests
@@ -85,11 +86,11 @@ jobs:
             allow-failure: true
             test-case: test-docker
           # --- debug ---
-          - os: ubuntu-latest
-            python-version: 3.7
-            allow-failure: false
-            test-case: test-custom
-            test-option: MAGPIE_LOG_LEVEL=DEBUG TEST_LOG_LEVEL=DEBUG SPEC='test_import_target or TestAdapterHooks'
+          # - os: ubuntu-latest
+          #   python-version: 3.7
+          #   allow-failure: false
+          #   test-case: test-custom
+          #   test-option: MAGPIE_LOG_LEVEL=DEBUG TEST_LOG_LEVEL=DEBUG SPEC='test_import_target or TestAdapterHooks'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
         python-version: ["3.6", "3.7", "3.8"]
         allow-failure: [false]
         test-case: [test-local]
+        test-option: [""]
         include:
           # linter tests
           - os: ubuntu-latest
@@ -83,6 +84,12 @@ jobs:
             python-version: none
             allow-failure: true
             test-case: test-docker
+          # --- debug ---
+          - os: ubuntu-latest
+            python-version: 3.7
+            allow-failure: false
+            test-case: test-custom
+            test-option: MAGPIE_LOG_LEVEL=DEBUG TEST_LOG_LEVEL=DEBUG SPEC='test_import_target or TestAdapterHooks'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -107,7 +114,7 @@ jobs:
           hash -r
           env | sort
       - name: Run Tests
-        run: make stop ${{ matrix.test-case }} TEST_LOG_LEVEL=WARNING
+        run: ${{ matrix.test-option }} make stop ${{ matrix.test-case }}
       - name: Upload coverage report
         uses: codecov/codecov-action@v2
         if: ${{ success() && matrix.test-case == 'coverage' }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,15 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add JSON schema validation of loaded `Service` configuration (``providers.cfg``).
+* Add optional ``hooks`` section under each `Service` definition of the ``providers.cfg`` or combined configuration
+  file that allows pre/post request/response processing operations using plugin Python scripts.
+* Store the validated `Service` configuration in ``magpie.services`` settings for later access to ``hooks`` definitions
+  by the ``MagpieAdapter``.
+* Rename the ``webhooks`` section stored in settings to ``magpie.webhooks`` to avoid possible name clashes.
+
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix typo in UI edit user page when listing order of resolution of permissions.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Features / Changes
 * Add JSON schema validation of loaded `Service` configuration (``providers.cfg``).
 * Add optional ``hooks`` section under each `Service` definition of the ``providers.cfg`` or combined configuration
   file that allows pre/post request/response processing operations using plugin Python scripts.
+* Add settings/environment variable ``MAGPIE_PROVIDERS_HOOKS_PATH`` to override the base directory where hook ``target``
+  functions can be found when relative references are employed.
 * Store the validated `Service` configuration in ``magpie.services`` settings for later access to ``hooks`` definitions
   by the ``MagpieAdapter``.
 * Rename the ``webhooks`` section stored in settings to ``magpie.webhooks`` to avoid possible name clashes.
@@ -21,6 +23,7 @@ Features / Changes
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix typo in UI edit user page when listing order of resolution of permissions.
+* Apply multiple typing improvements and fixes.
 
 .. _changes_3.24.0:
 

--- a/Dockerfile.adapter
+++ b/Dockerfile.adapter
@@ -3,7 +3,7 @@
 #   docker run will need to override ini file with mounted volume
 #   using config 'twitcher.adapter = magpie.adapter.MagpieAdapter'
 #
-FROM birdhouse/twitcher:v0.6.2
+FROM birdhouse/twitcher:v0.7.0
 LABEL Description="Configures MagpieAdapter on top of Twitcher application."
 LABEL Maintainer="Francis Charette-Migneault <francis.charette-migneault@crim.ca>"
 LABEL Vendor="CRIM"

--- a/Makefile
+++ b/Makefile
@@ -663,7 +663,7 @@ TEST_VERBOSITY ?= -vv
 # log calls will be collected if greater or equal to this value during tests
 TEST_LOG_LEVEL ?=
 ifneq ($(TEST_LOG_LEVEL),)
-  TEST_LOG_LEVEL = --log-cli-level $(TEST_LOG_LEVEL)
+  override TEST_LOG_LEVEL := --log-cli-level $(shell echo $(TEST_LOG_LEVEL) | tr '[:lower:]' '[:upper:]')
 endif
 
 # autogen tests variants with pre-install of dependencies using the '-only' target references
@@ -694,7 +694,7 @@ test-cli-only: 		## run only CLI tests with the environment Python
 .PHONY: test-local-only
 test-local-only: 		## run only local tests with the environment Python
 	@echo "Running local tests..."
-	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
+	bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
  		-m "not remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-remote-only

--- a/Makefile
+++ b/Makefile
@@ -695,7 +695,7 @@ test-cli-only: 		## run only CLI tests with the environment Python
 test-local-only: 		## run only local tests with the environment Python
 	@echo "Running local tests..."
 	bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
- 		-m "not remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
+		-m "not remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-remote-only
 test-remote-only:		## run only remote tests with the environment Python
@@ -703,12 +703,14 @@ test-remote-only:		## run only remote tests with the environment Python
 	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
 		-m "remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
+# https://docs.pytest.org/en/7.1.x/example/markers.html#mark-examples
+# https://docs.pytest.org/en/7.1.x/example/markers.html#using-k-expr-to-select-tests-based-on-their-name
 .PHONY: test-custom-only
-test-custom-only:		## run custom marker tests using SPEC="<marker-specification>"
+test-custom-only:		## run custom tests [example: SPEC="<marker1> or (<marker2> and not test_func or TestClass)"]
 	@echo "Running custom tests..."
 	@[ "${SPEC}" ] || ( echo ">> 'SPEC' is not set"; exit 1 )
 	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
- 		-m "${SPEC}" --junitxml "$(APP_ROOT)/tests/results.xml"'
+		-k "${SPEC}" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-docker
 test-docker: docker-test  ## run test with docker (alias for 'docker-test' target) - WARNING: build image if missing

--- a/Makefile
+++ b/Makefile
@@ -659,6 +659,12 @@ fix-css-only: mkdir-reports install-npm		## fix CSS styles problems automaticall
 # -v:  list of test names with PASS/FAIL/SKIP/ERROR/etc. next to it
 # -vv: extended collection of stdout/stderr on top of test results
 TEST_VERBOSITY ?= -vv
+# any valid log level: DEBUG|INFO|WARNING|ERROR|FATAL|CRITICAL
+# log calls will be collected if greater or equal to this value during tests
+TEST_LOG_LEVEL ?=
+ifneq ($(TEST_LOG_LEVEL),)
+  TEST_LOG_LEVEL = --log-cli-level $(TEST_LOG_LEVEL)
+endif
 
 # autogen tests variants with pre-install of dependencies using the '-only' target references
 TESTS := cli local remote custom
@@ -675,29 +681,34 @@ test-all: install install-dev test-only  ## run all tests (including long runnin
 .PHONY: test-only
 test-only: mkdir-reports		 ## run all tests combinations without pre-installation of dependencies
 	@echo "Running tests..."
-	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) --junitxml "$(APP_ROOT)/tests/results.xml"'
+	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
+		--junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-cli-only
 test-cli-only: 		## run only CLI tests with the environment Python
 	@echo "Running local tests..."
-	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) -m "cli" --junitxml "$(APP_ROOT)/tests/results.xml"'
+	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
+		-m "cli" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 # note: use 'not remote' instead of 'local' to capture other low-level tests like 'utils' unittests
 .PHONY: test-local-only
 test-local-only: 		## run only local tests with the environment Python
 	@echo "Running local tests..."
-	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) -m "not remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
+	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
+ 		-m "not remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-remote-only
 test-remote-only:		## run only remote tests with the environment Python
 	@echo "Running remote tests..."
-	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) -m "remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
+	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
+		-m "remote" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-custom-only
 test-custom-only:		## run custom marker tests using SPEC="<marker-specification>"
 	@echo "Running custom tests..."
 	@[ "${SPEC}" ] || ( echo ">> 'SPEC' is not set"; exit 1 )
-	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) -m "${SPEC}" --junitxml "$(APP_ROOT)/tests/results.xml"'
+	@bash -c '$(CONDA_CMD) pytest tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) \
+ 		-m "${SPEC}" --junitxml "$(APP_ROOT)/tests/results.xml"'
 
 .PHONY: test-docker
 test-docker: docker-test  ## run test with docker (alias for 'docker-test' target) - WARNING: build image if missing
@@ -709,7 +720,7 @@ COVERAGE_HTML_IDX := $(COVERAGE_HTML_DIR)/index.html
 $(COVERAGE_FILE): install-dev
 	@echo "Running coverage analysis..."
 	@bash -c '$(CONDA_CMD) coverage run --source "$(APP_ROOT)/$(APP_NAME)" \
-		`which pytest` tests -m "not remote" || true'
+		`which pytest` tests $(TEST_VERBOSITY) $(TEST_LOG_LEVEL) -m "not remote" || true'
 	@bash -c '$(CONDA_CMD) coverage xml -i -o "$(REPORTS_DIR)/coverage.xml"'
 	@bash -c '$(CONDA_CMD) coverage report -m'
 	@bash -c '$(CONDA_CMD) coverage html -d "$(COVERAGE_HTML_DIR)"'

--- a/Makefile
+++ b/Makefile
@@ -715,6 +715,9 @@ test-custom-only:		## run custom tests [example: SPEC="<marker1> or (<marker2> a
 .PHONY: test-docker
 test-docker: docker-test  ## run test with docker (alias for 'docker-test' target) - WARNING: build image if missing
 
+# for consistency only with other test
+test-docker-only: test-docker ## run test with docker (alias for 'docker-test' target) - WARNING: build image if missing
+
 # coverage file location cannot be changed
 COVERAGE_FILE     := $(APP_ROOT)/.coverage
 COVERAGE_HTML_DIR := $(REPORTS_DIR)/coverage

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,9 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
 .. start-badges
 
 .. list-table::
+    :header-rows: 0
     :stub-columns: 1
+    :widths: 10,90
 
     * - dependencies
       - | |py_ver| |dependencies|

--- a/ci/magpie.env
+++ b/ci/magpie.env
@@ -19,6 +19,7 @@ MAGPIE_TEST_ADMIN_USERNAME=unittest-admin
 MAGPIE_TEST_ADMIN_PASSWORD=
 # point to sources "magpie/config" dir in travis or locally
 MAGPIE_CONFIG_DIR=${TRAVIS_BUILD_DIR:-.}/config
+MAGPIE_PROVIDERS_HOOKS_PATH=${TRAVIS_BUILD_DIR:-.}
 TWITCHER_HOST=localhost
 PHOENIX_PUSH=false
 HOSTNAME=localhost

--- a/ci/magpie.env
+++ b/ci/magpie.env
@@ -18,8 +18,8 @@ MAGPIE_TEST_ADMIN_USERNAME=unittest-admin
 # auto-generate password
 MAGPIE_TEST_ADMIN_PASSWORD=
 # point to sources "magpie/config" dir in travis or locally
-MAGPIE_CONFIG_DIR="$(realpath ${TRAVIS_BUILD_DIR:-.}/config)"
-MAGPIE_PROVIDERS_HOOKS_PATH="$(realpath ${TRAVIS_BUILD_DIR:-.})"
+MAGPIE_CONFIG_DIR="$(realpath ${GITHUB_WORKSPACE:-.}/config)"
+MAGPIE_PROVIDERS_HOOKS_PATH="$(realpath ${GITHUB_WORKSPACE:-.})"
 TWITCHER_HOST=localhost
 PHOENIX_PUSH=false
 HOSTNAME=localhost

--- a/ci/magpie.env
+++ b/ci/magpie.env
@@ -18,8 +18,8 @@ MAGPIE_TEST_ADMIN_USERNAME=unittest-admin
 # auto-generate password
 MAGPIE_TEST_ADMIN_PASSWORD=
 # point to sources "magpie/config" dir in travis or locally
-MAGPIE_CONFIG_DIR="$(realpath ${GITHUB_WORKSPACE:-.}/config)"
-MAGPIE_PROVIDERS_HOOKS_PATH="$(realpath ${GITHUB_WORKSPACE:-.})"
+MAGPIE_CONFIG_DIR=/home/runner/work/Magpie/Magpie/config
+MAGPIE_PROVIDERS_HOOKS_PATH=/home/runner/work/Magpie/Magpie
 TWITCHER_HOST=localhost
 PHOENIX_PUSH=false
 HOSTNAME=localhost

--- a/ci/magpie.env
+++ b/ci/magpie.env
@@ -18,8 +18,8 @@ MAGPIE_TEST_ADMIN_USERNAME=unittest-admin
 # auto-generate password
 MAGPIE_TEST_ADMIN_PASSWORD=
 # point to sources "magpie/config" dir in travis or locally
-MAGPIE_CONFIG_DIR=${TRAVIS_BUILD_DIR:-.}/config
-MAGPIE_PROVIDERS_HOOKS_PATH=${TRAVIS_BUILD_DIR:-.}
+MAGPIE_CONFIG_DIR="$(realpath ${TRAVIS_BUILD_DIR:-.}/config)"
+MAGPIE_PROVIDERS_HOOKS_PATH="$(realpath ${TRAVIS_BUILD_DIR:-.})"
 TWITCHER_HOST=localhost
 PHOENIX_PUSH=false
 HOSTNAME=localhost

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -147,19 +147,25 @@ providers:
     type: api
     sync_type: api
     hooks:
+      # NOTE: 'target' relative to MAGPIE_ROOT, not this file position
+      # below hooks are used for testing adapter functionalities
       - type: request
         path: "/processes/[w+_-]/jobs"
         method: POST
-        target: ../tests/hooks/request_hooks.py:add_x_wps_output_context
+        target: tests/hooks/request_hooks.py:add_x_wps_output_context
       - type: request
         path: "/jobs"
         method: POST
-        target: ../tests/hooks/request_hooks.py:add_x_wps_output_context
+        target: tests/hooks/request_hooks.py:add_x_wps_output_context
       - type: response
         path: "/processes/[w+_-]/jobs/[a-z0-9-]+"
         method: GET
-        target: ../tests/hooks/request_hooks.py:add_x_wps_output_link
+        target: tests/hooks/request_hooks.py:add_x_wps_output_link
       - type: response
         path: "/jobs/[a-z0-9-]+"
         method: GET
-        target: ../tests/hooks/request_hooks.py:add_x_wps_output_link
+        target: tests/hooks/request_hooks.py:add_x_wps_output_link
+      - type: response
+        path: "/jobs/[a-z0-9-]+"
+        method: GET
+        target: tests/hooks/request_hooks.py:combined_arguments

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -20,7 +20,7 @@
 #               often equals to 'type' (see: magpie.cli.SYNC_SERVICES_TYPES)
 #   hooks:      list of request processing hooks for the service
 #
-# Hooks:
+# Hooks: (requires Magpie>=3.25.0, Twitcher>=0.7.0)
 # ------
 #   When items are specified and that the *original* request filters match a configuration, the processing hooks are
 #   applied onto the proxied request or response using it. Each hook definition must be provided using the following
@@ -33,19 +33,21 @@
 #       method: <HTTP_METHOD>     [optional] (HEAD|GET|POST|PUT|PATCH|DELETE|*) (default: "*")
 #       target: <FUNCTION_PATH>   [required] location of function to handle hook processing
 #                                            path should be absolute or relative to MAGPIE_ROOT
-#                                            module format must be directly importable
 #                                            (format: 'some/path/script.py:func')
 #     - <next hook>
 #     - <...>
 #
 #   Functions defined by request/response hook must respectively take as input the active request/response in the
 #   processing chain and return an equivalent request/response with desired modifications applied for following ones.
+#   Furthermore, they can specify an optional argument for the service definition that triggered the hook function.
+#   Permitted signatures of hooks are presented in:
+#   https://pavics-magpie.readthedocs.io/en/latest/configuration.html#service-hooks
+#
 #   Each hook that matches is applied iteratively in the listed order, allowing successive modifications of the
-#   request/responses as needed.
-#   When all request hooks are processed, the request is sent to the proxied service to obtain the response. This
-#   response then uses the same matching of the original request to apply response hook processing chain. The final
-#   response is returned if all steps succeeded all returned the expected request/response instances. If an error
-#   occurs or forbidden access happens during the request, following hooks are skipped entirely.
+#   request/responses as needed. When all request hooks are processed, the request is sent to the proxied service to
+#   obtain the response. This response then uses the same matching of the original request to apply response hook
+#   processing chain. The final response is returned if all steps succeeded all returned the expected request/response
+#   instances. If an error occurs or forbidden access happens during the request, following hooks are skipped entirely.
 #
 # Default behaviour:
 # ------------------
@@ -153,3 +155,11 @@ providers:
         path: "/jobs"
         method: POST
         target: ../tests/hooks/request_hooks.py:add_x_wps_output_context
+      - type: response
+        path: "/processes/[w+_-]/jobs/[a-z0-9-]+"
+        method: GET
+        target: ../tests/hooks/request_hooks.py:add_x_wps_output_link
+      - type: response
+        path: "/jobs/[a-z0-9-]+"
+        method: GET
+        target: ../tests/hooks/request_hooks.py:add_x_wps_output_link

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -16,8 +16,36 @@
 #   c4i:        parameter passed down to Phoenix for service registration
 #   type:       service type to use for creation, must be one of the known Magpie service types
 #               (see: magpie.services.SERVICE_TYPE_DICT)
-#   sync_type:  service synchronization type, must be one of the known Magpie service sync-types (often equals to 'type')
-#               (see: magpie.cli.SYNC_SERVICES_TYPES)
+#   sync_type:  service synchronization type, must be one of the known Magpie service sync-types,
+#               often equals to 'type' (see: magpie.cli.SYNC_SERVICES_TYPES)
+#   hooks:      list of request processing hooks for the service
+#
+# Hooks:
+# ------
+#   When items are specified and that the *original* request filters match a configuration, the processing hooks are
+#   applied onto the proxied request or response using it. Each hook definition must be provided using the following
+#   structure under the relevant service.
+#
+#   hooks:
+#     - type: <HOOK_TYPE>         [required] (request|response)
+#       path: <PROXIED_PATH>      [required] service-specific request path / regex pattern (after proxy prefix path)
+#       query: <HTTP_QUERY>       [optional] request query string / regex pattern excluding '?' prefix (default: ".*")
+#       method: <HTTP_METHOD>     [optional] (HEAD|GET|POST|PUT|PATCH|DELETE|*) (default: "*")
+#       target: <FUNCTION_PATH>   [required] location of function to handle hook processing
+#                                            path should be absolute or relative to MAGPIE_ROOT
+#                                            module format must be directly importable
+#                                            (format: 'some/path/script.py:func')
+#     - <next hook>
+#     - <...>
+#
+#   Functions defined by request/response hook must respectively take as input the active request/response in the
+#   processing chain and return an equivalent request/response with desired modifications applied for following ones.
+#   Each hook that matches is applied iteratively in the listed order, allowing successive modifications of the
+#   request/responses as needed.
+#   When all request hooks are processed, the request is sent to the proxied service to obtain the response. This
+#   response then uses the same matching of the original request to apply response hook processing chain. The final
+#   response is returned if all steps succeeded all returned the expected request/response instances. If an error
+#   occurs or forbidden access happens during the request, following hooks are skipped entirely.
 #
 # Default behaviour:
 # ------------------
@@ -108,3 +136,20 @@ providers:
     c4i: false
     type: api
     sync_type: project-api
+
+  weaver:
+    url: http://${HOSTNAME}:4001
+    title: weaver-ogc-api-processes
+    public: true
+    c4i: false
+    type: api
+    sync_type: api
+    hooks:
+      - type: request
+        path: "/processes/[w+_-]/jobs"
+        method: POST
+        target: ../tests/hooks/request_hooks.py:add_x_wps_output_context
+      - type: request
+        path: "/jobs"
+        method: POST
+        target: ../tests/hooks/request_hooks.py:add_x_wps_output_context

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -150,7 +150,7 @@ providers:
       # NOTE: 'target' relative to MAGPIE_ROOT, not this file position
       # below hooks are used for testing adapter functionalities
       - type: request
-        path: "/processes/[w+_-]/jobs"
+        path: "/processes/[\w_-]+/jobs"
         method: POST
         target: tests/hooks/request_hooks.py:add_x_wps_output_context
       - type: request
@@ -158,7 +158,7 @@ providers:
         method: POST
         target: tests/hooks/request_hooks.py:add_x_wps_output_context
       - type: response
-        path: "/processes/[w+_-]/jobs/[a-z0-9-]+"
+        path: "/processes/[\w_-]+/jobs/[a-z0-9-]+"
         method: GET
         target: tests/hooks/request_hooks.py:add_x_wps_output_link
       - type: response

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -147,10 +147,12 @@ providers:
     type: api
     sync_type: api
     hooks:
-      # NOTE: 'target' relative to MAGPIE_ROOT, not this file position
-      # below hooks are used for testing adapter functionalities
+      # NOTES:
+      # - each 'target' is relative to MAGPIE_ROOT, not this file's position
+      # - below hooks are used for testing adapter functionalities
+      # - when using regex special characters (eg: \w), double escape is required due to YAML escape characters
       - type: request
-        path: "/processes/[\w_-]+/jobs"
+        path: "/processes/[\\w_-]+/jobs"
         method: POST
         target: tests/hooks/request_hooks.py:add_x_wps_output_context
       - type: request
@@ -158,7 +160,7 @@ providers:
         method: POST
         target: tests/hooks/request_hooks.py:add_x_wps_output_context
       - type: response
-        path: "/processes/[\w_-]+/jobs/[a-z0-9-]+"
+        path: "/processes/[\\w_-]+/jobs/[a-z0-9-]+"
         method: GET
         target: tests/hooks/request_hooks.py:add_x_wps_output_link
       - type: response

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -32,7 +32,7 @@
 #       query: <HTTP_QUERY>       [optional] request query string / regex pattern excluding '?' prefix (default: ".*")
 #       method: <HTTP_METHOD>     [optional] (HEAD|GET|POST|PUT|PATCH|DELETE|*) (default: "*")
 #       target: <FUNCTION_PATH>   [required] location of function to handle hook processing
-#                                            path should be absolute or relative to MAGPIE_ROOT
+#                                            path should be absolute or relative to 'MAGPIE_PROVIDERS_HOOKS_PATH'
 #                                            (format: 'some/path/script.py:func')
 #     - <next hook>
 #     - <...>
@@ -148,7 +148,7 @@ providers:
     sync_type: api
     hooks:
       # NOTES:
-      # - each 'target' is relative to MAGPIE_ROOT, not this file's position
+      # - each 'target' is relative to 'MAGPIE_PROVIDERS_HOOKS_PATH' (or 'MAGPIE_ROOT'), not this file's position
       # - below hooks are used for testing adapter functionalities
       # - when using regex special characters (eg: \w), double escape is required due to YAML escape characters
       - type: request

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -346,6 +346,19 @@ These settings can be used to specify where to find other settings through custo
     .. warning::
         This setting is ignored if :envvar:`MAGPIE_CONFIG_PATH` is specified.
 
+.. envvar:: MAGPIE_PROVIDERS_HOOKS_PATH
+
+    (Default: :envvar:`MAGPIE_ROOT`)
+
+    Defines the root directory were to look for ``target`` references in :ref:`config_service_hooks` when the
+    provided path is relative.
+
+    .. note::
+        When using the :ref:`Docker <usage_docker>` image, the default :envvar:`MAGPIE_ROOT` corresponds to the
+        source location. When using the installed :ref:`package <usage_package>` (unless ``-e`` was provided to
+        ``pip`` for development installation), this :envvar:`MAGPIE_ROOT` will be located in site-packages of the
+        target `Python` environment.
+
 .. envvar:: MAGPIE_PERMISSIONS_CONFIG_PATH
 
     (Default: ``${MAGPIE_CONFIG_DIR}/permissions.cfg``)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -209,7 +209,7 @@ Each hook must be configured using the following parameters.
 .. list-table::
     :header-rows: 1
     :stub-columns: 1
-    :widths: 10,10,10,70
+    :widths: 10,10,80
 
     * - Field
       - Requirement

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -199,6 +199,10 @@ Service Hooks
 
 .. versionadded:: 3.25
 
+.. warning::
+    Requires `Twitcher`_ version ``0.7.0`` minimally to use this feature. Versions ``0.6.x`` of `Twitcher`_ remain
+    compatible but will not call the adapter hooks as the feature did not exist at that point.
+
 Under each :term:`Service` within `providers.cfg`_ or the :ref:`config_file`, it is possible to provide a section
 named``hooks`` that lists additional pre/post request/response processing operations to apply when matched against
 the given request filter conditions. These hooks are plugin-based Python scripts that can modify the proxied request

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -192,6 +192,28 @@ field.
     Variable :envvar:`MAGPIE_WEBHOOKS_CONFIG_PATH` was added and will act in a similar fashion as their providers and
     permissions counterparts, to load definitions from multiple configuration files.
 
+.. _config_service_hooks:
+
+Service Hooks
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.25
+
+Under each :term:`Service` within `providers.cfg`_ or the :ref:`config_file`, it is possible to provide a ``hooks``
+section that lists additional pre/post request/response processing operations to apply when matched against the given
+request filter conditions. These hooks are plugin-based Python scripts that can modify the proxied request and responses
+when `Magpie` and `Twitcher`_ work together using the :ref:`utilities_adapter<Magpie Adapter>`.
+
+More specifically, when a :term:`Service` or children :term:`Resource` is accessed, triggering a proxied request
+through `Twitcher`_, the authenticated and authorized request goes through a hooks processing chain that can adjust
+certain request and response parameters (e.g.: add headers, filter the body, etc.), or even substitute the request
+definition entirely based on target implementations. The plugin scripts can therefore apply some advanced logic to
+improve the synergy between the protected services. They can also be employed to apply some :term:`Service` specific
+operations such as filtering protected contents that `Magpie` and `Twitcher`_ cannot themselves process evidently.
+
+.. seealso::
+    File `providers.cfg`_ presents in detail the schema of ``hooks`` and providers more contextual information
+    as well as an explicit example.
 
 .. _config_constants:
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -64,6 +64,6 @@
 .. _Magpie Security: https://github.com/Ouranosinc/Magpie/tree/master/magpie/security.py
 .. _permissions.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg
 .. _postgres.env.example: https://github.com/Ouranosinc/Magpie/tree/master/env/postgres.env.example
-.. _providers.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/permissions.cfg
+.. _providers.cfg: https://github.com/Ouranosinc/Magpie/tree/master/config/providers.cfg
 .. _themes: https://github.com/Ouranosinc/Magpie/tree/master/magpie/ui/home/static/themes
 .. _tests: https://github.com/Ouranosinc/Magpie/tree/master/tests

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -98,6 +98,8 @@ follow parameters for parsing :term:`OWS` requests.
 .. list-table::
     :header-rows: 1
 
+    * - Attribute
+      - Description
     * - :attr:`ServiceOWS.params_expected` |br| (``List[str]``)
       - Represents specific parameter names that can be preprocessed during HTTP request parsing to ease following
         resolution of :term:`ACL` use cases.
@@ -110,6 +112,8 @@ Furthermore, some :term:`Services <Service>` specifically implement extended :te
 .. list-table::
     :header-rows: 1
 
+    * - Attribute
+      - Description
     * - :attr:`ServiceGeoserverBase.resource_scoped` |br| (``bool``)
       - Indicates if the :term:`Service` is allowed to employ scoped :class:`models.Workspace` naming, meaning that
         a :term:`Resource` of that type can be extracted either from the request path or the specific request parameter

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,6 +5,8 @@
 Usage
 ========
 
+.. _usage_package:
+
 Package
 ----------------------
 

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -182,6 +182,11 @@ class MagpieAdapter(AdapterInterface):
         self._owssecurity = None
         super(MagpieAdapter, self).__init__(container)  # pylint: disable=E1101,no-member
 
+    def reset(self):
+        # type: () -> None
+        self._servicestore = None
+        self._owssecurity = None
+
     @property
     def name(self):
         # type: () -> Str

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -95,7 +95,7 @@ if TYPE_CHECKING:
 
     from magpie.typedefs import JSON, AnyResponseType, AnySettingsContainer, ServiceHookType, Str
 
-    from twitcher.models.service import ServiceConfig     # noqa  # pylint: disable=E0611  # Twitcher >= 0.6.3
+    from twitcher.models.service import ServiceConfig  # noqa  # pylint: disable=E0611  # Twitcher >= 0.6.3
     from twitcher.store import AccessTokenStoreInterface  # noqa  # pylint: disable=E0611  # Twitcher <= 0.5.x
 
 LOGGER = get_logger("TWITCHER|{}".format(__name__))

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -57,14 +57,14 @@ if LooseVersion(twitcher_version) >= LooseVersion("0.6.0"):
 
     if LooseVersion(twitcher_version) >= LooseVersion("0.8.0"):
         warnings.warn(
-            "Magpie version is not guaranteed to work with newer versions of Twitcher. "
+            "This Magpie version is not guaranteed to work with newer versions of Twitcher. "
             "This Magpie version offers compatibility with Twitcher 0.6.x and 0.7.x."
             "Current package versions are (Twitcher: {}, Magpie: {})".format(twitcher_version, magpie_version),
             ImportWarning
         )
     elif LooseVersion(twitcher_version) < LooseVersion("0.7.0"):
         warnings.warn(
-            "Magpie version offers more capabilities than Twitcher 0.6.x is able to provide. "
+            "This Magpie version offers more capabilities than Twitcher 0.6.x is able to provide. "
             "Consider updating to more recent Twitcher 0.7.x to make use of new functionalities. "
             "Current package versions are (Twitcher: {}, Magpie: {})".format(twitcher_version, magpie_version),
             ImportWarning
@@ -72,7 +72,7 @@ if LooseVersion(twitcher_version) >= LooseVersion("0.6.0"):
 
 if LooseVersion(twitcher_version) < LooseVersion("0.6.0"):
     warnings.warn(
-        "Magpie version is not guaranteed to work with versions prior to Twitcher 0.6.x. "
+        "This Magpie version is not guaranteed to work with versions prior to Twitcher 0.6.x. "
         "It is recommended to either use more recent Twitcher 0.6.x version or revert back "
         "to older Magpie < 3.18 in order to use Twitcher 0.5.x versions. "
         "Current package versions are (Twitcher: {}, Magpie: {})".format(twitcher_version, magpie_version),

--- a/magpie/alembic/versions/2021-06-09_cb92ff1f81bb_add_group_terms.py
+++ b/magpie/alembic/versions/2021-06-09_cb92ff1f81bb_add_group_terms.py
@@ -1,5 +1,5 @@
 """
-Add group terms
+Add group terms.
 
 Revision ID: cb92ff1f81bb
 Revises: 35e98bdc8aed

--- a/magpie/api/management/group/group_views.py
+++ b/magpie/api/management/group/group_views.py
@@ -119,6 +119,7 @@ def delete_group_view(request):
 def get_group_users_view(request):
     """
     List all users from a group.
+
     Users can be filtered by status depending of input arguments.
     """
     group = ar.get_group_matchdict_checked(request)

--- a/magpie/api/management/resource/resource_formats.py
+++ b/magpie/api/management/resource/resource_formats.py
@@ -76,7 +76,7 @@ def format_resource_tree(
     nesting_key="children",     # type: NestingKeyType
 ):                              # type: (...) -> JSON
     """
-    Generates the formatted resource tree under the provided nested resources
+    Generates the formatted resource tree under the provided nested resources.
 
     For all of the nested resources, formatting is applied by calling :func:`format_resource` recursively on them.
     Apply specific resource permissions as defined by :paramref:`resources_perms_dict` if provided.

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
     from typing import Any, Iterable, List, Optional, Tuple
 
-    from pyramid.httpexceptions import HTTPException
+    from pyramid.httpexceptions import HTTPException, HTTPSuccessful
     from pyramid.request import Request
     from pyramid.response import Response
     from sqlalchemy.orm.session import Session
@@ -314,10 +314,12 @@ def assign_user_group(user, group, db_session):
 
 
 def send_group_terms_email(user, group, db_session):
-    # type: (models.User, models.Group, Session) -> None
+    # type: (models.User, models.Group, Session) -> HTTPSuccessful
     """
-    Sends an email for terms and conditions confirmation, in the case of a request for the creation of
-    a user-group relationship where the group requires a terms and conditions confirmation.
+    Sends an email for terms and conditions confirmation.
+
+    Terms and conditions email are sent in the case of a request for the creation of a user-group
+    relationship where the group requires a terms and conditions confirmation.
 
     :returns: valid HTTP response on successful operations.
     :raises HTTPError: corresponding error matching problem encountered.
@@ -344,11 +346,13 @@ def send_group_terms_email(user, group, db_session):
 
 
 def create_pending_or_assign_user_group(user, group, db_session):
-    # type: (models.User, models.Group, Session) -> None
+    # type: (models.User, models.Group, Session) -> HTTPSuccessful
     """
+    Associates the pending user or existing user to the group.
+
     Creates either a new user-group relationship (user membership to a group) or a pending terms and conditions
-    confirmation. If the group requires a T&C confirmation, sends an email for T&C confirmation,
-    else, the user is assigned directly to the group.
+    confirmation. If the group requires a T&C confirmation, sends an email for T&C confirmation, else, the user is
+    assigned directly to the group.
 
     :returns: valid HTTP response on successful operations.
     :raises HTTPError: corresponding error matching problem encountered.
@@ -463,7 +467,7 @@ def get_similar_user_resource_permission(user, resource, permission, db_session)
     err_content = {"resource_id": resource.resource_id, "user_id": user.id,
                    "permission_name": str(permission), "permission": permission.json()}
 
-    def is_similar_permission():
+    def is_similar_permission():  # type: () -> List[PermissionSet]
         perms_list = ResourceService.direct_perms_for_user(resource, user, db_session=db_session)
         perms_list = [PermissionSet(perm) for perm in perms_list]
         return [perm for perm in perms_list if perm.like(permission)]

--- a/magpie/api/management/user/user_views.py
+++ b/magpie/api/management/user/user_views.py
@@ -127,6 +127,7 @@ def delete_user_view(request):
 def get_user_groups_view(request):
     """
     List all groups a user belongs to.
+
     Groups can be filtered by status depending of input arguments.
     """
     user = ar.get_user_matchdict_checked_or_logged(request)

--- a/magpie/api/requests.py
+++ b/magpie/api/requests.py
@@ -1,3 +1,4 @@
+import json
 from typing import TYPE_CHECKING
 
 import six

--- a/magpie/api/requests.py
+++ b/magpie/api/requests.py
@@ -1,4 +1,3 @@
-import json
 from typing import TYPE_CHECKING
 
 import six
@@ -24,7 +23,7 @@ from magpie.utils import CONTENT_TYPE_JSON, get_logger
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Any, Iterable, List, Optional, Union
+    from typing import Any, Dict, Iterable, List, Optional, Union
 
     from pyramid.request import Request
 
@@ -54,7 +53,12 @@ def check_value(value, param_name, check_type=six.string_types, pattern=ax.PARAM
 
 
 def get_request_method_content(request):
-    # 'request' object stores GET content into 'GET' property, while other methods are in 'POST' property
+    # type: (Request) -> Dict[Str, Any]
+    """
+    Obtain request content from property according to submitted method.
+
+    Requests with HTTP ``GET`` store content into ``GET`` property, while other methods are in ``POST`` property.
+    """
     method_property = "GET" if request.method == "GET" else "POST"
     return getattr(request, method_property)
 

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -128,6 +128,20 @@ class WebhookAction(ExtendedEnum):
     """
 
 
+if TYPE_CHECKING:
+    from typing import Literal
+
+    WebhookActionNames = Literal[
+        WebhookAction.CREATE_USER,
+        WebhookAction.CREATE_USER_PERMISSION,
+        WebhookAction.CREATE_GROUP_PERMISSION,
+        WebhookAction.DELETE_USER,
+        WebhookAction.DELETE_USER_PERMISSION,
+        WebhookAction.DELETE_GROUP_PERMISSION,
+    ]
+    AnyWebhookAction = Union[WebhookAction, WebhookActionNames]
+
+
 def get_permission_update_params(target,         # type: Union[models.User, models.Group]
                                  resource,       # type: ServiceOrResourceType
                                  permission,     # type: PermissionSet

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -129,7 +129,7 @@ class WebhookAction(ExtendedEnum):
 
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Literal, Union  # noqa: F811
 
     WebhookActionNames = Literal[
         WebhookAction.CREATE_USER,
@@ -139,7 +139,7 @@ if TYPE_CHECKING:
         WebhookAction.DELETE_USER_PERMISSION,
         WebhookAction.DELETE_GROUP_PERMISSION,
     ]
-    AnyWebhookAction = Union[WebhookAction, WebhookActionNames]
+    AnyWebhookAction = Union[WebhookAction, WebhookActionNames]  # pylint: disable=E0601
 
 
 def get_permission_update_params(target,         # type: Union[models.User, models.Group]

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -166,7 +166,7 @@ def process_webhook_requests(action, params, update_user_status_on_error=False, 
     # ignore if triggered during application startup, settings not yet loaded
     if not settings:
         return
-    webhooks = settings.get("webhooks", {})  # type: WebhookSettings
+    webhooks = settings.get("magpie.webhooks", {})  # type: WebhookSettings
     if not webhooks:
         return
     action_webhooks = webhooks[action]
@@ -299,8 +299,8 @@ def setup_webhooks(config_path, settings):
     :param settings: modified settings in-place with added valid webhooks.
     """
 
-    settings["webhooks"] = defaultdict(lambda: [])
-    webhooks_settings = settings["webhooks"]  # type: WebhookSettings
+    settings["magpie.webhooks"] = defaultdict(lambda: [])
+    webhooks_settings = settings["magpie.webhooks"]  # type: WebhookSettings
     if not config_path:
         LOGGER.info("No configuration file provided to load webhook definitions.")
     else:

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -41,7 +41,6 @@ from magpie.utils import (
 if TYPE_CHECKING:
     from typing import Optional
 
-    from pyramid.config import Configurator
     from pyramid.router import Router
     from sqlalchemy.orm.session import Session
 
@@ -96,7 +95,7 @@ def setup_magpie_configs(settings, db_session=None,
 
 
 def main(global_config=None, **settings):  # noqa: F811
-    # type: (Optional[Configurator], SettingsType) -> Router
+    # type: (Optional[SettingsType], SettingsType) -> Router
     """
     This function returns a Pyramid WSGI application.
     """

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -94,8 +94,9 @@ def main(global_config=None, **settings):  # noqa: F811
                                        raise_missing=False, raise_not_set=False, print_missing=True))
     prov_cfg = combined_config or get_constant("MAGPIE_PROVIDERS_CONFIG_PATH", settings, default_value="",
                                                raise_missing=False, raise_not_set=False, print_missing=True)
-    magpie_register_services_from_config(prov_cfg, push_to_phoenix=push_phoenix, force_update=True,
-                                         disable_getcapabilities=True, db_session=db_session)
+    svc_cfg = magpie_register_services_from_config(prov_cfg, push_to_phoenix=push_phoenix, force_update=True,
+                                                   disable_getcapabilities=True, db_session=db_session)
+    settings["magpie.services"] = svc_cfg
 
     print_log("Register configuration permissions...", LOGGER)
     perm_cfg = combined_config or get_constant("MAGPIE_PERMISSIONS_CONFIG_PATH", settings, default_value="",

--- a/magpie/app.py
+++ b/magpie/app.py
@@ -5,6 +5,7 @@
 Magpie is a service for AuthN and AuthZ based on Ziggurat-Foundations.
 """
 import logging
+from typing import TYPE_CHECKING
 
 from pyramid.events import NewRequest
 from pyramid.settings import asbool
@@ -19,7 +20,7 @@ from magpie.api.generic import (
     unauthorized_or_forbidden,
     validate_accept_header_tween
 )
-from magpie.api.webhooks import setup_webhooks
+from magpie.api.webhooks import setup_webhooks as setup_webhooks_config
 from magpie.cli.register_defaults import register_defaults
 from magpie.constants import get_constant
 from magpie.db import get_db_session_from_config_ini, run_database_migration_when_ready, set_sqlalchemy_log_level
@@ -37,10 +38,65 @@ from magpie.utils import (
     setup_ziggurat_config
 )
 
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from pyramid.config import Configurator
+    from pyramid.router import Router
+    from sqlalchemy.orm.session import Session
+
+    from magpie.typedefs import SettingsType
+
 LOGGER = get_logger(__name__)
 
 
+def setup_magpie_configs(settings, db_session=None,
+                         setup_providers=True, setup_permissions=True, setup_webhooks=True,
+                         skip_registration=False):
+    # type: (SettingsType, Optional[Session], bool, bool, bool, bool) -> None
+    """
+    Resolve known configuration file paths from settings or environment variables and process them for the application.
+
+    .. seealso::
+        - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#file-providers-cfg
+        - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#file-permissions-cfg
+        - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#configuration-file-formats
+        - https://pavics-magpie.readthedocs.io/en/latest/configuration.html#combined-configuration-file
+    """
+    print_log("Register service providers...", logger=LOGGER)
+    combined_config = get_constant("MAGPIE_CONFIG_PATH", settings, default_value=None,
+                                   raise_missing=False, raise_not_set=False, print_missing=True)
+    if combined_config:
+        print_log("Setting 'MAGPIE_CONFIG_PATH' detected for single file configuration, "
+                  "following settings for multi-file configuration will be ignored: "
+                  "[MAGPIE_PROVIDERS_CONFIG_PATH, MAGPIE_PERMISSIONS_CONFIG_PATH, MAGPIE_WEBHOOKS_CONFIG_PATH]",
+                  logger=LOGGER, level=logging.WARNING)
+
+    if setup_providers:
+        push_phoenix = asbool(get_constant("PHOENIX_PUSH", settings, settings_name="phoenix.push", default_value=False,
+                                           raise_missing=False, raise_not_set=False, print_missing=True))
+        prov_cfg = combined_config or get_constant("MAGPIE_PROVIDERS_CONFIG_PATH", settings, default_value="",
+                                                   raise_missing=False, raise_not_set=False, print_missing=True)
+        svc_cfg = magpie_register_services_from_config(prov_cfg, skip_registration=skip_registration,
+                                                       push_to_phoenix=push_phoenix, force_update=True,
+                                                       disable_getcapabilities=True, db_session=db_session)
+        settings["magpie.services"] = svc_cfg
+
+    if setup_permissions:
+        print_log("Register configuration permissions...", LOGGER)
+        perm_cfg = combined_config or get_constant("MAGPIE_PERMISSIONS_CONFIG_PATH", settings, default_value="",
+                                                   raise_missing=False, raise_not_set=False, print_missing=True)
+        magpie_register_permissions_from_config(perm_cfg, db_session=db_session)
+
+    if setup_webhooks:
+        print_log("Register webhook configurations...", LOGGER)
+        webhook_cfg = combined_config or get_constant("MAGPIE_WEBHOOKS_CONFIG_PATH", settings, default_value="",
+                                                      raise_missing=False, raise_not_set=False, print_missing=True)
+        setup_webhooks_config(webhook_cfg, settings)
+
+
 def main(global_config=None, **settings):  # noqa: F811
+    # type: (Optional[Configurator], SettingsType) -> Router
     """
     This function returns a Pyramid WSGI application.
     """
@@ -81,32 +137,7 @@ def main(global_config=None, **settings):  # noqa: F811
     print_log("Register default users...", LOGGER)
     register_defaults(db_session=db_session, settings=settings)
 
-    print_log("Register service providers...", logger=LOGGER)
-    combined_config = get_constant("MAGPIE_CONFIG_PATH", settings, default_value=None,
-                                   raise_missing=False, raise_not_set=False, print_missing=True)
-    if combined_config:
-        print_log("Setting 'MAGPIE_CONFIG_PATH' detected for single file configuration, "
-                  "following settings for multi-file configuration will be ignored: "
-                  "[MAGPIE_PROVIDERS_CONFIG_PATH, MAGPIE_PERMISSIONS_CONFIG_PATH, MAGPIE_WEBHOOKS_CONFIG_PATH]",
-                  logger=LOGGER, level=logging.WARNING)
-
-    push_phoenix = asbool(get_constant("PHOENIX_PUSH", settings, settings_name="phoenix.push", default_value=False,
-                                       raise_missing=False, raise_not_set=False, print_missing=True))
-    prov_cfg = combined_config or get_constant("MAGPIE_PROVIDERS_CONFIG_PATH", settings, default_value="",
-                                               raise_missing=False, raise_not_set=False, print_missing=True)
-    svc_cfg = magpie_register_services_from_config(prov_cfg, push_to_phoenix=push_phoenix, force_update=True,
-                                                   disable_getcapabilities=True, db_session=db_session)
-    settings["magpie.services"] = svc_cfg
-
-    print_log("Register configuration permissions...", LOGGER)
-    perm_cfg = combined_config or get_constant("MAGPIE_PERMISSIONS_CONFIG_PATH", settings, default_value="",
-                                               raise_missing=False, raise_not_set=False, print_missing=True)
-    magpie_register_permissions_from_config(perm_cfg, db_session=db_session)
-
-    print_log("Register webhook configurations...", LOGGER)
-    webhook_cfg = combined_config or get_constant("MAGPIE_WEBHOOKS_CONFIG_PATH", settings, default_value="",
-                                                  raise_missing=False, raise_not_set=False, print_missing=True)
-    setup_webhooks(webhook_cfg, settings)
+    setup_magpie_configs(settings, db_session)
 
     print_log("Running configurations setup...", LOGGER)
     patch_magpie_url(settings)

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -29,6 +29,7 @@ SERVICE_HOOK_ITEM_SCHEMA = {
     "required": [
         "type",
         "path",
+        "target",
     ],
     "additionalProperties": False
 }

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -1,0 +1,100 @@
+import logging
+from typing import TYPE_CHECKING
+
+from jsonschema import validators
+
+from magpie.utils import get_logger, print_log
+from magpie.services import SERVICE_TYPE_DICT
+from magpie.cli.sync_services import SYNC_SERVICES_TYPES
+
+if TYPE_CHECKING:
+    from magpie.typedefs import JSON, ServicesConfig
+
+LOGGER = get_logger(__name__)
+
+
+SERVICE_HOOK_ITEM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["request", "response"]},
+        "path": {"type": "string"},
+        "query": {"type": "string", "default": r".*"},
+        "method": {"type": "string", "default": "*", "enum": [
+            "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE",
+            "head", "get", "post", "put", "patch", "delete",
+            "*"
+        ]},
+        "target": {"type": "string", "pattern": r"^\.{0,2}\/?([\w-]+\/)*[A-Za-z_]\w+\.py:[A-Za-z]\w+$"}
+    },
+    "required": [
+        "type",
+        "path",
+    ],
+    "additionalProperties": False
+}
+SERVICE_CONFIG_ITEM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "url": {"type": "string", "pattern": r"^https?:\/\/.*$"},
+        "title": {"type": "string"},
+        "type": {"type": "string", "enum": list(SERVICE_TYPE_DICT)},
+        "sync_type":  {"type": "string", "enum": list(set(SYNC_SERVICES_TYPES) | set(SERVICE_TYPE_DICT))},
+        "public": {"type": "boolean", "default": True},
+        "c4i": {"type": "boolean", "default": False},
+        "configuration": {"type": "object", "additionalProperties": True},
+        "hooks": {"type": "array", "items": SERVICE_HOOK_ITEM_SCHEMA}
+    },
+    "required": [
+        "url",
+        "type"
+    ],
+    "additionalProperties": False
+}
+SERVICES_CONFIGURATION_SCHEMA = {
+    "type": "object",
+    "additionalProperties": SERVICE_CONFIG_ITEM_SCHEMA
+}
+
+
+def extend_with_default(validator_class):
+    """
+    Validator that applies inplace defaults in the instance when provided by the schema.
+    """
+    validate_properties = validator_class.VALIDATORS["properties"]
+
+    def set_defaults(validator, properties, instance, schema):
+        for property, subschema in properties.items():
+            if "default" in subschema:
+                instance.setdefault(property, subschema["default"])
+
+        for error in validate_properties(
+            validator, properties, instance, schema,
+        ):
+            yield error
+
+    return validators.extend(
+        validator_class, {"properties": set_defaults},
+    )
+
+
+JsonSchemaDefaultValidator = extend_with_default(validators.Draft7Validator)  # noqa
+
+
+def validate_services_config(services_configuration):
+    # type: (JSON) -> ServicesConfig
+    """
+    Validate configuration within the ``providers`` section.
+
+    .. seealso::
+        :ref:`config_providers` and :ref:`config_file`.
+
+    :param services_configuration: Service definitions loaded from one or more combined configuration files.
+    :return: Services configuration with validated schema and applied defaults.
+    """
+    try:
+        JsonSchemaDefaultValidator(SERVICES_CONFIGURATION_SCHEMA).validate(services_configuration)
+        return services_configuration
+    except Exception as exc:
+        print_log("Failed schema validation of services/providers configuration.",
+                  level=logging.ERROR, logger=LOGGER, exc_info=exc)
+        raise

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -38,7 +38,7 @@ SERVICE_CONFIG_ITEM_SCHEMA = {
         "url": {"type": "string", "pattern": r"^https?:\/\/.*$"},
         "title": {"type": "string"},
         "type": {"type": "string", "enum": list(SERVICE_TYPE_DICT)},
-        "sync_type":  {"type": "string", "enum": list(set(SYNC_SERVICES_TYPES) | set(SERVICE_TYPE_DICT))},
+        "sync_type": {"type": "string", "enum": list(set(SYNC_SERVICES_TYPES) | set(SERVICE_TYPE_DICT))},
         "public": {"type": "boolean", "default": True},
         "c4i": {"type": "boolean", "default": False},
         "configuration": {"type": "object", "additionalProperties": True},

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -65,16 +65,11 @@ def extend_with_default(validator_class):
     def set_defaults(validator, properties, instance, schema):
         for prop, child_schema in properties.items():
             if "default" in child_schema:
-                instance.setdefault(property, prop["default"])
-
-        for error in validate_properties(
-            validator, properties, instance, schema,
-        ):
+                instance.setdefault(prop, child_schema["default"])
+        for error in validate_properties(validator, properties, instance, schema):
             yield error
 
-    return validators.extend(
-        validator_class, {"properties": set_defaults},
-    )
+    return validators.extend(validator_class, {"properties": set_defaults})
 
 
 JsonSchemaDefaultValidator = extend_with_default(validators.Draft7Validator)  # noqa

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -8,6 +8,10 @@ from magpie.services import SERVICE_TYPE_DICT
 from magpie.utils import get_logger, print_log
 
 if TYPE_CHECKING:
+    from typing import Any, Dict
+
+    from jsonschema.protocols import Validator  # noqa
+
     from magpie.typedefs import JSON, ServicesConfig
 
 LOGGER = get_logger(__name__)
@@ -58,12 +62,14 @@ SERVICES_CONFIGURATION_SCHEMA = {
 
 
 def extend_with_default(validator_class):
+    # type: (Validator) -> Validator
     """
     Validator that applies inplace defaults in the instance when provided by the schema.
     """
     validate_properties = validator_class.VALIDATORS["properties"]
 
     def set_defaults(validator, properties, instance, schema):
+        # type: (Validator, Dict[str, Any], Dict[str, Any], JSON) -> Validator
         for prop, child_schema in properties.items():
             if "default" in child_schema:
                 instance.setdefault(prop, child_schema["default"])

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING
 
 from jsonschema import validators
 
-from magpie.utils import get_logger, print_log
-from magpie.services import SERVICE_TYPE_DICT
 from magpie.cli.sync_services import SYNC_SERVICES_TYPES
+from magpie.services import SERVICE_TYPE_DICT
+from magpie.utils import get_logger, print_log
 
 if TYPE_CHECKING:
     from magpie.typedefs import JSON, ServicesConfig

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -63,9 +63,9 @@ def extend_with_default(validator_class):
     validate_properties = validator_class.VALIDATORS["properties"]
 
     def set_defaults(validator, properties, instance, schema):
-        for property, subschema in properties.items():
-            if "default" in subschema:
-                instance.setdefault(property, subschema["default"])
+        for prop, child_schema in properties.items():
+            if "default" in child_schema:
+                instance.setdefault(property, prop["default"])
 
         for error in validate_properties(
             validator, properties, instance, schema,

--- a/magpie/constants.py
+++ b/magpie/constants.py
@@ -35,6 +35,7 @@ MAGPIE_ROOT = os.path.dirname(MAGPIE_MODULE_DIR)
 MAGPIE_CONFIG_DIR = os.getenv("MAGPIE_CONFIG_DIR") or os.path.join(MAGPIE_ROOT, "config")  # default also if empty
 MAGPIE_PROVIDERS_CONFIG_PATH = os.getenv(
     "MAGPIE_PROVIDERS_CONFIG_PATH", "{}/providers.cfg".format(MAGPIE_CONFIG_DIR))
+MAGPIE_PROVIDERS_HOOKS_PATH = os.getenv("MAGPIE_PROVIDERS_HOOKS_PATH", MAGPIE_ROOT)
 MAGPIE_PERMISSIONS_CONFIG_PATH = os.getenv(
     "MAGPIE_PERMISSIONS_CONFIG_PATH", "{}/permissions.cfg".format(MAGPIE_CONFIG_DIR))
 MAGPIE_WEBHOOKS_CONFIG_PATH = os.getenv("MAGPIE_WEBHOOKS_CONFIG_PATH")
@@ -67,6 +68,7 @@ except IOError:
 
 
 def _get_default_log_level():
+    # type: () -> Str
     """
     Get logging level from INI configuration file or fallback to default ``INFO`` if it cannot be retrieved.
     """
@@ -170,6 +172,7 @@ _REGEX_ASCII_ONLY = re.compile(r"\W|^(?=\d)")
 
 
 def get_constant_setting_name(name):
+    # type: (Str) -> Str
     """
     Find the equivalent setting name of the provided environment variable name.
 

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -50,12 +50,13 @@ from magpie.utils import (
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+    from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
     from magpie.typedefs import (
         JSON,
         AnyCookiesType,
         AnyResolvedSettings,
+        AnyResponseType,
         CombinedConfig,
         CookiesOrSessionType,
         GroupsConfig,
@@ -315,7 +316,7 @@ def sync_services_phoenix(services, services_as_dicts=False):
     services_dict = {}
     for svc in services:
         if services_as_dicts:
-            svc_dict = services[svc]
+            svc_dict = services[svc]  # type: JSON
             services_dict[svc] = {"url": svc_dict["public_url"], "title": svc_dict["service_name"],
                                   "type": svc_dict["service_type"], "c4i": False, "public": True}
         else:
@@ -620,9 +621,9 @@ def _expand_all(config):
     return config
 
 
-def magpie_register_services_from_config(service_config_path, push_to_phoenix=False,
+def magpie_register_services_from_config(service_config_path, push_to_phoenix=False, skip_registration=False,
                                          force_update=False, disable_getcapabilities=False, db_session=None):
-    # type: (Str, bool, bool, bool, Optional[Session]) -> ServicesSettings
+    # type: (Str, bool, bool, bool, bool, Optional[Session]) -> ServicesSettings
     """
     Registers Magpie services from one or many `providers.cfg` file.
 
@@ -631,6 +632,7 @@ def magpie_register_services_from_config(service_config_path, push_to_phoenix=Fa
 
     :param service_config_path: where to look for `providers` configuration(s). Directory or file path.
     :param push_to_phoenix: whether to push loaded service definitions to remote `Phoenix` service.
+    :param skip_registration: Load, validate and combine :term:`Service` configurations, but don't register them.
     :param force_update: override service definitions that conflict by name with registered ones.
     :param disable_getcapabilities:
         Skip `GetCapabilities` request validation and permission update.
@@ -660,21 +662,22 @@ def magpie_register_services_from_config(service_config_path, push_to_phoenix=Fa
 
     merged_service_configs = validate_services_config(merged_service_configs)
 
-    # register services using API POSTs
-    if db_session is None:
-        admin_usr = get_constant("MAGPIE_ADMIN_USER")
-        admin_pwd = get_constant("MAGPIE_ADMIN_PASSWORD")
-        local_provider = get_constant("MAGPIE_DEFAULT_PROVIDER")
-        _magpie_register_services_with_requests(merged_service_configs, push_to_phoenix,
-                                                admin_usr, admin_pwd, local_provider,
-                                                force_update=force_update,
-                                                disable_getcapabilities=disable_getcapabilities)
+    if not skip_registration:
+        # register services using API POSTs
+        if db_session is None:
+            admin_usr = get_constant("MAGPIE_ADMIN_USER")
+            admin_pwd = get_constant("MAGPIE_ADMIN_PASSWORD")
+            local_provider = get_constant("MAGPIE_DEFAULT_PROVIDER")
+            _magpie_register_services_with_requests(merged_service_configs, push_to_phoenix,
+                                                    admin_usr, admin_pwd, local_provider,
+                                                    force_update=force_update,
+                                                    disable_getcapabilities=disable_getcapabilities)
 
-    # register services directly to db using session
-    else:
-        _magpie_register_services_with_db_session(merged_service_configs, db_session,
-                                                  push_to_phoenix=push_to_phoenix, force_update=force_update,
-                                                  update_getcapabilities_permissions=not disable_getcapabilities)
+        # register services directly to db using session
+        else:
+            _magpie_register_services_with_db_session(merged_service_configs, db_session,
+                                                      push_to_phoenix=push_to_phoenix, force_update=force_update,
+                                                      update_getcapabilities_permissions=not disable_getcapabilities)
     LOGGER.info("All services processed.")
     return merged_service_configs
 
@@ -763,13 +766,14 @@ def _parse_resource_path(permission_config_entry,   # type: PermissionConfigItem
             if _use_request(cookies_or_session):
                 res_path = get_magpie_url() + ServiceResourcesAPI.path.format(service_name=svc_name)
                 res_resp = requests.get(res_path, cookies=cookies_or_session)
-                res_dict = get_json(res_resp)[svc_name]["resources"]
+                svc_json = get_json(res_resp)[svc_name]  # type: JSON
+                res_dict = svc_json["resources"]
             else:
                 from magpie.api.management.service.service_formats import format_service_resources
                 svc = models.Service.by_service_name(svc_name, db_session=cookies_or_session)
                 res_dict = format_service_resources(svc, show_all_children=True, db_session=cookies_or_session)
             parent = res_dict["resource_id"]
-            child_resources = res_dict["resources"]
+            child_resources = res_dict["resources"]  # type: Dict[Str, JSON]
             for res, resource_type in zip(resource_list, resource_type_list):
                 # search in existing children resources
                 if len(child_resources):
@@ -839,6 +843,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
     """
 
     def _apply_request(_usr_name=None, _grp_name=None):
+        # type: (Optional[Str], Optional[Str]) -> Optional[AnyResponseType]
         """
         Apply operation using HTTP request.
         """
@@ -856,6 +861,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
         return action_resp
 
     def _apply_session(_usr_name=None, _grp_name=None):
+        # type: (Optional[Str], Optional[Str]) -> AnyResponseType
         """
         Apply operation using db session.
         """
@@ -883,6 +889,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
                                                                     db_session=cookies_or_session)
 
     def _apply_profile(_usr_name=None, _grp_name=None):
+        # type: (Optional[Str], Optional[Str]) -> AnyResponseType
         """
         Creates the user/group profile as required.
         """
@@ -917,6 +924,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
                 return create_group(**grp_data)
 
     def _validate_response(operation, is_create, item_type="Permission"):
+        # type: (Callable[[], Optional[AnyResponseType]], bool, str) -> None
         """
         Validate action/operation applied and handles raised ``HTTPException`` as returned response.
         """
@@ -969,7 +977,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
 
 
 def magpie_register_permissions_from_config(permissions_config, magpie_url=None, db_session=None, raise_errors=False):
-    # type: (Union[Str, PermissionsConfig], Optional[Str], Optional[Session]) -> None
+    # type: (Union[Str, PermissionsConfig], Optional[Str], Optional[Session], bool) -> None
     """
     Applies `permissions` specified in configuration(s) defined as file, directory with files or literal configuration.
 
@@ -1036,7 +1044,7 @@ def _resolve_config_registry(config_files, key):
 
 
 def _process_permissions(permissions, magpie_url, cookies_or_session, users=None, groups=None, raise_errors=False):
-    # type: (PermissionsConfig, Str, Session, Optional[UsersSettings], Optional[GroupsSettings]) -> None
+    # type: (PermissionsConfig, Str, Session, Optional[UsersSettings], Optional[GroupsSettings], bool) -> None
     """
     Processes a single `permissions` configuration.
     """

--- a/magpie/security.py
+++ b/magpie/security.py
@@ -1,5 +1,10 @@
 import logging
+import warnings
 from typing import TYPE_CHECKING
+
+# openid warnings about deprecated 'defusedxml.cElementTree' when trying to find any available implementation
+# explicitly marked as safe by openid package
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="openid")  # isort:skip # noqa: E402
 
 from authomatic import Authomatic, provider_id
 from authomatic.providers import oauth2, openid

--- a/magpie/security.py
+++ b/magpie/security.py
@@ -3,7 +3,9 @@ import warnings
 from typing import TYPE_CHECKING
 
 # openid warnings about deprecated 'defusedxml.cElementTree' when trying to find any available implementation
-# explicitly marked as safe by openid package
+# explicitly marked as safe by openid package, must filter before any import to avoid raising warning
+# flake8: noqa: E402
+# pylint: disable=C0413
 warnings.filterwarnings("ignore", category=DeprecationWarning, module="openid")  # isort:skip # noqa: E402
 
 from authomatic import Authomatic, provider_id

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -128,7 +128,7 @@ if TYPE_CHECKING:
     WebhookConfigItem = TypedDict("WebhookConfigItem", {
         "name": Str,
         "action": Str,
-        "method": RequestMethod,
+        "method": AnyRequestMethod,
         "url": Str,
         "format": Str,
         "payload": WebhookPayload
@@ -159,7 +159,7 @@ if TYPE_CHECKING:
         "type": Literal["request", "response"],
         "path": str,
         "query": Optional[str],
-        "method": RequestMethod,
+        "method": AnyRequestMethod,
         "target": str
     }, total=True)
     # generic 'configuration' field under a service that supports it

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     Number = Union[int, float]
     SettingValue = Union[Str, Number, bool, None]
     SettingsType = Dict[Str, SettingValue]
-    AnySettingsContainer = Union[Configurator, Registry, PyramidRequest, SettingsType]
+    AnySettingsContainer = Union[Configurator, Registry, PyramidRequest, PyramidResponse, SettingsType]
 
     ParamsType = Dict[Str, Any]
     CookiesType = Union[Dict[Str, Str], List[Tuple[Str, Str]]]
@@ -155,8 +155,9 @@ if TYPE_CHECKING:
         "email": Optional[Str],
         "group": Optional[Str],
     }, total=False)
-    ServiceHookConfig = TypedDict("ServiceHookConfig", {
-        "type": Literal["request", "response"],
+    ServiceHookType = Literal["request", "response"]
+    ServiceHookConfigItem = TypedDict("ServiceHookConfigItem", {
+        "type": ServiceHookType,
         "path": str,
         "query": Optional[str],
         "method": AnyRequestMethod,
@@ -173,7 +174,7 @@ if TYPE_CHECKING:
         "public": bool,
         "c4i": bool,
         "configuration": Optional[ServiceConfiguration],
-        "hooks": Optional[List[ServiceHookConfig]]
+        "hooks": Optional[List[ServiceHookConfigItem]]
     })
 
     # individual sections directly loaded from config files (BEFORE resolution)

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -110,6 +110,12 @@ if TYPE_CHECKING:
     PermissionRequested = Optional[Union[Permission, Collection[Permission]]]
     ResourceTypePermissions = Dict[Type[models.Resource], List[Permission]]
 
+    AnyRequestMethod = Literal[
+        "HEAD", "GET", "POST", "PUT", "PATCH", "DELETE",
+        "head", "get", "post", "put", "patch", "delete",
+        "*"
+    ]
+
     # note:
     #   For all following items 'Settings' suffix refer to loaded definitions AFTER resolution.
     #   When 'Config' suffix is used, it instead refers to raw definitions BEFORE resolution.
@@ -122,7 +128,7 @@ if TYPE_CHECKING:
     WebhookConfigItem = TypedDict("WebhookConfigItem", {
         "name": Str,
         "action": Str,
-        "method": Str,
+        "method": RequestMethod,
         "url": Str,
         "format": Str,
         "payload": WebhookPayload
@@ -149,6 +155,13 @@ if TYPE_CHECKING:
         "email": Optional[Str],
         "group": Optional[Str],
     }, total=False)
+    ServiceHookConfig = TypedDict("ServiceHookConfig", {
+        "type": Literal["request", "response"],
+        "path": str,
+        "query": Optional[str],
+        "method": RequestMethod,
+        "target": str
+    }, total=True)
     # generic 'configuration' field under a service that supports it
     ServiceConfiguration = Dict[Str, Union[Str, List[JSON], JSON]]
     ServiceConfigItem = TypedDict("ServiceConfigItem", {
@@ -160,6 +173,7 @@ if TYPE_CHECKING:
         "public": bool,
         "c4i": bool,
         "configuration": Optional[ServiceConfiguration],
+        "hooks": Optional[List[ServiceHookConfig]]
     })
 
     # individual sections directly loaded from config files (BEFORE resolution)

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from ziggurat_foundations.permissions import PermissionTuple  # noqa
 
     from magpie import models
-    from magpie.api.webhooks import WEBHOOK_TEMPLATE_PARAMS, WebhookAction
+    from magpie.api.webhooks import WEBHOOK_TEMPLATE_PARAMS, WebhookAction, WebhookActionNames
     from magpie.permissions import Permission, PermissionSet
 
     if hasattr(typing, "TypeAlias"):
@@ -127,7 +127,7 @@ if TYPE_CHECKING:
     })
     WebhookConfigItem = TypedDict("WebhookConfigItem", {
         "name": Str,
-        "action": Str,
+        "action": WebhookActionNames,
         "method": AnyRequestMethod,
         "url": Str,
         "format": Str,
@@ -135,6 +135,7 @@ if TYPE_CHECKING:
     }, total=False)
 
     # registered configurations
+    PermissionAction = Literal["create", "remove"]
     PermissionConfigItem = TypedDict("PermissionConfigItem", {
         "service": Str,
         "resource": Optional[Str],
@@ -142,7 +143,7 @@ if TYPE_CHECKING:
         "user": Optional[Str],
         "group": Optional[Str],
         "permission": Union[Str, PermissionDict],
-        "action": Optional[Str],  # create/remove
+        "action": Optional[PermissionAction],
     }, total=False)
     GroupConfigItem = TypedDict("GroupConfigItem", {
         "name": Str,

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
     AnyValue = Union[Str, Number, bool, None]
     _JSONType = "JSON"  # type: TypeAlias   # pylint: disable=C0103
     BaseJSON = Union[AnyValue, List[_JSONType], Dict[AnyKey, _JSONType]]
-    JSON = Union[Dict[Str, Union[BaseJSON, _JSONType]], List[BaseJSON]]
+    JSON = Union[Dict[Str, Union[_JSONType]], List[_JSONType]]
 
     GroupPriority = Union[int, Type[math.inf]]
     UserServicesType = Union[Dict[Str, Dict[Str, Any]], List[Dict[Str, Any]]]

--- a/magpie/ui/utils.py
+++ b/magpie/ui/utils.py
@@ -27,7 +27,7 @@ from magpie.utils import CONTENT_TYPE_JSON, get_header, get_json, get_logger, ge
 
 if TYPE_CHECKING:
     # pylint: disable=W0611,unused-import
-    from typing import Any, Dict, List, Optional, Union
+    from typing import Any, Callable, Dict, List, Optional, Union
 
     from pyramid.response import Response
 
@@ -132,6 +132,7 @@ def redirect_error(request, code=None, content=None):
 
 
 def handle_errors(func):
+    # type: (Callable) -> Callable
     """
     Decorator that encapsulates the operation in a try/except block, and redirects the response to the UI error page
     with API error contents.
@@ -143,6 +144,7 @@ def handle_errors(func):
         :func:`redirect_error`
     """
     def wrap(*args, **kwargs):
+        # type: (Any, Any) -> Callable[[...], Any]
         view_container = None if not args and not isinstance(args[0], BaseViews) else args[0]
         try:
             return func(*args, **kwargs)
@@ -346,6 +348,7 @@ class AdminRequests(BaseViews):
 
     @handle_errors
     def get_group_info(self, group_name):
+        # type: (Str) -> JSON
         path = schemas.GroupAPI.path.format(group_name=group_name)
         resp = request_api(self.request, path, "GET")
         check_response(resp)
@@ -353,7 +356,7 @@ class AdminRequests(BaseViews):
 
     @handle_errors
     def get_group_users(self, group_name, user_group_status=UserGroupStatus.ACTIVE):
-        # type: (UserGroupStatus) -> List[str]
+        # type: (Str, UserGroupStatus) -> List[Str]
         path = schemas.GroupUsersAPI.path.format(group_name=group_name)
         resp = request_api(self.request, path + "?status={}".format(user_group_status.value), "GET")
         check_response(resp)
@@ -361,6 +364,7 @@ class AdminRequests(BaseViews):
 
     @handle_errors
     def update_group_info(self, group_name, group_info):
+        # type: (Str, JSON) -> JSON
         path = schemas.GroupAPI.path.format(group_name=group_name)
         resp = request_api(self.request, path, "PATCH", data=group_info)
         check_response(resp)
@@ -368,6 +372,7 @@ class AdminRequests(BaseViews):
 
     @handle_errors
     def delete_group(self, group_name):
+        # type: (Str) -> JSON
         path = schemas.GroupAPI.path.format(group_name=group_name)
         resp = request_api(self.request, path, "DELETE")
         check_response(resp)

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -671,17 +671,22 @@ def import_target(target, default_root=None):
         return None
     mod_path, target = target.rsplit(":", 1)
     if not mod_path.startswith("/"):
-        if default_root and os.path.isdir(default_root):
+        if default_root:
             mod_root = default_root
         else:
             mod_root = get_constant("MAGPIE_ROOT")
+        if not os.path.isdir(mod_root):
+            LOGGER.warning("Cannot import relative target, root directory not found: [%s]", mod_root)
+            return None
         mod_path = os.path.join(mod_root, mod_path)
     mod_path = os.path.abspath(mod_path)
     if not os.path.isfile(mod_path):
+        LOGGER.warning("Cannot import target reference, file not found: [%s]", mod_path)
         return None
     mod_name = re.sub(r"\W", "_", mod_path)
     mod_spec = importlib.util.spec_from_file_location(mod_name, mod_path)
     if not mod_spec:
+        LOGGER.warning("Cannot import target reference [%s], not found in file: [%s]", mod_name, mod_path)
         return None
     mod = importlib.util.module_from_spec(mod_spec)
     mod_spec.loader.exec_module(mod)

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -601,7 +601,8 @@ def get_admin_cookies(container, verify=True, raise_message=None):
     magpie_login_url = "{}{}".format(magpie_url, SigninAPI.path)
     cred = {"user_name": get_constant("MAGPIE_ADMIN_USER", container),
             "password": get_constant("MAGPIE_ADMIN_PASSWORD", container)}
-    resp = requests.post(magpie_login_url, data=cred, headers={"Accept": CONTENT_TYPE_JSON}, verify=verify)
+    headers = {"Accept": CONTENT_TYPE_JSON, "Content-Type": CONTENT_TYPE_JSON}
+    resp = requests.post(magpie_login_url, data=cred, headers=headers, verify=verify)
     if resp.status_code != HTTPOk.code:
         if raise_message:
             raise_log(raise_message, logger=LOGGER)
@@ -627,6 +628,8 @@ def get_settings(container, app=False):
     :return: found application settings dictionary.
     :raise TypeError: when no application settings could be found or unsupported container.
     """
+    if isinstance(container, Response):
+        container = container.request
     if isinstance(container, (Configurator, Request)):
         return container.registry.settings  # noqa
     if isinstance(container, Registry):
@@ -810,6 +813,7 @@ def get_twitcher_url(container=None, hostname=None):
 
 
 def get_twitcher_protected_service_url(magpie_service_name, container=None, hostname=None):
+    # type: (Str, Optional[AnySettingsContainer], Optional[Str]) -> Str
     """
     Obtains the protected service URL behind Twitcher Proxy based on combination of supported configuration settings.
 

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -602,7 +602,7 @@ def get_admin_cookies(container, verify=True, raise_message=None):
     cred = {"user_name": get_constant("MAGPIE_ADMIN_USER", container),
             "password": get_constant("MAGPIE_ADMIN_PASSWORD", container)}
     headers = {"Accept": CONTENT_TYPE_JSON, "Content-Type": CONTENT_TYPE_JSON}
-    resp = requests.post(magpie_login_url, data=cred, headers=headers, verify=verify)
+    resp = requests.post(magpie_login_url, json=cred, headers=headers, verify=verify)
     if resp.status_code != HTTPOk.code:
         if raise_message:
             raise_log(raise_message, logger=LOGGER)
@@ -683,12 +683,13 @@ def import_target(target, default_root=None):
     return getattr(mod, target, None)
 
 
-def normalize_field_pattern(pattern):
-    # type: (Str) -> Str
+def normalize_field_pattern(pattern, escape=True):
+    # type: (Str, bool) -> Str
     """
     Escapes necessary regex pattern characters and applies start/end-of-line control characters.
     """
-    pattern = re.escape(pattern)
+    if escape:
+        pattern = re.escape(pattern)
     if not pattern:
         pattern = r".*"
     if pattern[0] != "^":

--- a/magpie/utils.py
+++ b/magpie/utils.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import re
-
 import importlib.util
 import inspect
 import json
 import logging
 import os
+import re
 import sys
 import time
 import types

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ pylint>=2.11,!=2.12; python_version >= "3.6"
 pylint-quotes
 # bird-house/twticher, must match version in Dockerfile.adapater
 pyramid-twitcher>=0.5.3; python_version < "3.6"  # pyup: ignore
-pyramid-twitcher>=0.6.2; python_version >= "3.6"
+pyramid-twitcher>=0.7.0; python_version >= "3.6"
 pytest
 python2-secrets; python_version <= "3.5"
 safety

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ futures; python_version < "3"
 gunicorn<20; python_version < "3.5"  # pyup: ignore
 gunicorn>=20; python_version >= "3"
 humanize
-jsonschema>4
+jsonschema>=4
 lxml>=3.7
 mako  # controlled by pyramid_mako
 paste

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ futures; python_version < "3"
 gunicorn<20; python_version < "3.5"  # pyup: ignore
 gunicorn>=20; python_version >= "3"
 humanize
-jsonschema>=4
+jsonschema<4; python_version < "3.6"
+jsonschema>=4; python_version >= "3.6"
 lxml>=3.7
 mako  # controlled by pyramid_mako
 paste

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ futures; python_version < "3"
 gunicorn<20; python_version < "3.5"  # pyup: ignore
 gunicorn>=20; python_version >= "3"
 humanize
+jsonschema
 lxml>=3.7
 mako  # controlled by pyramid_mako
 paste

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ futures; python_version < "3"
 gunicorn<20; python_version < "3.5"  # pyup: ignore
 gunicorn>=20; python_version >= "3"
 humanize
-jsonschema
+jsonschema>4
 lxml>=3.7
 mako  # controlled by pyramid_mako
 paste

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,17 +17,17 @@ search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
 [bumpversion:file:CHANGES.rst]
-search = 
+search =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-replace = 
+replace =
 	`Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 	------------------------------------------------------------------------------------
-	
+
 	* Nothing new for the moment.
-	
+
 	.. _changes_{new_version}:
-	
+
 	`{new_version} <https://github.com/Ouranosinc/Magpie/tree/{new_version}>`_ ({now:%%Y-%%m-%%d})
 	------------------------------------------------------------------------------------
 
@@ -41,7 +41,7 @@ ignore-path = docs/_build,docs/autoapi
 [flake8]
 ignore = E501,W291,W503,W504
 max-line-length = 120
-exclude = 
+exclude =
 	.git,
 	__pycache__,
 	build,
@@ -72,7 +72,7 @@ combine_as_imports = false
 branch = true
 source = ./
 include = magpie/*
-omit = 
+omit =
 	setup.py
 	docs/*
 	tests/*
@@ -80,7 +80,7 @@ omit =
 	magpie/typedefs.py
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
 	raise AssertionError
 	raise NotImplementedError
@@ -95,11 +95,12 @@ exclude_lines =
 	LOGGER.log
 
 [tool:pytest]
-addopts = 
+addopts =
 	--strict-markers
 	--tb=native
-markers = 
+markers =
 	adapter: magpie adapter functional operations
+	caching: magpie caching functional operations
 	defaults: magpie default users, providers and views
 	register: magpie methods employed in 'register' module (config loading)
 	registration: magpie operations related to user/group registration

--- a/tests/hooks/README.md
+++ b/tests/hooks/README.md
@@ -1,0 +1,4 @@
+# Test Note
+
+In order to properly validate the import functionality of hooks, do not add `__init__.py` to this directory to ensure
+it is not interpreted as a Python module.

--- a/tests/hooks/request_hooks.py
+++ b/tests/hooks/request_hooks.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramid.request import Request
+
+
+def add_x_wps_output_context(request):
+    # type: (Request) -> Request
+    if "application/json" in request.content_type:
+        body = request.json
+        body["test"] = "added by hook"
+    if request.user is not None:
+        request.headers["X-WPS-Output-Context"] = "user-" + str(request.user.id)
+    return request

--- a/tests/hooks/request_hooks.py
+++ b/tests/hooks/request_hooks.py
@@ -1,17 +1,42 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+import json
 from typing import TYPE_CHECKING
+
+from six.moves.urllib.parse import urljoin
 
 if TYPE_CHECKING:
     from pyramid.request import Request
+    from pyramid.response import Response
+
+    from magpie.typedefs import ServiceHookConfigItem
 
 
 def add_x_wps_output_context(request):
     # type: (Request) -> Request
     if "application/json" in request.content_type:
-        body = request.json
+        body = request.json  # JSON generated from body, cannot override directly
         body["test"] = "added by hook"
+        request.body = json.dumps(body).encode()
     if request.user is not None:
         request.headers["X-WPS-Output-Context"] = "user-" + str(request.user.id)
     return request
+
+
+def add_x_wps_output_link(response, hook):
+    # type: (Response, ServiceHookConfigItem) -> Response
+    if "application/json" not in response.content_type or response.status_code != 200:
+        return response
+    body = response.json
+    if body.get("status") != "succeeded":
+        return response
+    job_out_url = response.request.url + "/outputs"
+    wps_out_url = urljoin(response.request.url, "/wps-outputs")
+    wps_job_id = hook["path"].rsplit(",", 1)[-1]
+    x_wps_output_context = response.request.headers.get("X-WPS-Output-Context")
+    if x_wps_output_context:
+        wps_out_link = wps_out_url + "/" + x_wps_output_context + "/" + wps_job_id
+    else:
+        wps_out_link = wps_out_url + "/" + wps_job_id
+    response.headers["X-WPS-Output-Link"] = wps_out_link
+    return response

--- a/tests/hooks/request_hooks.py
+++ b/tests/hooks/request_hooks.py
@@ -9,20 +9,26 @@ if TYPE_CHECKING:
     from pyramid.request import Request
     from pyramid.response import Response
 
-    from magpie.typedefs import ServiceHookConfigItem
+    from magpie.typedefs import ServiceConfigItem, ServiceHookConfigItem
 
 
-def add_x_wps_output_context(request):
-    # type: (Request) -> Request
+def add_x_wps_output_context(request, service):
+    # type: (Request, ServiceConfigItem) -> Request
     if "application/json" in request.content_type:
         body = request.json  # JSON generated from body, cannot override directly
-        body["test"] = "added by hook"
+        # following for testing purposes only
+        body["hooks"] = len(service["hooks"])
+        body["hook"] = "add_x_wps_output_context"
         request.body = json.dumps(body).encode()
     if request.user is not None:
         request.headers["X-WPS-Output-Context"] = "user-" + str(request.user.id)
     return request
 
 
+# WARNING:
+#   Operation on 'body' or 'json' can only work on non-buffered responses.
+#   Otherwise, the content is not *yet* available at this point.
+#   If it gets accumulated, this could cause an out-of-memory error if it is too large.
 def add_x_wps_output_link(response, hook):
     # type: (Response, ServiceHookConfigItem) -> Response
     if "application/json" not in response.content_type or response.status_code != 200:
@@ -30,13 +36,26 @@ def add_x_wps_output_link(response, hook):
     body = response.json
     if body.get("status") != "succeeded":
         return response
+    # following for testing purposes only
     job_out_url = response.request.url + "/outputs"
     wps_out_url = urljoin(response.request.url, "/wps-outputs")
-    wps_job_id = hook["path"].rsplit(",", 1)[-1]
-    x_wps_output_context = response.request.headers.get("X-WPS-Output-Context")
-    if x_wps_output_context:
-        wps_out_link = wps_out_url + "/" + x_wps_output_context + "/" + wps_job_id
-    else:
-        wps_out_link = wps_out_url + "/" + wps_job_id
-    response.headers["X-WPS-Output-Link"] = wps_out_link
+    wps_job_id = response.request.path.rsplit("/", 1)[-1]
+    wps_out_ctx = None if not response.request.user else ("user-" + str(response.request.user.id))
+    wps_out_link = wps_out_url + ("/" + wps_out_ctx if wps_out_ctx else "") + "/" + wps_job_id
+    response.headers["X-WPS-Output-Location"] = wps_out_link
+    response.headers["X-WPS-Output-Context"] = wps_out_ctx
+    response.headers["X-WPS-Output-Link"] = job_out_url
+    response.headers["X-Magpie-Hook-Name"] = "add_x_wps_output_link"
+    response.headers["X-Magpie-Hook-Target"] = hook["target"]
+    return response
+
+
+# only to demonstrate that hook/service parameters can be combined however we want
+# also, this hook is used in combination with above one in matching condition to test multi-hook chaining
+def combined_arguments(response, service, hook):
+    # type: (Response, ServiceConfigItem, ServiceHookConfigItem) -> Response
+    for i, svc_hook in enumerate(service["hooks"]):
+        if svc_hook == hook:
+            response.headers["X-Magpie-Hook-Index"] = str(i)  # string because header requires it
+            break
     return response

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7533,6 +7533,12 @@ class SetupMagpieAdapter(ConfigTestCase):
         cls.adapter = adapter
         if cls.test_twitcher:
             cls.test_twitcher_app = utils.get_test_twitcher_app(settings)
+            if not cls.settings:
+                cls.settings = {}
+            cls.settings.update({
+                key: value for key, value in cls.test_twitcher_app.app.registry.settings.items()
+                if key.startswith("twitcher.")
+            })
 
     @utils.mocked_get_settings
     def mock_request(self, *args, **kwargs):

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7613,5 +7613,5 @@ class SetupTwitcher(ConfigTestCase):
 
     @classmethod
     def setup_twitcher(cls):
-        settings = cls.settings.fget(cls())
+        settings = cls.settings.fget(cls())  # pylint: disable=E1111
         cls.test_twitcher_app = utils.get_test_twitcher_app(settings)

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -81,9 +81,11 @@ class ConfigTestCase(object):
     cookies = None                  # type: Optional[CookiesType]
     headers = None                  # type: Optional[HeadersType]
     json_headers = {"Accept": CONTENT_TYPE_JSON, "Content-Type": CONTENT_TYPE_JSON}
+    # parameters for testing, extracted automatically within 'utils.TestSetup' methods
+    # test cookies/headers can match above admin cookies/headers for test suites targeting administrative operations
+    # for other access level operations, they should correspond to another appropriate test user
     test_headers = None             # type: Optional[HeadersType]
     test_cookies = None             # type: Optional[CookiesType]
-    # parameters for testing, extracted automatically within 'utils.TestSetup' methods
     test_service_type = None        # type: Optional[Str]
     test_service_name = None        # type: Optional[Str]
     test_resource_name = None       # type: Optional[Str]

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7512,9 +7512,11 @@ class SetupMagpieAdapter(ConfigTestCase):
     to the ones that would be received by the proxy. This allows to test handling of the requests be the various
     components defined in the adapter.
     """
-    session = None          # type: Optional[Session]
-    cache_enabled = False   # type: bool
-    cache_expire = None     # type: Optional[int]
+    session = None              # type: Optional[Session]
+    cache_enabled = False       # type: bool
+    cache_expire = None         # type: Optional[int]
+    test_twitcher = False       # type: bool
+    test_twitcher_app = None    # type: Optional[TestApp]
 
     @classmethod
     def setup_adapter(cls, setup_cache=True):
@@ -7529,6 +7531,8 @@ class SetupMagpieAdapter(ConfigTestCase):
         cls.test_adapter_app = TestApp(config.make_wsgi_app())
         cls.ows = adapter.owssecurity_factory(settings)
         cls.adapter = adapter
+        if cls.test_twitcher:
+            cls.test_twitcher_app = utils.get_test_twitcher_app(settings)
 
     @utils.mocked_get_settings
     def mock_request(self, *args, **kwargs):

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7615,6 +7615,8 @@ class SetupTwitcher(ConfigTestCase):
         return settings
 
     @classmethod
-    def setup_twitcher(cls):
-        settings = cls.settings.fget(cls())  # pylint: disable=E1111
-        cls.test_twitcher_app = utils.get_test_twitcher_app(settings)
+    def setup_twitcher(cls, settings=None):
+        # type: (Optional[SettingsType]) -> None
+        _settings = cls.settings.fget(cls())  # pylint: disable=E1111
+        _settings.update(settings or {})
+        cls.test_twitcher_app = utils.get_test_twitcher_app(_settings)

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -2420,11 +2420,12 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
 
         def check_permissions(permissions_data):
             """
-            Utility function that checks if resource and permissions found in data were succesfully create/removed.
+            Utility function that checks if resource and permissions found in data were successfully create/removed.
             """
-            path = "/services/{}/resources".format(self.test_service_name)
-            resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
-            resources = utils.check_response_basic_info(resp)[self.test_service_name]["resources"]
+            _path = "/services/{}/resources".format(self.test_service_name)
+            _resp = utils.test_request(self, "GET", _path, headers=self.json_headers, cookies=self.cookies)
+            _info = utils.check_response_basic_info(_resp)  # type: JSON
+            resources = _info[self.test_service_name]["resources"]
 
             for perm_entry in permissions_data["permissions"][1:]:  # skip first resource, which is the service
                 target_res = [res for res in resources.values() if res["resource_name"] == perm_entry["resource_name"]]
@@ -2443,13 +2444,13 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                     if perm_entry.get("group"):
                         check_paths.append("/groups/{}/resources/{}/permissions".format(
                             self.test_group_name, target_res["resource_id"]))
-                    for path in check_paths:
-                        resp = utils.test_request(self, "GET", path, headers=self.json_headers, cookies=self.cookies)
-                        body = utils.check_response_basic_info(resp)
+                    for _path in check_paths:
+                        _resp = utils.test_request(self, "GET", _path, headers=self.json_headers, cookies=self.cookies)
+                        _body = utils.check_response_basic_info(_resp)
                         if perm_entry.get("action") and perm_entry["action"] == "remove":
-                            utils.check_val_not_in(perm, body["permission_names"])
+                            utils.check_val_not_in(perm, _body["permission_names"])
                         else:
-                            utils.check_val_is_in(perm, body["permission_names"])
+                            utils.check_val_is_in(perm, _body["permission_names"])
                 resources = target_res["children"]
 
         check_permissions(data)
@@ -6379,7 +6380,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/resources/{}".format(res3_id)
         query = {"parent": "true"}
         body = utils.test_request(self, "GET", path, params=query, headers=self.json_headers, cookies=self.cookies)
-        info = utils.check_response_basic_info(body)
+        info = utils.check_response_basic_info(body)  # type: JSON
 
         utils.check_val_is_in("resource", info)
         utils.check_val_not_in("children", info["resource"])
@@ -6410,7 +6411,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/resources/{}".format(res3_id)
         query = {"parent": "true", "invert": "true"}
         body = utils.test_request(self, "GET", path, params=query, headers=self.json_headers, cookies=self.cookies)
-        info = utils.check_response_basic_info(body)
+        info = utils.check_response_basic_info(body)  # type: JSON
 
         err_one = (
             "Even if service has more than one children, using parent query should only list "
@@ -6477,7 +6478,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         path = "/resources/{}".format(res3_id)
         query = {"parent": "true", "flatten": "true"}
         body = utils.test_request(self, "GET", path, params=query, headers=self.json_headers, cookies=self.cookies)
-        info = utils.check_response_basic_info(body)
+        info = utils.check_response_basic_info(body)  # type: JSON
 
         utils.check_val_not_in("resource", info)
         utils.check_val_is_in("resources", info)
@@ -7533,7 +7534,7 @@ class SetupMagpieAdapter(ConfigTestCase):
         cls.ows = adapter.owssecurity_factory(settings)
         cls.adapter = adapter
         # rebuild sub-classes and handles from scratch, ensure that nothing is persisted between tests
-        # different adapter/twitcher cache/no-cache settings combinations are otherwsie propagated inconsistently
+        # different adapter/twitcher cache/no-cache settings combinations are otherwise propagated inconsistently
         cls.adapter.reset()
 
     @utils.mocked_get_settings

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -26,6 +26,7 @@ _TEST_MODULES = [os.path.splitext(f)[0] for f in filter(lambda i: filter_test_fi
 # run test options, correspond to known pytest markers
 MAGPIE_TEST_DEFAULTS = RunOptionDecorator("MAGPIE_TEST_DEFAULTS", "default users, providers and views")
 MAGPIE_TEST_ADAPTER = RunOptionDecorator("MAGPIE_TEST_ADAPTER", "magpie adapter functional operations")
+MAGPIE_TEST_CACHING = RunOptionDecorator("MAGPIE_TEST_CACHING", "magpie caching functional operations")
 MAGPIE_TEST_REGISTER = RunOptionDecorator("MAGPIE_TEST_REGISTER", "magpie methods employed in 'register' module")
 MAGPIE_TEST_REGISTRATION = RunOptionDecorator("MAGPIE_TEST_REGISTRATION", "magpie methods for user/group registration")
 MAGPIE_TEST_LOGIN = RunOptionDecorator("MAGPIE_TEST_LOGIN", "magpie login operations")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -259,7 +259,10 @@ class TestAdapterHooks(ti.SetupTwitcher, ti.UserTestCase, ti.BaseTestCase):
         cls.test_user_name = "unittest-adapter-hooks-user"
         cls.test_group_name = "unittest-adapter-hooks-group"
 
-        cls.setup_twitcher()
+        cls.setup_twitcher(settings={
+            # ensure base path is relative to repository to find hooks
+            "magpie.providers_hooks_path": os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        })
         cls.setup_admin()
         cls.login_admin()
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 import time
 import unittest
@@ -344,10 +345,17 @@ class TestAdapterHooks(ti.SetupTwitcher, ti.UserTestCase, ti.BaseTestCase):
                     path = twitcher_proxy_path + "/weaver/jobs"
                     resp = utils.test_request(self.test_twitcher_app, "POST", path, json={},
                                               headers=self.test_headers, cookies=self.test_cookies)
-                utils.check_val_equal(import_hook_target.call_count, 1,
-                                      msg="Only a single hook expected to be matched against request parameters.")
-                utils.check_val_not_equal(import_hook_target.call_args_list[-1].return_value, None,
-                                          msg="Imported target expected to have succeeded and found the function.")
+                err_msg = (
+                    "Single hook expected to be matched against request parameters.\n" +
+                    "Imported target expected to have succeeded and found the function.\n" +
+                    "Maybe invalid environment variable or setting definition caused invalid resolution?\n" +
+                    "MAGPIE_PROVIDERS_HOOKS_PATH={}\n".format(os.getenv("MAGPIE_PROVIDERS_HOOKS_PATH")) +
+                    "twitcher settings: {}\n".format(json.dumps(self.twitcher_settings, indent=2, ensure_ascii=False)) +
+                    "magpie settings: {}\n".format(json.dumps(self.magpie_settings, indent=2, ensure_ascii=False)) +
+                    "current file: {}".format(os.path.realpath(__file__))
+                )
+                utils.check_val_equal(import_hook_target.call_count, 1, msg=err_msg)
+                utils.check_val_not_equal(import_hook_target.call_args_list[-1].return_value, None, msg=err_msg)
 
                 # check request hook called
                 utils.check_val_equal(resp.status_code, 201)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -210,6 +210,8 @@ class TestAdapter(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
                                               headers=self.test_headers, cookies=self.test_cookies)
                     utils.check_response_basic_info(resp, expected_method="GET", expected_code=400)
 
+                    utils.check_or_try_logout_user(self)
+                    self.test_adapter_app.reset()  # clear saved logins
                     data = {"user_name": self.test_user_name, "password": self.test_user_name}
                     resp = utils.test_request(self.test_adapter_app, "POST", "/verify", json=data, expect_errors=True,
                                               headers={}, cookies={})

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -23,6 +23,8 @@ from magpie.utils import CONTENT_TYPE_JSON, get_magpie_url, get_twitcher_protect
 from tests import interfaces as ti
 from tests import runner, utils
 
+from twitcher.__version__ import __version__ as twitcher_version  # noqa
+
 if six.PY3:
     from magpie.adapter.magpieowssecurity import MagpieOWSSecurity, OWSAccessForbidden  # noqa: F401
 
@@ -270,7 +272,8 @@ class TestAdapterHooks(ti.SetupTwitcher, ti.UserTestCase, ti.BaseTestCase):
         """
         Validate hooks functionalities using examples defined in ``config/providers.cfg`` loaded by default.
         """
-        utils.warn_version(self, "adapter hooks functionality", "3.25", skip=True)
+        utils.warn_version(self, "Magpie adapter hooks feature", "3.25", skip=True)
+        utils.warn_version(self, "Twitcher adapter hooks feature", "0.7", fail=True, test_version=twitcher_version)
 
         assert "magpie.services" in self.settings
         assert "weaver" in self.settings["magpie.services"]

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import sys
 import time
 import unittest
 import uuid
@@ -34,6 +35,8 @@ if TYPE_CHECKING:
     from mock import MagicMock
 
     from magpie.typedefs import AnyRequestType, AnyResponseType, CookiesType
+
+PYTHON_VERSION = sys.version_info
 
 
 @unittest.skipIf(six.PY2, "Unsupported Twitcher for MagpieAdapter in Python 2")
@@ -272,6 +275,9 @@ class TestAdapterHooks(ti.SetupTwitcher, ti.UserTestCase, ti.BaseTestCase):
         """
         Validate hooks functionalities using examples defined in ``config/providers.cfg`` loaded by default.
         """
+        # first two requirements are package versions when hooks become available
+        # last is a valid combination of package versions, but insufficient to test this feature (test bound to fail)
+        utils.warn_version(self, "Twitcher package with adapter hooks", "3.6", skip=True, test_version=PYTHON_VERSION)
         utils.warn_version(self, "Magpie adapter hooks feature", "3.25", skip=True)
         utils.warn_version(self, "Twitcher adapter hooks feature", "0.7", fail=True, test_version=twitcher_version)
 

--- a/tests/test_magpie_ui.py
+++ b/tests/test_magpie_ui.py
@@ -636,7 +636,7 @@ class TestCase_MagpieUI_UserRegistration_Local(ti.UserTestCase, unittest.TestCas
                 utils.check_or_try_logout_user(self)  # return to pending user not logged in
                 utils.check_or_try_login_user(self, username=test_register_user, password=test_register_user,
                                               use_ui_form_submit=True)
-                resp = utils.test_request(self, "GET", "/session", headers=self.json_headers, cookies=self.cookies)
+                resp = utils.test_request(self, "GET", "/session")
                 body = utils.check_response_basic_info(resp, 200)
                 utils.check_val_true(body["authenticated"])
                 utils.check_val_equal(body["user"]["user_name"], test_register_user)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -24,7 +24,7 @@ class TestPermissions(unittest.TestCase):
         Validate that provided permission sets are formatted as intended, with both implicit and explicit variants, and
         with both name strings and detailed JSON objects.
         """
-        utils.warn_version(__meta__.__version__, "permission format validation", "3.0", skip=True)
+        utils.warn_version(self, "permission format validation", "3.0", test_version=__meta__.__version__, skip=True)
 
         usr_perm = models.UserPermission()
         usr_perm.perm_name = Permission.GET_FEATURE.value
@@ -78,7 +78,7 @@ class TestPermissions(unittest.TestCase):
         .. seealso::
             :meth:`test_format_permissions_applied`
         """
-        utils.warn_version(__meta__.__version__, "permission format validation", "3.0", skip=True)
+        utils.warn_version(self, "permission format validation", "3.0", test_version=__meta__.__version__, skip=True)
 
         # add duplicates with extra modifiers only to test removal
         # provide in random order to validate proper sorting
@@ -128,7 +128,7 @@ class TestPermissions(unittest.TestCase):
 
         Validate various implicit conversion of permission name string to explicit definition.
         """
-        utils.warn_version(__meta__.__version__, "permission set conversion", "3.0", skip=True)
+        utils.warn_version(self, "permission set conversion", "3.0", test_version=__meta__.__version__, skip=True)
 
         perm = PermissionSet("read")  # old implicit format
         utils.check_val_equal(perm.name, Permission.READ)
@@ -157,7 +157,7 @@ class TestPermissions(unittest.TestCase):
 
         Validate various implicit conversion of permission name string to explicit definition.
         """
-        utils.warn_version(__meta__.__version__, "permission set conversion", "3.0", skip=True)
+        utils.warn_version(self, "permission set conversion", "3.0", test_version=__meta__.__version__, skip=True)
 
         perm = PermissionSet(Permission.READ)
         utils.check_val_equal(perm.name, Permission.READ)
@@ -174,7 +174,7 @@ class TestPermissions(unittest.TestCase):
 
         Validate various implicit conversion of permission JSON definition.
         """
-        utils.warn_version(__meta__.__version__, "permission set conversion", "3.0", skip=True)
+        utils.warn_version(self, "permission set conversion", "3.0", test_version=__meta__.__version__, skip=True)
 
         perm = PermissionSet({"name": Permission.WRITE, "access": Access.DENY, "scope": Scope.MATCH})
         utils.check_val_equal(perm.name, Permission.WRITE)
@@ -191,7 +191,7 @@ class TestPermissions(unittest.TestCase):
 
         Validate various implicit conversion of permission elements to explicit definition.
         """
-        utils.warn_version(__meta__.__version__, "permission set conversion", "3.0", skip=True)
+        utils.warn_version(self, "permission set conversion", "3.0", test_version=__meta__.__version__, skip=True)
 
         perm = PermissionSet(PermissionTuple("user-name", "write-deny-match", "user",  # important: perm-name & type
                                              "group_id", "resource_id", "owner", "allowed"))  # these doesn't matter
@@ -212,7 +212,7 @@ class TestPermissions(unittest.TestCase):
 
         Validate various implicit conversion of permission elements to explicit definition.
         """
-        utils.warn_version(__meta__.__version__, "permission set conversion", "3.0", skip=True)
+        utils.warn_version(self, "permission set conversion", "3.0", test_version=__meta__.__version__, skip=True)
 
         perm = PermissionSet((Allow, 1, "write-deny-match"))
         utils.check_val_equal(perm.name, Permission.WRITE)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ Tests for the various utility operations employed by Magpie.
 """
 import inspect
 import os
+import tempfile
 import unittest
 from distutils.version import LooseVersion
 
@@ -23,6 +24,11 @@ from magpie.api import generic as ag
 from magpie.api import requests as ar
 from magpie.utils import CONTENT_TYPE_JSON, ExtendedEnum, get_header, get_magpie_url, import_target
 from tests import runner, utils
+
+if six.PY2:
+    from backports import tempfile as tempfile2  # noqa  # pylint: disable=E0611,no-name-in-module  # Python 2
+else:
+    tempfile2 = tempfile  # pylint: disable=C0103,invalid-name
 
 
 class DummyEnum(ExtendedEnum):
@@ -43,6 +49,35 @@ def test_import_target():
     assert _cls.__module__ != DummyEnum.__module__, "imported target should have its own file-based module reference"
     assert _cls is not DummyEnum, "since different module references, should be considered different references"
     assert _cls.TEST_VALUE_1.value == DummyEnum.TEST_VALUE_1.value
+
+    root = os.path.abspath(os.path.join(here, ".."))
+    with mock.patch("magpie.utils.get_constant", return_value=root):
+        func = import_target("tests/hooks/request_hooks.py:add_x_wps_output_context")
+        assert func is not None
+        assert inspect.isfunction(func)
+        assert func.__name__ == "add_x_wps_output_context"
+        # if invalid default root dir does not exist, it should also fail (must not suddenly find relative path)
+        rand_dir = os.path.join(root, "random")
+        func = import_target("tests/hooks/request_hooks.py:add_x_wps_output_context", rand_dir)
+        assert func is None
+
+    # validate variable was employed, and not just that path happened to match
+    with tempfile2.TemporaryDirectory() as tmp_dir:
+        with mock.patch("magpie.utils.get_constant", return_value=tmp_dir):
+            func = import_target("tests/hooks/request_hooks.py:add_x_wps_output_context")
+            assert func is None
+            # even if root path is invalid, if default is provided, it is prioritized
+            func = import_target("tests/hooks/request_hooks.py:add_x_wps_output_context", root)
+            assert func is not None
+            assert inspect.isfunction(func)
+            assert func.__name__ == "add_x_wps_output_context"
+            # but if this default root (dir exists) produces an invalid path, then fails to locate the hooks
+            func = import_target("tests/hooks/request_hooks.py:add_x_wps_output_context", tmp_dir)
+            assert func is None
+            # if invalid default root dir does not exist, it should also fail (no sudden success)
+            rand_dir = os.path.join(tmp_dir, "random")
+            func = import_target("tests/hooks/request_hooks.py:add_x_wps_output_context", rand_dir)
+            assert func is None
 
 
 @runner.MAGPIE_TEST_LOCAL

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ test_utils
 
 Tests for the various utility operations employed by Magpie.
 """
+import inspect
 import os
 import unittest
 from distutils.version import LooseVersion
@@ -20,13 +21,28 @@ from magpie import __meta__, constants
 from magpie.api import exception as ax
 from magpie.api import generic as ag
 from magpie.api import requests as ar
-from magpie.utils import CONTENT_TYPE_JSON, ExtendedEnum, get_header, get_magpie_url
+from magpie.utils import CONTENT_TYPE_JSON, ExtendedEnum, get_header, get_magpie_url, import_target
 from tests import runner, utils
 
 
 class DummyEnum(ExtendedEnum):
     TEST_VALUE_1 = "value-1"
     TEST_VALUE_2 = "value-2"
+
+
+@runner.MAGPIE_TEST_UTILS
+def test_import_target():
+    func = import_target("tests/hooks/request_hooks.py:add_x_wps_output_context")
+    assert func is not None
+    assert inspect.isfunction(func)
+    assert func.__name__ == "add_x_wps_output_context"
+
+    here = os.path.abspath(os.path.dirname(__file__))
+    _cls = import_target("test_utils.py:DummyEnum", here)
+    assert _cls is not None
+    assert _cls.__module__ != DummyEnum.__module__, "imported target should have its own file-based module reference"
+    assert _cls is not DummyEnum, "since different module references, should be considered different references"
+    assert _cls.TEST_VALUE_1.value == DummyEnum.TEST_VALUE_1.value
 
 
 @runner.MAGPIE_TEST_LOCAL

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -13,6 +13,7 @@ import os
 import tempfile
 import unittest
 from time import sleep
+from typing import TYPE_CHECKING
 
 import requests
 import six
@@ -38,6 +39,9 @@ if six.PY2:
     from backports import tempfile as tempfile2  # noqa  # pylint: disable=E0611,no-name-in-module  # Python 2
 else:
     tempfile2 = tempfile  # pylint: disable=C0103,invalid-name
+
+if TYPE_CHECKING:
+    from magpie.api.webhooks import WebhookSettings
 
 WEBHOOK_TEST_DELAY = 0.25  # small delay to let webhook being processed before resuming tests
 
@@ -735,16 +739,16 @@ def test_webhook_multiple_files():
             yaml.safe_dump(cfg2, cfg2_file, default_flow_style=False)
         setup_webhooks(tmpdir, settings)
 
-    webhooks = settings["webhooks"]
+    webhooks = settings["magpie.webhooks"]  # type: WebhookSettings
     assert len(webhooks) == 3, "overridden webhook should have been dropped"
     expect_actions = [WebhookAction.CREATE_USER, WebhookAction.DELETE_USER_PERMISSION, WebhookAction.UPDATE_USER_STATUS]
     assert all(action in webhooks for action in expect_actions)
 
     expect_cfg1 = copy.deepcopy(cfg1)
-    for cfg in expect_cfg1["webhooks"]:  # type: dict
+    for cfg in expect_cfg1["webhooks"]:
         cfg.setdefault("format", None)
     expect_cfg2 = copy.deepcopy(cfg2)
-    for cfg in expect_cfg2["webhooks"]:  # type: dict
+    for cfg in expect_cfg2["webhooks"]:
         cfg.setdefault("format", None)
 
     assert len(webhooks[WebhookAction.CREATE_USER]) == 2
@@ -834,4 +838,4 @@ class TestFailingWebhooks(unittest.TestCase):
                 settings = {}
                 utils.check_no_raise(lambda: setup_webhooks(webhook_tmp_config.name, settings))
                 for key in WEBHOOK_KEYS:
-                    utils.check_val_is_in(key, settings["webhooks"][action][0])
+                    utils.check_val_is_in(key, settings["magpie.webhooks"][action][0])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -686,7 +686,7 @@ def mock_request(request_path_query="",     # type: Str
                  headers=None,              # type: Optional[AnyHeadersType]
                  cookies=None,              # type: Optional[AnyCookiesType]
                  settings=None,             # type: SettingsType
-                 **kwargs,                  # type: Any
+                 **kwargs                   # type: Any
                  ):                         # type: (...) -> Request
     """
     Generates a fake request with provided arguments.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1921,6 +1921,7 @@ class TestSetup(object):
                          expected_code=200,                 # type: int
                          expected_type=CONTENT_TYPE_HTML,   # type: Str
                          expect_errors=False,               # type: bool
+                         override_headers=null,             # type: Optional[HeadersType]
                          override_cookies=null,             # type: Optional[CookiesType]
                          ):                                 # type: (...) -> AnyResponseType
         """
@@ -1958,19 +1959,21 @@ class TestSetup(object):
         :param expected_code: validate the HTTP status code from the response (returned or provided one).
         :param expected_type: validate the content-type of the response (returned or provided one).
         :param expect_errors: indicate if error HTTP status codes (>=400) are considered normal in the response.
-        :param override_cookies: enforce some cookies in the request.
+        :param override_headers: headers for request to override any stored ones from Test Suite.
+        :param override_cookies: cookies for request to override any stored ones from Test Suite.
 
         :returns: response from the rendered page for further tests
         :raises AssertionError: if any check along the ways results into error or unexpected state.
         """
         app_or_url = get_app_or_url(test_case)
         if not isinstance(app_or_url, TestApp):
-            test_case.skipTest(reason="test form submit with remote URL not implemented")
+            test_case.fail(msg="test form submit with remote URL not implemented")
         if isinstance(previous_response, TestResponse):
             resp = previous_response
         else:
             resp = test_request(app_or_url, method, path, timeout=timeout,
-                                cookies=override_cookies if override_cookies is not null else test_case.cookies)
+                                headers=override_headers if override_headers is not null else test_case.test_headers,
+                                cookies=override_cookies if override_cookies is not null else test_case.test_cookies)
         check_val_equal(resp.status_code, 200, msg="Cannot test form submission, initial page returned an error.")
         form = find_html_form(resp.forms, form_match)
         if not form:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1097,6 +1097,7 @@ def test_request(test_item,             # type: AnyMagpieTestItemType
             resp.cookies = RequestsCookieJar()
             for cookie in cookie_headers:
                 cookie_name, cookie_token = cookie.split("=", 1)
+                cookie_token = cookie_token.split(";")[0]
                 cookie_value = create_cookie(cookie_name, cookie_token)
                 resp.cookies.set_cookie(cookie_value)
         return resp

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -945,7 +945,7 @@ def wrapped_call(target, method=None, instance=None, side_effect=None):
                     mock.patch(func, side_effect=lambda *_, **__: real(*_, **__)))
         return __WRAPPED_INSTANCES__[target]
 
-    def wrapped_func(*_, **__):
+    def wrapped_func(*_, **__):  # type: (Any, Any) -> Any
         if instance is None:
             return real(*_, **__)
         if type(real) is property:  # pylint: disable=C0123
@@ -958,8 +958,8 @@ def wrapped_call(target, method=None, instance=None, side_effect=None):
         """
         def _execute_mock_call(self, *args, **kwargs):  # type: (Any, Any) -> Any
             result = super(MockPatcher, self)._execute_mock_call(*args, **kwargs)
-            if self.call_args_list and self.call_args_list[-1].args == args and self.call_args_list[-1].kwargs == kwargs:
-                setattr(self.call_args_list[-1], "return_value", result)
+            if self.call_args and self.call_args.args == args and self.call_args.kwargs == kwargs:
+                setattr(self.call_args, "return_value", result)
             return result
 
     if method and instance:
@@ -2088,7 +2088,7 @@ class TestSetup(object):
         for resource_id in resource_children:
             check_val_type(resource_id, six.string_types)
             resource_int_id = int(resource_id)  # should by an 'int' string, no error raised
-            resource_info = resource_children[resource_id]
+            resource_info = resource_children[resource_id]  # type: JSON
             check_val_is_in("root_service_id", resource_info)
             check_val_type(resource_info["root_service_id"], int)
             check_val_equal(resource_info["root_service_id"], root_service_id)
@@ -2195,12 +2195,12 @@ class TestSetup(object):
         resp = test_request(app_or_url, "GET", path,
                             headers=override_headers if override_headers is not null else test_case.json_headers,
                             cookies=override_cookies if override_cookies is not null else test_case.cookies)
-        json_body = check_response_basic_info(resp, 200, expected_method="GET")
+        json_body = check_response_basic_info(resp, 200, expected_method="GET")  # type: JSON
         check_val_is_in("services", json_body)
         check_val_is_in(svc_type, json_body["services"])
         check_val_not_equal(len(json_body["services"][svc_type]), 0,
                             msg="Missing any required service of type: '{}'".format(test_case.test_service_type))
-        services_dict = json_body["services"][svc_type]
+        services_dict = json_body["services"][svc_type]  # type: JSON
         return list(services_dict.values())[0]
 
     @staticmethod
@@ -2575,8 +2575,8 @@ class TestSetup(object):
                             expect_errors=ignore_missing_service)
         if ignore_missing_service and resp.status_code == 404:
             return []
-        json_body = get_json_body(resp)
-        resources = json_body[svc_name]["resources"]  # type: Dict[str, JSON]
+        json_body = get_json_body(resp)  # type: Dict[str, JSON]
+        resources = json_body[svc_name]["resources"]
         return [resources[res] for res in resources]
 
     @staticmethod
@@ -2725,12 +2725,12 @@ class TestSetup(object):
         resp = test_request(app_or_url, "GET", "/services",
                             headers=override_headers if override_headers is not null else test_case.json_headers,
                             cookies=override_cookies if override_cookies is not null else test_case.cookies)
-        json_body = check_response_basic_info(resp, 200, expected_method="GET")
+        json_body = check_response_basic_info(resp, 200, expected_method="GET")  # type: JSON
 
         # prepare a flat list of registered services
         services_list = []
         for svc_type in json_body["services"]:
-            services_of_type = json_body["services"][svc_type]
+            services_of_type = json_body["services"][svc_type]  # type: JSON
             services_list.extend(services_of_type.values())
         return services_list
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -945,7 +945,8 @@ def wrapped_call(target, method=None, instance=None, side_effect=None):
                     mock.patch(func, side_effect=lambda *_, **__: real(*_, **__)))
         return __WRAPPED_INSTANCES__[target]
 
-    def wrapped_func(*_, **__):  # type: (Any, Any) -> Any
+    def wrapped_func(*_, **__):
+        # type: (Any, Any) -> Any
         if instance is None:
             return real(*_, **__)
         if type(real) is property:  # pylint: disable=C0123
@@ -956,7 +957,8 @@ def wrapped_call(target, method=None, instance=None, side_effect=None):
         """
         Magic mock with injected return value from the wrapped call by the patched function.
         """
-        def _execute_mock_call(self, *args, **kwargs):  # type: (Any, Any) -> Any
+        def _execute_mock_call(self, *args, **kwargs):  # pylint: disable=W0221
+            # type: (Any, Any) -> Any
             result = super(MockPatcher, self)._execute_mock_call(*args, **kwargs)
             if self.call_args and self.call_args.args == args and self.call_args.kwargs == kwargs:
                 setattr(self.call_args, "return_value", result)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -600,10 +600,10 @@ def warn_version(test, functionality, version, test_version=None, skip=True, fai
             msg = "Functionality [{}] was deprecated in version [{}], downgrade [<{}] required to test." \
                   .format(functionality, test_version, version)
         warnings.warn(msg, FutureWarning)
-        if skip:
-            test.skipTest(reason=msg)   # noqa: F401
         if fail:
             test.fail(msg)
+        if skip:
+            test.skipTest(reason=msg)   # noqa: F401
 
 
 def json_msg(json_body, msg=null):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -960,8 +960,9 @@ def wrapped_call(target, method=None, instance=None, side_effect=None):
         def _execute_mock_call(self, *args, **kwargs):  # pylint: disable=W0221
             # type: (Any, Any) -> Any
             result = super(MockPatcher, self)._execute_mock_call(*args, **kwargs)
-            if self.call_args and self.call_args.args == args and self.call_args.kwargs == kwargs:
-                setattr(self.call_args, "return_value", result)
+            if self.call_args_list:
+                if self.call_args_list[-1].args == args and self.call_args_list[-1].kwargs == kwargs:
+                    setattr(self.call_args_list[-1], "return_value", result)
             return result
 
     if method and instance:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1023,6 +1023,9 @@ def test_request(test_item,             # type: AnyMagpieTestItemType
         if cookies is not None:
             cookies_dict = dict(cookies)  # convert tuple-list as needed
             cookies_list = cookies if isinstance(cookies, list) else list(cookies_dict.items())
+            # filter possible extra parameters (e.g.: Path, Domain, Expire, etc.)
+            cookies_list = [(name, cookie.split(";", 1)[0]) for name, cookie in cookies_list]
+            cookies_dict = dict(cookies_list)
             if not app_or_url.cookies or app_or_url.cookies != cookies_dict:
                 for name, cookie in cookies_list:
                     app_or_url.set_cookie(name, cookie)


### PR DESCRIPTION
## Summary

The main purpose is presented here: https://github.com/Ouranosinc/Magpie/pull/517/files#diff-1c805585a74c7c16218b333063aed89c528c90d8ec5aa76257a1e248eda0a10fR139-R155
Using this config, pointing at file https://github.com/Ouranosinc/Magpie/blob/request-hooks/tests/hooks/request_hooks.py, `MagpieAdapter` would add the `X-WPS-Output-Context` header in the request sent during job creation toward Weaver using the requesting user ID, effectively producing the WPS-outputs in its user directory. 

## Changes

* Add JSON schema validation of loaded `Service` configuration (``providers.cfg``).
* Add optional ``hooks`` section under each `Service` definition of the ``providers.cfg`` or combined configuration
  file that allows pre/post request/response processing operations using plugin Python scripts.
* Store the validated `Service` configuration in ``magpie.services`` settings for later access to ``hooks`` definitions
  by the ``MagpieAdapter``.
* Rename the ``webhooks`` section stored in settings to ``magpie.webhooks`` to avoid possible name clashes.

## References

- Depends on bird-house/twitcher#114 to call the hooks. 
- Addresses DAC-145, DAC-168, DAC-467

## WIP

- [x] Add specific tests for `hooks`
- [x] Merge #516 (this PR is based on it) to reduce diff of actual changes by this PR