### PR TITLE
adapter request/response hook `context` parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,19 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
 * Add ``context`` parameter available for `Service Hook` functions, offering more handlers to obtain references to
   the adapter, the request's `Service` implementation, and the corresponding database `Resource`. This can be used,
   amongst other things, to perform advanced operations such as validating other `Resource` and `Permission` conditions
   to modify the handled ``request`` or ``response`` by the hook.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix ``request.user`` property attempting ``setattr`` for unauthenticated use-case (*anonymous* pseudo user) when
+  other piece of code (``MagpieAdapter``, `Twitcher`, etc.) except ``None`` since no actual user is authenticated.
+  Identified during implementation testing of
+  `bird-house/birdhouse-deploy#245 <https://github.com/bird-house/birdhouse-deploy/pull/245>`_ feature.
 
 .. _changes_3.25.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+* Add ``context`` parameter available for `Service Hook` functions, offering more handlers to obtain references to
+  the adapter, the request's `Service` implementation, and the corresponding database `Resource`. This can be used,
+  amongst other things, to perform advanced operations such as validating other `Resource` and `Permission` conditions
+  to modify the handled ``request`` or ``response`` by the hook.
 
 .. _changes_3.25.0:
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -216,6 +216,13 @@ Glossary
         :term:`Service` defines different combination of functionalities. Implemented by sub-classes of
         :py:class:`magpie.models.ServiceInterface`.
 
+    Service Hook
+        Plugin function handler that can apply modifications onto received requests or returned responses when
+        interacting with `Twitcher`_ :term:`Proxy`, based on a set of filter conditions.
+
+        .. seealso::
+            :ref:`Service Hooks` section for details.
+
     User
         Unitary entity containing details about the user allowing it to log into `Magpie` and that can have other
         relationships applied to it such as :term:`Permission` and :term:`Group` that extend his specific access rights

--- a/magpie/adapter/__init__.py
+++ b/magpie/adapter/__init__.py
@@ -16,6 +16,8 @@ from pyramid.httpexceptions import (
     HTTPServiceUnavailable,
     HTTPUnauthorized
 )
+from pyramid.request import Request
+from pyramid.response import Response
 from pyramid_beaker import set_cache_regions_from_settings
 from requests.exceptions import HTTPError
 from six.moves.urllib.parse import parse_qsl, urlparse
@@ -92,9 +94,9 @@ if TYPE_CHECKING:
 
     from pyramid.authentication import AuthTktCookieHelper
     from pyramid.config import Configurator
-    from pyramid.request import Request
-    from pyramid.response import Response
 
+    from magpie.models import Resource
+    from magpie.services import ServiceInterface as MagpieService
     from magpie.typedefs import JSON, AnyResponseType, AnySettingsContainer, ServiceHookType, Str
 
     from twitcher.models.service import ServiceConfig  # noqa  # pylint: disable=E0611  # Twitcher >= 0.6.3
@@ -285,6 +287,7 @@ class MagpieAdapter(AdapterInterface):
         svc_hooks = svc_config.get("hooks", [])
         # copy to avoid (un)intentional modifications to configurations
         svc_config = copy.deepcopy(svc_config)
+        svc_config["name"] = service_name  # often useful reference, but not directly in definition since dict key
         for hook_cfg in svc_hooks:
             if hook_cfg["type"] != hook_type:
                 continue
@@ -307,7 +310,7 @@ class MagpieAdapter(AdapterInterface):
             kwargs = {}
             if len(signature.parameters) > 1:
                 hook = copy.deepcopy(hook_cfg)
-                for key, val in [("service", svc_config), ("hook", hook)]:
+                for key, val in [("service", svc_config), ("hook", hook), ("context", HookContext(instance, self))]:
                     if key in signature.parameters:
                         kwargs[key] = val
             try:
@@ -368,3 +371,44 @@ class MagpieAdapter(AdapterInterface):
             response.request.method, request_path, response.request.query_string
         )
         return response
+
+
+class HookContext(object):
+    """
+    Context handlers associated to the request/response for the :term:`Service Hook` to be evaluated.
+
+    Dispatch calls to database or other derived operations *on demand* as much as possible to minimize the impact of
+    retrieving some parameters by each request that requires this hook context.
+    """
+    adapter = None   # type: MagpieAdapter
+    request = None   # type: Request
+    response = None  # type: Optional[Response]  # optional in case request hook (response not yet reached)
+    _service = None  # type: Optional[MagpieService]
+
+    def __init__(self, instance, adapter):
+        # type: (Union[Request, Response], MagpieAdapter) -> None
+        self.adapter = adapter
+        if isinstance(instance, Request):
+            self.request = instance
+            self.response = None
+        if isinstance(instance, Response):
+            self.response = instance
+            self.request = instance.request
+
+    @property
+    def service(self):
+        # type: () -> MagpieService
+        """
+        Service implementation that defines the :term:`Resource` structure and :term:`Permission` resolution method.
+        """
+        if not self._service:
+            self._service = self.adapter.owssecurity_factory(self.request).get_service(self.request)
+        return self._service
+
+    @property
+    def resource(self):
+        # type: () -> Resource
+        """
+        Database :term:`Resource` that represents the :term:`Service` reference implementation.
+        """
+        return self.service.service

--- a/magpie/api/management/resource/resource_utils.py
+++ b/magpie/api/management/resource/resource_utils.py
@@ -212,19 +212,23 @@ def get_resource_parents(resource, db_session, tree_service_builder=None):
     return list(parents)
 
 
-def get_resource_children(resource, db_session, tree_service_builder=None):
-    # type: (ServiceOrResourceType, Session, Optional[ResourceTreeService]) -> NestedResourceNodes
+def get_resource_children(resource, db_session, tree_service_builder=None, limit_depth=None):
+    # type: (ServiceOrResourceType, Session, Optional[ResourceTreeService], Optional[int]) -> NestedResourceNodes
     """
     Obtains the children resource node structure of the input service or resource.
 
     :param resource: Initial resource where to start building the tree from.
     :param db_session: Database connection to retrieve resources.
     :param tree_service_builder: Utility that build the tree (default: :py:data:`models.RESOURCE_TREE_SERVICE`).
+    :param limit_depth: Maximum depth to look for children resources (very deep if not specified, could be slow).
     :returns: ``{node: Resource, children: {node_id: <recursive>}}``
     """
     if tree_service_builder is None:
         tree_service_builder = models.RESOURCE_TREE_SERVICE
-    query = tree_service_builder.from_parent_deeper(resource.resource_id, db_session=db_session)
+    kwargs = {}
+    if isinstance(limit_depth, int):
+        kwargs["limit_depth"] = limit_depth
+    query = tree_service_builder.from_parent_deeper(resource.resource_id, db_session=db_session, **kwargs)
     tree_struct_dict = tree_service_builder.build_subtree_strut(query)
     return tree_struct_dict["children"]
 

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -167,6 +167,7 @@ if TYPE_CHECKING:
     # generic 'configuration' field under a service that supports it
     ServiceConfiguration = Dict[Str, Union[Str, List[JSON], JSON]]
     ServiceConfigItem = TypedDict("ServiceConfigItem", {
+        "name": Optional[Str],  # injected in some cases from parent dict key
         "url": Str,
         "title": Str,
         "type": Str,

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -84,7 +84,8 @@ if TYPE_CHECKING:
     }, total=False)
     # recursive nodes structure employed by functions for listing children resources hierarchy
     # {<res-id>: {"node": <res>, "children": {<res-id>: ... }}
-    NestedResourceNodes = Dict[int, "ResourceNode"]
+    _ResourceNode = "ResourceNode"  # type: TypeAlias  # pylint: disable=C0103
+    NestedResourceNodes = Dict[int, _ResourceNode]
     ResourceNode = TypedDict("ResourceNode", {
         "node": ServiceOrResourceType,
         "children": NestedResourceNodes

--- a/tests/hooks/request_hooks.py
+++ b/tests/hooks/request_hooks.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from pyramid.request import Request
     from pyramid.response import Response
 
+    from magpie.adapter import HookContext
     from magpie.typedefs import ServiceConfigItem, ServiceHookConfigItem
 
 
@@ -52,10 +53,20 @@ def add_x_wps_output_link(response, hook):
 
 # only to demonstrate that hook/service parameters can be combined however we want
 # also, this hook is used in combination with above one in matching condition to test multi-hook chaining
-def combined_arguments(response, service, hook):
-    # type: (Response, ServiceConfigItem, ServiceHookConfigItem) -> Response
+def combined_arguments(response, service, hook, context):
+    # type: (Response, ServiceConfigItem, ServiceHookConfigItem, HookContext) -> Response
     for i, svc_hook in enumerate(service["hooks"]):
         if svc_hook == hook:
             response.headers["X-Magpie-Hook-Index"] = str(i)  # string because header requires it
             break
+    # below is to validate definitions during testing of hook feature
+    assert context
+    assert context.request is response.request
+    assert context.response is response
+    assert context.hook == hook
+    assert context.service
+    assert context.service.service_type == "api"
+    assert context.resource
+    assert context.resource.resource_name == "weaver"
+    assert context.resource.resource_type == "service"
     return response


### PR DESCRIPTION
## Changes

Add ``context`` parameter available for `Service Hook` functions, offering more handlers to obtain references to
  the adapter, the request's `Service` implementation, and the corresponding database `Resource`. This can be used,
  amongst other things, to perform advanced operations such as validating other `Resource` and `Permission` conditions
  to modify the handled ``request`` or ``response`` by the hook.

## Context

When attempting to implement [DAC-178 *6.2.2 - Filter processes based on permissions*](https://crim-ca.atlassian.net/browse/DAC-178), it became quite obvious that the parameters offered by hooks were not sufficient. For filtering items returned by `/processes` for example, a check of all items in that response must be done. With the previous parameters, this involved recomputing many elements from the baser service JSON definitions, when in fact, many are already computed and fetched from the database for processing the request.

A single `context` parameter is used to "package" anything that could be necessary, mostly to limit a growing number of parameters over time. It also allows us to reuse some precomputed elements based on internal Magpie logic. 