### PR TITLE
update dependency requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,13 +4,14 @@ autopep8>=1.5.4; python_version >= "3.6"
 backports.tempfile; python_version < "3"
 bandit==1.7.1; python_version < "3.7"  # pyup: ignore
 bandit==1.7.4; python_version >= "3.7"
-bump2version==1.0.0
+bump2version==1.0.1
 codacy-coverage>=1.3.11
-coverage==5.5; python_version < "3"
-coverage==5.5,<5.6; python_version >= "3"
+coverage==5.5; python_version < "3"  # pyup: ignore
+coverage>=5.5; python_version >= "3"
 doc8; python_version < "3.6"
 doc8>=0.8; python_version >= "3.6"
-docformatter==1.4
+docformatter==1.4; python_version < "3.6"  # pyup: ignore
+docformatter; python_version >= "3.6"
 flake8; python_version < "3.6"
 flake8>=3.8.3,<3.9; python_version >= "3.6"
 isort; python_version < "3.6"

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -4,7 +4,8 @@
 astroid<2.12    # pin to resolve sphinx-autoapi (see https://github.com/readthedocs/sphinx-autoapi/issues/349)
 cloud_sptheme
 jinja2<3.1  # fix sphinx failing, see: https://github.com/sphinx-doc/sphinx/issues/10291
-pycodestyle==2.6.0; python_version >= "3.6"
+pycodestyle>=2.6.0,<2.9.0; python_version <= "3.5"  # pyup: ignore
+pycodestyle>=2.6.0,<3; python_version >= "3.6"
 # sphinx-autoapi dropped 3.5 support at 1.3.0
 # latest to fullfil requirements, but that is not the main doc builder version
 sphinx-autoapi; python_version < "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,8 +52,8 @@ six>=1.12.0
 sqlalchemy==1.3.22
 sqlalchemy_utils<0.36.4; python_version < "3"    # pyup: ignore
 sqlalchemy_utils==0.37.9; python_version >= "3"  # pyup: ignore
-threddsclient==0.4.1; python_version < "3"
-threddsclient>=0.4.1; python_version >= "3"
+threddsclient==0.4.2; python_version < "3"       # pyup: ignore
+threddsclient>=0.4.2; python_version >= "3"
 transaction
 typing; python_version < "3"
 # typing extension required for TypedDict


### PR DESCRIPTION
- update dependency requirements to most recent packages versions
- ignore pyup backward compats for older python

follow-up with #532, depends on  #535