### PR TITLE
add service type to permission webhooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add the ``service.type`` data in the `Webhooks` for a `Permission` change, even if the resource is not a service,
+  since the root service type is necessary to `Cowbird`.
 
 .. _changes_3.33.0:
 

--- a/magpie/api/management/group/group_utils.py
+++ b/magpie/api/management/group/group_utils.py
@@ -190,7 +190,7 @@ def create_group_resource_permission_response(group, resource, permission, db_se
     ax.evaluate_call(lambda: db_session.add(new_perm), fallback=lambda: db_session.rollback(),
                      http_error=HTTPForbidden, content=perm_content,
                      msg_on_fail=s.GroupResourcePermissions_POST_ForbiddenAddResponseSchema.description)
-    webhook_params = get_permission_update_params(group, resource, permission)
+    webhook_params = get_permission_update_params(group, resource, permission, db_session)
     process_webhook_requests(WebhookAction.CREATE_GROUP_PERMISSION, webhook_params)
     return ax.valid_http(http_success=http_success, content=perm_content, detail=http_detail)
 
@@ -277,7 +277,7 @@ def delete_group_resource_permission_response(group, resource, permission, db_se
     ax.evaluate_call(lambda: db_session.delete(del_perm), fallback=lambda: db_session.rollback(),
                      http_error=HTTPForbidden, content=perm_content,
                      msg_on_fail=s.GroupServicePermission_DELETE_ForbiddenResponseSchema.description)
-    webhook_params = get_permission_update_params(group, resource, permission)
+    webhook_params = get_permission_update_params(group, resource, permission, db_session)
     process_webhook_requests(WebhookAction.DELETE_GROUP_PERMISSION, webhook_params)
     return ax.valid_http(http_success=HTTPOk, detail=s.GroupServicePermission_DELETE_OkResponseSchema.description)
 

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -310,7 +310,7 @@ def create_user_resource_permission_response(user, resource, permission, db_sess
     ax.evaluate_call(lambda: db_session.add(new_perm), fallback=lambda: db_session.rollback(),
                      http_error=HTTPForbidden, content=err_content,
                      msg_on_fail=s.UserResourcePermissions_POST_ForbiddenResponseSchema.description)
-    webhook_params = get_permission_update_params(user, resource, permission)
+    webhook_params = get_permission_update_params(user, resource, permission, db_session)
     process_webhook_requests(WebhookAction.CREATE_USER_PERMISSION, webhook_params)
     return ax.valid_http(http_success=http_success, content=err_content, detail=http_detail)
 
@@ -470,7 +470,7 @@ def delete_user_resource_permission_response(user, resource, permission, db_sess
     ax.evaluate_call(lambda: db_session.delete(del_perm), fallback=lambda: db_session.rollback(),
                      http_error=HTTPNotFound, content=err_content,
                      msg_on_fail=s.UserResourcePermissionName_DELETE_NotFoundResponseSchema.description)
-    webhook_params = get_permission_update_params(user, resource, permission)
+    webhook_params = get_permission_update_params(user, resource, permission, db_session)
     process_webhook_requests(WebhookAction.DELETE_USER_PERMISSION, webhook_params)
     return ax.valid_http(http_success=HTTPOk, detail=s.UserResourcePermissionName_DELETE_OkResponseSchema.description)
 

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -13,8 +13,8 @@ from magpie import models
 from magpie.api import exception as ax
 from magpie.api import schemas as s
 from magpie.api.management.group.group_formats import format_group
-from magpie.api.management.resource.resource_formats import format_resource
 from magpie.api.management.resource import resource_utils as ru
+from magpie.api.management.resource.resource_formats import format_resource
 from magpie.api.management.service.service_formats import format_service
 from magpie.api.management.user.user_formats import format_user
 from magpie.constants import get_constant

--- a/magpie/api/webhooks.py
+++ b/magpie/api/webhooks.py
@@ -170,8 +170,8 @@ def get_permission_update_params(target,         # type: Union[models.User, mode
     else:
         res_params = {"service.{}".format(param): None for param in ["name", "sync_type", "public_url"]}
         # Add the root service type even for non-service resources, since it is needed by Cowbird.
-        res_params["service.type"] = \
-            ru.get_resource_root_service_by_id(resource.resource_id, db_session=db_session).type
+        res_params["service.type"] = ru.get_resource_root_service_by_id(
+            resource.resource_id, db_session=db_session).type
     res_params.update(format_resource(resource, basic_info=True, dotted=True))
     params = permission.webhook_params()
     params.update(target_params)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -554,7 +554,7 @@ class TestWebhooks(ti.AdminTestCase):
                     expected["data"]["resource_type"] = self.test_resource_type
                     expected["data"]["resource_id"] = res_id
                     expected["data"]["service_name"] = None
-                    expected["data"]["service_type"] = None
+                    expected["data"]["service_type"] = self.test_service_type
                     expected["data"]["service_public_url"] = None
                 else:
                     expected["data"]["resource_name"] = self.test_service_name


### PR DESCRIPTION
Add the `service.type` data in the `Webhooks` for a `Permission` change, even if the resource is not a service,
since the root service type is necessary to `Cowbird`.