### PR TITLE
maintenance update of Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,11 @@ jobs:
             python-version: 3.6
             allow-failure: true
             test-case: test-local
+          # test allowed failing for recent versions
+          - os: ubuntu-latest
+            python-version: 3.11
+            allow-failure: true
+            test-case: test-local
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         # os: [ubuntu-latest, windows-latest]
         # python-version: ["2.7", "3.5", "3.6", "3.7", "3.8"]
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         allow-failure: [false]
         test-case: [test-local]
         # can use below option to set environment variables or makefile settings applied during test execution
@@ -67,10 +67,10 @@ jobs:
             test-case: start test-remote
           # test allowed failing because of old versions
           # FIXME: remove altogether (twitcher does not support it for a long time)
-          #- os: ubuntu-latest
-          #  python-version: 2.7
-          #  allow-failure: true
-          #  test-case: test-local
+          - os: ubuntu-latest
+            python-version: 2.7
+            allow-failure: true
+            test-case: test-local
           - os: ubuntu-latest
             python-version: 3.5
             allow-failure: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, windows-latest]
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         allow-failure: [false]
         test-case: [test-local]
         # can use below option to set environment variables or makefile settings applied during test execution
@@ -84,10 +84,10 @@ jobs:
             allow-failure: true
             test-case: test-local
           # test allowed failing for recent versions
-          - os: ubuntu-latest
-            python-version: 3.11
-            allow-failure: true
-            test-case: test-local
+          # - os: ubuntu-latest
+          #   python-version: 3.12
+          #   allow-failure: true
+          #   test-case: test-local
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,9 +47,8 @@ jobs:
     strategy:
       matrix:
         # os: [ubuntu-latest, windows-latest]
-        # python-version: ["2.7", "3.5", "3.6", "3.7", "3.8"]
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         allow-failure: [false]
         test-case: [test-local]
         # can use below option to set environment variables or makefile settings applied during test execution
@@ -65,16 +64,6 @@ jobs:
             python-version: 3.7
             allow-failure: true
             test-case: start test-remote
-          # test allowed failing because of old versions
-          # FIXME: remove altogether (twitcher does not support it for a long time)
-          - os: ubuntu-latest
-            python-version: 2.7
-            allow-failure: true
-            test-case: test-local
-          - os: ubuntu-latest
-            python-version: 3.5
-            allow-failure: true
-            test-case: test-local
           # coverage test
           - os: ubuntu-latest
             python-version: 3.7
@@ -85,12 +74,15 @@ jobs:
             python-version: none
             allow-failure: true
             test-case: test-docker
-          # --- debug ---
-          # - os: ubuntu-latest
-          #   python-version: 3.7
-          #   allow-failure: false
-          #   test-case: test-custom
-          #   test-option: MAGPIE_LOG_LEVEL=DEBUG TEST_LOG_LEVEL=DEBUG SPEC='test_import_target or TestAdapterHooks'
+          # test allowed failing for legacy versions
+          - os: ubuntu-latest
+            python-version: 3.5
+            allow-failure: true
+            test-case: test-local
+          - os: ubuntu-latest
+            python-version: 3.6
+            allow-failure: true
+            test-case: test-local
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* Add Python 3.9 and 3.10 support.
+* Add Python 3.9, 3.10 and 3.11 support.
 * Drop Python 2.7 support.
 * Mark Python 3.5 and 3.6 as legacy versions.
   Those are not recommended for security reasons, but are technically still functional to run `Magpie`.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,17 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add Python 3.9 and 3.10 support.
+* Drop Python 2.7 support.
+* Mark Python 3.5 and 3.6 as legacy versions.
+  Those are not recommended for security reasons, but are technically still functional to run `Magpie`.
+  To run `Magpie` within `Twitcher`, Python 3.6 is required.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Maintenance updates for security fixes of dependency packages.
 
 .. _changes_3.28.0:
 

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
     * - releases
       - | |version| |commits-since|
 
-.. |py_ver_support| image:: https://img.shields.io/badge/python%20%28legacy%20support%29-2.7%2C%203.5%2B-orange.svg
-    :alt: Python 2.7, 3.5+ supported (legacy)
+.. |py_ver_support| image:: https://img.shields.io/badge/python%20%28legacy%20support%29-3.5%2B-orange.svg
+    :alt: Python 3.5+ supported (legacy)
     :target: https://www.python.org/getit
 
 .. |py_ver_recommend| image:: https://img.shields.io/badge/python%20%28recommended%29-3.7%2B-blue.svg

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
     :widths: 10,90
 
     * - dependencies
-      - | |py_ver| |dependencies|
+      - | |py_ver_support| |py_ver_recommend| |dependencies|
     * - tests status
       - | |github_latest| |github_tagged| |coverage| |codacy|
     * - docker status
@@ -27,8 +27,12 @@ Behind the scene, it uses `Ziggurat-Foundations`_ and `Authomatic`_.
     * - releases
       - | |version| |commits-since|
 
-.. |py_ver| image:: https://img.shields.io/badge/python-2.7%2C%203.5%2B-blue.svg
-    :alt: Requires Python 2.7, 3.5+
+.. |py_ver_support| image:: https://img.shields.io/badge/python%20%28legacy%20support%29-2.7%2C%203.5%2B-orange.svg
+    :alt: Python 2.7, 3.5+ supported (legacy)
+    :target: https://www.python.org/getit
+
+.. |py_ver_recommend| image:: https://img.shields.io/badge/python%20%28recommended%29-3.7%2B-blue.svg
+    :alt: Python 3.7+ recommended
     :target: https://www.python.org/getit
 
 .. |commits-since| image:: https://img.shields.io/github/commits-since/Ouranosinc/Magpie/3.27.0.svg

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     python_requires=">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
 

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -213,7 +213,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
+    python_requires=">=3.5, <4",
 
     # -- Package structure -------------------------------------------------
     packages=[__meta__.__package__],

--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     python_requires=">=3.5, <4",
 


### PR DESCRIPTION
- add Python 3.9, 3.10, 3.11 to test pipeline
- mark Python 3.5, 3.6 as legacy support
- drop Python 2.7 support (officially, but was not working for a while due to recent changes)