### PR TITLE
fix email related validation to avoid duplicates

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -48,7 +48,7 @@ jobs:
       #     https://github.com/eshork/gitleaks-action/issues/3
       #- uses: fmigneault/gitleaks-action@master
       #- uses: eshork/gitleaks-action@v1.0.0
-      - uses: zricethezav/gitleaks-action@master
+      - uses: gitleaks/gitleaks-action@v1.6.0  # see: https://github.com/gitleaks/gitleaks-action/issues/57
 
       # NOTE:
       #   does the same as gitleaks-action, but over the whole git history + posts found problem on issue/PR comments

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,11 @@ jobs:
         if: ${{ matrix.python-version != 'none' }}
         with:
           python-version: ${{ matrix.python-version }}
+      # run 'install-sys' by itself first even if other targets depend on it to setup pip
+      # this ensures that the auto-resolved PIP_XARGS will match the active pip version for following installs
+      - name: Install Package Managers
+        if: ${{ matrix.python-version != 'none' }}
+        run: make install-sys
       - name: Install Dependencies
         if: ${{ matrix.python-version != 'none' }}
         run: make install-pkg install-dev version

--- a/.pylintrc
+++ b/.pylintrc
@@ -75,6 +75,9 @@ disable=C0111,missing-docstring,
         E0401,import-error,
         R0201,no-self-use,
         R0205,useless-object-inheritance,
+        # R0401 disabled to avoid unnecessary warnings on already handled circular imports
+        # See issue : https://github.com/PyCQA/pylint/issues/850
+        R0401,cyclic-import,
         R0801,duplicate-code,
         R0904,too-many-public-methods,
         R0912,too-many-branches,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,15 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
 * Nothing new for the moment.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix conflicting ``User`` email not properly reported in UI with an appropriate message in creation page.
+  The ``User`` name was instead reported as the conflicting property, although it was not the problematic field
+  (resolves `#521 <https://github.com/Ouranosinc/Magpie/issues/521>`_).
 
 .. _changes_3.26.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Features / Changes
   | If any ``User`` entries with duplicate case-insensitive emails are present in the database, the application
     will fail when performing the database migration. Resolve those cases manually before starting `Magpie`.
 
+* Display ``User`` email field in UI page providing the list of registered and pending users.
+* Add ``mailto:`` link for all ``User`` email fields displayed in UI.
+
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~
 * Fix conflicting ``User`` email not properly reported in UI with an appropriate message in creation page.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,11 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* Nothing new for the moment.
+* | Add database unique index to ensure case-insensitive ``User`` email cannot be stored.
+  |
+  | **IMPORTANT**:
+  | If any ``User`` entries with duplicate case-insensitive emails are present in the database, the application
+    will fail when performing the database migration. Resolve those cases manually before starting `Magpie`.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -86,14 +86,20 @@ PIP_USE_FEATURE := `python -c '\
 	import pip; \
 	from distutils.version import LooseVersion; \
 	print(LooseVersion(pip.__version__) < LooseVersion("21.0"))'`
+PIP_DISABLE_FEATURE := `python -c '\
+	import pip; \
+	from distutils.version import LooseVersion; \
+	print(LooseVersion(pip.__version__) >= LooseVersion("22.0"))'`
 ifeq ($(findstring "--use-feature=2020-resolver",$(PIP_XARGS)),)
   # feature not specified, but needed
   ifeq ("$(PIP_USE_FEATURE)", "True")
     PIP_XARGS := --use-feature=2020-resolver $(PIP_XARGS)
   else
     # use faster legacy resolver
-    ifeq ($(subst "--use-deprecated=legacy-resolver",,$(PIP_XARGS)),)
-      PIP_XARGS := --use-deprecated=legacy-resolver $(PIP_XARGS)
+    ifeq ($(PIP_DISABLE_FEATURE), "False")
+      ifeq ($(findstring "--use-deprecated=legacy-resolver",$(PIP_XARGS)),)
+        PIP_XARGS := --use-deprecated=legacy-resolver $(PIP_XARGS)
+      endif
     endif
     ifeq ($(findstring "--use-feature=fast-deps",$(PIP_XARGS)),)
       PIP_XARGS := --use-feature=fast-deps $(PIP_XARGS)
@@ -105,10 +111,12 @@ else
     PIP_XARGS := $(subst "--use-feature=2020-resolver",,$(PIP_XARGS))
   else
     # use faster legacy resolver
-    ifeq $(subst "--use-deprecated=legacy-resolver",,$(PIP_XARGS))
-      PIP_XARGS := --use-deprecated=legacy-resolver $(PIP_XARGS)
+    ifeq ($(PIP_DISABLE_FEATURE), "False")
+      ifeq ($(findstring "--use-deprecated=legacy-resolver",$(PIP_XARGS)),)
+        PIP_XARGS := --use-deprecated=legacy-resolver $(PIP_XARGS)
+      endif
     endif
-  	ifeq ($(findstring "--use-feature=fast-deps",$(PIP_XARGS)),)
+    ifeq ($(findstring "--use-feature=fast-deps",$(PIP_XARGS)),)
       PIP_XARGS := --use-feature=fast-deps $(PIP_XARGS)
     endif
   endif

--- a/magpie/alembic/script.py.mako
+++ b/magpie/alembic/script.py.mako
@@ -8,11 +8,12 @@ Create Date: ${create_date}
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.orm.session import sessionmaker
 
 # Revision identifiers, used by Alembic.
 # pylint: disable=C0103,invalid-name  # revision control variables not uppercase
-%if revision:
-revision = "${revision}"
+%if up_revision:
+revision = "${up_revision}"
 %else:
 revision = None
 %endif
@@ -31,6 +32,8 @@ depends_on = "${depends_on}"
 %else:
 depends_on = None
 %endif
+
+Session = sessionmaker()
 
 
 def upgrade():

--- a/magpie/alembic/versions/2022-09-01_5e5acc33adce_case_insensitive_email_constraint.py
+++ b/magpie/alembic/versions/2022-09-01_5e5acc33adce_case_insensitive_email_constraint.py
@@ -1,0 +1,30 @@
+"""
+Case Insensitive Email Constraint
+
+Revision ID: 5e5acc33adce
+Revises: 0c6269f410cd
+Create Date: 2022-09-01 21:16:40.175730
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "5e5acc33adce"
+down_revision = "0c6269f410cd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_users_email_unique_case_insensitive",
+        "users",
+        [text("lower(email)")],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index("ix_users_email_unique_case_insensitive", "users")

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -2004,8 +2004,13 @@ class User_Check_ForbiddenResponseSchema(BaseResponseSchemaAPI):
     body = ErrorResponseBodySchema(code=HTTPForbidden.code, description=description)
 
 
-class User_Check_ConflictResponseSchema(BaseResponseSchemaAPI):
+class User_Check_Name_ConflictResponseSchema(BaseResponseSchemaAPI):
     description = "User name matches an already existing user name."
+    body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
+
+
+class User_Check_Email_ConflictResponseSchema(BaseResponseSchemaAPI):
+    description = "User email matches an already existing user email."
     body = ErrorResponseBodySchema(code=HTTPConflict.code, description=description)
 
 
@@ -3681,7 +3686,7 @@ Users_POST_responses = {
     "401": UnauthorizedResponseSchema(),
     "403": Users_POST_ForbiddenResponseSchema(),  # FIXME: https://github.com/Ouranosinc/Magpie/issues/359
     "406": NotAcceptableResponseSchema(),
-    "409": User_Check_ConflictResponseSchema(),
+    "409": User_Check_Name_ConflictResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
 User_GET_responses = {
@@ -3699,7 +3704,7 @@ User_PATCH_responses = {
     "401": UnauthorizedResponseSchema(),
     "403": UserGroup_GET_ForbiddenResponseSchema(),  # FIXME: https://github.com/Ouranosinc/Magpie/issues/359
     "406": NotAcceptableResponseSchema(),
-    "409": User_Check_ConflictResponseSchema(),
+    "409": User_Check_Name_ConflictResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
 User_DELETE_responses = {

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 from ziggurat_foundations import ziggurat_model_init
 from ziggurat_foundations.models.base import BaseModel, get_db_session
 from ziggurat_foundations.models.external_identity import ExternalIdentityMixin
@@ -512,16 +513,16 @@ class UserSearchService(UserService):
             if status is not None:
                 status = [int(status) for status in status]
                 query = query.in_(status)
-            return query.filter((User.user_name == user_name) | (User.email == email)).first()
+            return query.filter((User.user_name == user_name) | (func.lower(User.email) == email.lower())).first()
         user = cls.by_user_name(user_name=user_name, status=status, db_session=db_session)
         if user is not None:
             return user
         if status is UserStatuses.Pending:
-            return db_session.query(UserPending).filter(UserPending.email == email).first()
+            return db_session.query(UserPending).filter(func.lower(UserPending.email) == email.lower()).first()
         user = super(UserSearchService, cls).by_email(email=email, db_session=db_session)
         if user is not None and UserStatuses.get(user.status) in status:
             return user
-        return db_session.query(UserPending).filter(UserPending.email == email).first()
+        return db_session.query(UserPending).filter(func.lower(UserPending.email) == email.lower()).first()
 
 
 class ExternalIdentity(ExternalIdentityMixin, Base):

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -757,8 +757,8 @@ table.simple-list tr.list-row-even {
 }
 
 table.simple-list tr,
-table.simple-list td:first-child,
-table.simple-list th:first-child {
+table.simple-list td:first-child:not(.user-info),
+table.simple-list th:first-child:not(.user-info) {
     width: 75%;
     text-align: left;
 }
@@ -771,6 +771,18 @@ table.simple-list th:not(:first-child) {
 table.simple-list input[type="button"],
 table.simple-list input[type="submit"] {
     margin: 0 0.5em;
+}
+
+table.simple-list th.user-info,
+table.simple-list td.user-info {
+    text-align: left;
+}
+table.simple-list td.user-info:first-child {
+    width: 25%;
+}
+
+table.simple-list td:last-child {
+    width: 10%;
 }
 
 /* --- Resource tree rendering  --- */

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -777,6 +777,7 @@ table.simple-list th.user-info,
 table.simple-list td.user-info {
     text-align: left;
 }
+
 table.simple-list td.user-info:first-child {
     width: 25%;
 }

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -177,7 +177,9 @@
                                         </label>
                                     %else:
                                         <label>
-                                        <span class="panel-value">${email}</span>
+                                        <span class="panel-value">
+                                            <a href="mailto:${email}">${email}</a>
+                                        </span>
                                         %if user_name not in MAGPIE_FIXED_USERS:
                                             <input type="submit" value="Edit" name="edit_email" class="button theme">
                                         %endif

--- a/magpie/ui/management/templates/view_pending_user.mako
+++ b/magpie/ui/management/templates/view_pending_user.mako
@@ -58,7 +58,9 @@
                             <form id="edit_email" action="${request.path}" method="post">
                                 <div class="panel-line-entry">
                                     <label>
-                                        <span class="panel-value">${email}</span>
+                                        <span class="panel-value">
+                                            <a href="mailto:${email}">${email}</a>
+                                        </span>
                                         <input type="submit" value="Edit" name="edit_email" class="button theme">
                                     </label>
                                 </div>

--- a/magpie/ui/management/templates/view_users.mako
+++ b/magpie/ui/management/templates/view_users.mako
@@ -16,20 +16,31 @@
 <table class="simple-list" id="view_users_list">
 <thead class="theme">
 <tr>
-    <th>User</th>
+    <th class="user-info">User</th>
+    <th class="user-info">Email</th>
     <th>Status</th>
     <th>Action</th>
 </tr>
 </thead>
 <tbody>
-%for i, user_name in enumerate(users):
+%for i, user_info in enumerate(users):
+    <%
+        user_name = user_info["name"]
+        user_email = user_info["email"]
+    %>
     <form action="${request.path}" method="post">
         %if i % 2:
         <tr class="list-row-even">
         %else:
         <tr class="list-row-odd">
         %endif
-            <td><input type="hidden" value="${user_name}" name="user_name">${user_name}</td>
+            <td class="user-info">
+                <input type="hidden" value="${user_name}" name="user_name">
+                ${user_name}
+            </td>
+            <td class="user-info">
+                <a href="mailto:${user_email}">${user_email}</a>
+            </td>
             <td>
                 <div class="status-container">
                     %if user_name in users_with_error:

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -79,10 +79,10 @@ class ManagementViews(AdminRequests, BaseViews):
 
         users = self.get_user_details(status="all")
         non_error = UserStatuses.OK | UserStatuses.Pending  # use combine in case more error types gets added later on
-        user_names = [user["user_name"] for user in users]
+        user_info = [{"name": user["user_name"], "email": user["email"]} for user in users]
         user_error = [user["user_name"] for user in users if UserStatuses.get(user["status"]) not in non_error]
         pending = [user["user_name"] for user in users if UserStatuses.get(user["status"]) == UserStatuses.Pending]
-        return self.add_template_data({"users": user_names, "users_with_error": user_error, "users_pending": pending})
+        return self.add_template_data({"users": user_info, "users_with_error": user_error, "users_pending": pending})
 
     @view_config(route_name="add_user", renderer="templates/add_user.mako")
     def add_user(self):

--- a/magpie/ui/user/templates/edit_current_user.mako
+++ b/magpie/ui/user/templates/edit_current_user.mako
@@ -173,7 +173,9 @@
                                         </label>
                                     %else:
                                         <label>
-                                            <span class="panel-value">${email}</span>
+                                            <span class="panel-value">
+                                                <a href="mailto:${email}">${email}</a>
+                                            </span>
                                             %if user_edit_email and user_name not in MAGPIE_USER_PWD_LOCKED:
                                             <input type="submit" value="Edit" name="edit_email" class="button theme">
                                             %else:

--- a/magpie/ui/utils.py
+++ b/magpie/ui/utils.py
@@ -558,7 +558,7 @@ class AdminRequests(BaseViews):
 
         # soft pre-checks
         user_details = self.get_user_details(status="all", cookies=admin_cookies)
-        if user_email in [usr["email"] for usr in user_details]:
+        if user_email in [usr["email"].lower() for usr in user_details]:
             data["invalid_user_email"] = True
             data["reason_user_email"] = "Conflict"
         if user_email == "":
@@ -577,7 +577,7 @@ class AdminRequests(BaseViews):
             data["invalid_password"] = True
             data["reason_password"] = "Mismatch"  # nosec: B105  # avoid false positive
 
-        check_data = ["invalid_user_name", "invalid_email", "invalid_password", "invalid_group_name"]
+        check_data = ["invalid_user_name", "invalid_user_email", "invalid_password", "invalid_group_name"]
         for check_fail in check_data:
             if data.get(check_fail, False):
                 return self.add_template_data(data)
@@ -595,7 +595,7 @@ class AdminRequests(BaseViews):
         resp = request_api(self.request, path, "POST", data=payload)
 
         # hard post checks, retrieve known errors related to fields to display messages instead of raising
-        if resp.status_code in (HTTPBadRequest.code, HTTPUnprocessableEntity.code):
+        if resp.status_code in (HTTPBadRequest.code, HTTPConflict.code, HTTPUnprocessableEntity.code):
             # attempt to retrieve the API more-specific reason why the operation is invalid
             body = get_json(resp)
             param_name = body.get("param", {}).get("name")

--- a/magpie/ui/utils.py
+++ b/magpie/ui/utils.py
@@ -558,7 +558,7 @@ class AdminRequests(BaseViews):
 
         # soft pre-checks
         user_details = self.get_user_details(status="all", cookies=admin_cookies)
-        if user_email in [usr["email"].lower() for usr in user_details]:
+        if (user_email or "").lower() in [usr["email"].lower() for usr in user_details]:
             data["invalid_user_email"] = True
             data["reason_user_email"] = "Conflict"
         if user_email == "":

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ mock; python_version < "3.6"
 mock>4; python_version >= "3.6"
 pylint<2.7; python_version < "3.6"  # pyup: ignore
 # ignore 2.12 bad docstring asterisks args handling (https://github.com/PyCQA/pylint/issues/5406)
-pylint>=2.11,!=2.12; python_version >= "3.6"
+pylint>=2.11,!=2.12,!=2.15; python_version >= "3.6"
 pylint-quotes
 # bird-house/twticher, must match version in Dockerfile.adapater
 pyramid-twitcher>=0.5.3; python_version < "3.6"  # pyup: ignore

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,7 @@
 # these are doc-only requirements
 # we actually need to install all requirements during docs build because of OpenAPI generation
 # (see 'docs/conf.py')
+astroid<2.12    # pin to resolve sphinx-autoapi (see https://github.com/readthedocs/sphinx-autoapi/issues/349)
 cloud_sptheme
 jinja2<3.1  # fix sphinx failing, see: https://github.com/sphinx-doc/sphinx/issues/10291
 pycodestyle==2.6.0; python_version >= "3.6"

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7496,9 +7496,12 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         # filter only to users of this test to avoid failing side-effects from other test data
         test_user_forms = {user: utils.find_html_form(user_forms, {"user_name": user}) for user in test_users}
         utils.check_val_equal(len(test_user_forms), len(test_users), msg="Could not find all test user forms")
-        # each form has an HTML body with 'status' in it, the status is located on second column (index = 1)
+        # each form has an HTML body with 'status' in it
+        # status is located on second column (index = 1) in older versions [user, status, buttons]
+        # status is located on third column (index = 2) in newer versions [user, email, status, buttons]
+        status_index = 2 if utils.TestSetup.get_Version(self) >= TestVersion("3.27.0") else 1
         html_search = [{"name": "form"}, {"class": ["list-row-even", "list-row-odd"]},
-                       {"name": "td", "index": 1}, {"class": ["status-container"]}]
+                       {"name": "td", "index": status_index}, {"class": ["status-container"]}]
         test_user_statuses = {user: utils.find_html_body_contents(form.html, html_search)
                               for user, form in test_user_forms.items()}
         for user in test_users:
@@ -7509,6 +7512,44 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
                                       msg="Expected user with 'error' status to display the correct error code.")
             else:
                 utils.check_val_is_in("OK", str(test_user_statuses[user]), msg="Expected user to have 'OK' status.")
+
+    @runner.MAGPIE_TEST_STATUS
+    @runner.MAGPIE_TEST_USERS
+    def test_GetUsersList_DisplayedEmails(self):
+        """
+        Validate that UI user list page displays user email next to its name.
+        """
+        utils.warn_version(self, "user emails displayed in UI user list page", "3.27.0", skip=True)
+
+        un_anonym = get_constant("MAGPIE_ANONYMOUS_USER")
+        un_admin = get_constant("MAGPIE_ADMIN_USER")
+        ue_anonym = get_constant("MAGPIE_ANONYMOUS_EMAIL")
+        ue_admin = get_constant("MAGPIE_ADMIN_EMAIL")
+        u1_name = "test-{}".format(uuid.uuid4())
+        u2_name = "test-{}".format(uuid.uuid4())
+        test_users = [un_anonym, un_admin, u1_name, u2_name]
+        expect_emails = {un_anonym: ue_anonym, un_admin: ue_admin}
+        utils.TestSetup.create_TestGroup(self)
+        for user_name in [u1_name, u2_name]:
+            body = utils.TestSetup.create_TestUser(self, override_user_name=user_name)
+            info = utils.TestSetup.get_UserInfo(self, override_body=body)
+            expect_emails[user_name] = info["email"]
+
+        resp = utils.TestSetup.check_UpStatus(self, method="GET", path="/ui/users", expected_type=CONTENT_TYPE_HTML)
+        user_forms = resp.forms  # every user is in a distinct form
+        # filter only to users of this test to avoid failing side-effects from other test data
+        test_user_forms = {user: utils.find_html_form(user_forms, {"user_name": user}) for user in test_users}
+        utils.check_val_equal(len(test_user_forms), len(test_users), msg="Could not find all test user forms")
+        html_search = [{"name": "form"}, {"class": ["list-row-even", "list-row-odd"]},
+                       {"name": "td", "index": 1}, {"name": "a", "attribute": "href"}]
+        test_user_emails = {
+            user: utils.find_html_body_contents(form.html, html_search)
+            for user, form in test_user_forms.items()
+        }
+        utils.check_val_true(all(email.startswith("mailto:") for email in test_user_emails.values()),
+                             msg="All emails should display links to send email.")
+        test_emails_visible = {user: email.split(":")[-1] for user, email in test_user_emails.items()}
+        utils.check_val_equal(test_emails_visible, expect_emails)
 
     @runner.MAGPIE_TEST_STATUS
     @runner.MAGPIE_TEST_USERS

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -4571,8 +4571,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         ]
         utils.TestSetup.delete_TestUser(self, override_user_name=other_name)
         utils.TestSetup.create_TestGroup(self)
-        body = utils.TestSetup.create_TestUser(self, override_email=test_email)
-        info = utils.TestSetup.get_UserInfo(self, override_body=body)
+        utils.TestSetup.create_TestUser(self, override_email=test_email)
         data = {
             "user_name": other_name,
             "password": self.test_user_name,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1631,9 +1631,12 @@ def find_html_body_contents(response_or_body, html_search=None):
         provided within the same level-search to distinguish between multiple matches to pick a single one.
 
         If provided, definition ``index`` must be an integer corresponding to the item to pick within a set.
-        When using ``index``, the HTML items to pick from do not need to be represent similar sub-contents.
+        When using ``index``, the HTML items to pick from do not need to represent similar sub-contents.
         If provided, definition ``attribute`` must be a string corresponding to an HTML attribute that is contained
         by only one item within multiple matches.
+
+        If the last matched element is unique (not a list) and the corresponding final search definition of this item
+        provides ``attribute``, the value of this attribute will be returned instead of the full element definition.
 
         Only the last nested element can return multiple matches (list of elements), intermediate elements must all be
         unique in order to search deeper in the nested definitions. If multiple intermediate elements can be matched,
@@ -1680,6 +1683,9 @@ def find_html_body_contents(response_or_body, html_search=None):
             body = parts[0]  # move to next child element to search
         # otherwise, search is done, return found item or list of elements
         elif len(parts) == 1:
+            elem_attr = search_element.get("attribute")
+            if elem_attr and elem_attr in parts[0].attrs:
+                return parts[0].attrs[elem_attr]
             return parts[0]
         else:
             parts = [item for item in parts if str(item).strip()]  # remove empty items separators

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -192,7 +192,7 @@ def make_run_option_decorator(run_option):
     @functools.wraps(run_option)
     def wrap(test_func, *_, **__):
         # type: (Callable, Any, Any) -> Callable
-        pytest_marker = pytest.mark.__getattr__(run_option.marker)
+        pytest_marker = getattr(pytest.mark, run_option.marker)
         unittest_skip = unittest.skipUnless(*run_option())
         test_func = pytest_marker(test_func)
         test_func = unittest_skip(test_func)


### PR DESCRIPTION
# Features / Changes

* Add database unique index to ensure case-insensitive ``User`` email cannot be stored.
* Display ``User`` email field in UI page providing the list of registered and pending users.
* Add ``mailto:`` link for all ``User`` email fields displayed in UI.

# Bug Fixes
* Fix conflicting ``User`` email not properly reported in UI with an appropriate message in creation page.
  The ``User`` name was instead reported as the conflicting property, although it was not the problematic field 
  (resolves #521).

# Important 
If any ``User`` entries with duplicate case-insensitive emails are present in the database, the application will fail when performing the database migration. Resolve those cases manually before starting `Magpie`.