### PR TITLE
dist to pypi as pavics-magpie

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,3 +115,26 @@ jobs:
           files: ./reports/coverage.xml
           fail_ci_if_error: true
           verbose: true
+
+  deploy_pypi:
+    needs: tests
+    if: ${{ success() && (contains(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
+    runs-on: ubuntu-latest
+    env:
+      # override make command to install directly in active python
+      CONDA_COMMAND: ""
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Build Distribution Package
+        run: make install-dev dist
+      - name: Push Package to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/magpie/__meta__.py
+++ b/magpie/__meta__.py
@@ -5,6 +5,7 @@ General meta information on the magpie package.
 __version__ = "3.24.0"
 __title__ = "Magpie"
 __package__ = "magpie"  # pylint: disable=W0622
+__distribution__ = "pavics-magpie"  # name for pypi
 __author__ = "Francois-Xavier Derue, Francis Charette-Migneault"
 __maintainer__ = "Francis Charette-Migneault"
 __email__ = "francis.charette-migneault@crim.ca"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,5 +28,6 @@ pytest
 python2-secrets; python_version <= "3.5"
 safety
 tox>=3.0
+twine
 webtest
 waitress

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ LOGGER.info("link requirements: %s", LINKS)
 
 setup(
     # -- meta information --------------------------------------------------
-    name=__meta__.__package__,
+    name=__meta__.__distribution__,
     version=__meta__.__version__,
     description=__meta__.__description__,
     long_description=README + "\n\n" + CHANGES,


### PR DESCRIPTION
PyPI requires that all `dist_require` packages are publicly accessible using `pip install <pkg>`. 
Because of this, URL commit/branch references are not permitted. 

The package distribution is blocked by the following PR (so new official versions are published) until Mapgie can be pushed as well:

- https://github.com/bbangert/beaker/pull/221
- https://github.com/authomatic/authomatic/pull/195