### PR TITLE
ignore linkcheck on down login providers when their servers status are down

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ def ignore_down_providers():
         )
         if prov_down:
             print(f"Ignoring provider [{prov_key}] detected as all instances down for link-check.")
-            locations = set(prov_cfg["hostname"] + prov_cfg["locations"])
+            locations = set([prov_cfg["hostname"]] + prov_cfg["locations"])
             locations |= set("https://{}".format(url) for url in locations)
             down_list.extend(list(locations))
     return down_list


### PR DESCRIPTION
Avoid failing checks for external causes.

When performing link-checks in the documentation and code docstrings, any login provider that is down due to maintenance fails the PR and validation pipeline. Use a status endpoint that reports down instances to consider them as unreachable and temporarily ignore them to avoid the "broken" link errors.