### PR TITLE
support API request paths under GeoServer service

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ formats:
   #- pdf
   #- epub
 python:
-  version: "3.7"
+  version: "3.10"
   install:
     - requirements: requirements-sys.txt
     - requirements: requirements-doc.txt
@@ -21,4 +21,3 @@ python:
 #      path: .
 #      extra_requirements:
 #        - docs
-  system_packages: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ formats:
   #- pdf
   #- epub
 python:
-  version: "3.10"
+  version: "3.8"
   install:
     - requirements: requirements-sys.txt
     - requirements: requirements-doc.txt

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,14 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add support of RESTful API endpoints (i.e.: ``ServiceAPI``) under ``ServiceGeoserver`` using ``Route`` resources
+  (fixes `#584 <https://github.com/Ouranosinc/Magpie/issues/584>`_).
+  Requires the `Service` to be configured either with the default ``configuration``,
+  or by explicitly setting ``api: true``. When a HTTP request is sent toward a `Service` typed ``ServiceGeoserver``,
+  any non-`OWS` request (i.e.: `WFS`, `WMS`, `WPS`) will default to the resolution handling of typical ``ServiceAPI``.
+  This can be used notably to access the ``/web`` and ``/ogc`` endpoints of a `GeoServer` instance.
 
 .. _changes_3.34.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-.. explicit references must be used in this file (not references.rst) to ensure they are directly rendered on Github
+    .. explicit references must be used in this file (not references.rst) to ensure they are directly rendered on Github
 .. :changelog:
 
 Changes
@@ -17,6 +17,13 @@ Features / Changes
   or by explicitly setting ``api: true``. When a HTTP request is sent toward a `Service` typed ``ServiceGeoserver``,
   any non-`OWS` request (i.e.: `WFS`, `WMS`, `WPS`) will default to the resolution handling of typical ``ServiceAPI``.
   This can be used notably to access the ``/web`` and ``/ogc`` endpoints of a `GeoServer` instance.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~~~~
+* Fix `UI` rendering of the `Permission` label list under a `Service` edition page when a large amount of possible
+  permissions is applicable. This was notably the case of ``ServiceGeoserver`` that combines permissions of multiple
+  `OWS`-based services, which where going out of bound of the UI page.
+* Fix `UI` scrollbars going over the `Permission` titles in the `User` and `Group` permission edition pages.
 
 .. _changes_3.34.0:
 

--- a/Makefile
+++ b/Makefile
@@ -564,8 +564,9 @@ check-security-code-only: mkdir-reports  ## run security checks on source code
 .PHONY: check-docs-only
 check-docs-only: check-doc8-only check-docf-only check-links-only	## run every code documentation checks
 
-# FIXME: temporary workaround (https://github.com/PyCQA/doc8/issues/145)
-# 		configuration somehow not picked up directly from setup.cfg
+# FIXME: temporary workaround (https://github.com/PyCQA/doc8/issues/145 and https://github.com/PyCQA/doc8/issues/147)
+# 		configuration somehow not picked up directly from setup.cfg in python 3.11
+#		setting 'ignore-path-errors' not working without the full path (relative 'docs/changes.rst' fails)
 CHECK_DOC8_XARGS := --ignore-path-errors "$(APP_ROOT)/docs/changes.rst;D000"
 
 .PHONY: check-doc8-only

--- a/Makefile
+++ b/Makefile
@@ -564,12 +564,17 @@ check-security-code-only: mkdir-reports  ## run security checks on source code
 .PHONY: check-docs-only
 check-docs-only: check-doc8-only check-docf-only check-links-only	## run every code documentation checks
 
+# FIXME: temporary workaround (https://github.com/PyCQA/doc8/issues/145)
+# 		configuration somehow not picked up directly from setup.cfg
+CHECK_DOC8_XARGS := --ignore-path-errors "$(APP_ROOT)/docs/changes.rst;D000"
+
 .PHONY: check-doc8-only
 check-doc8-only: mkdir-reports		## run PEP8 documentation style checks
 	@echo "Running PEP8 doc style checks..."
 	@-rm -fr "$(REPORTS_DIR)/check-doc8.txt"
 	@bash -c '$(CONDA_CMD) \
 		doc8 --config "$(APP_ROOT)/setup.cfg" "$(APP_ROOT)/docs" \
+			$(CHECK_DOC8_XARGS) \
 		1> >(tee "$(REPORTS_DIR)/check-doc8.txt")'
 
 # FIXME: move parameters to setup.cfg when implemented (https://github.com/myint/docformatter/issues/10)

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -139,7 +139,7 @@ providers:
     title: geoserver
     public: true
     c4i: false
-    type: wfs
+    type: geoserver
     sync_type: wfs
 
   geoserver-web:

--- a/config/providers.cfg
+++ b/config/providers.cfg
@@ -10,15 +10,42 @@
 #
 # Parameters:
 # -----------
-#   url:        private URL of the service to be created
-#   title:      pretty name of the service (real name is the section key)
-#   public:     parameter passed down to Phoenix for service registration
-#   c4i:        parameter passed down to Phoenix for service registration
-#   type:       service type to use for creation, must be one of the known Magpie service types
-#               (see: magpie.services.SERVICE_TYPE_DICT)
-#   sync_type:  service synchronization type, must be one of the known Magpie service sync-types,
-#               often equals to 'type' (see: magpie.cli.SYNC_SERVICES_TYPES)
-#   hooks:      list of request processing hooks for the service
+#   url:            private URL of the service to be created
+#   title:          pretty name of the service (real name is the section key)
+#   public:         parameter passed down to Phoenix for service registration
+#   c4i:            parameter passed down to Phoenix for service registration
+#   type:           service type to use for creation, must be one of the known Magpie service types
+#                   (see: magpie.services.SERVICE_TYPE_DICT)
+#   sync_type:      service synchronization type, must be one of the known Magpie service sync-types,
+#                   often equals to 'type' (see: magpie.cli.sync_services.SYNC_SERVICES_TYPES)
+#   configuration:  advanced custom configuration for service type that support it (see details in section below)
+#   hooks:          list of request processing hooks for the service (see details in section below)
+#
+# Configuration (requires Magpie>=3.21.0 minimally, or more recent version as relevant for specific features)
+# -------------
+#   Some services allow custom configuration settings to slightly modify their behaviour for handling requests.
+#   This can be used to enable/disable a subset of functionalities offered by a given service, or to control special
+#   logic of request properties for the service. The specific configuration format differs for each service type, and
+#   is only supported for certain cases listed below. More configuration details are provided in the documentation.
+#
+#   - type: geoserver   (see also: https://pavics-magpie.readthedocs.io/en/latest/services.html#servicegeoserver)
+#     configuration:
+#       wfs: true|false   # allows use of OWS WFS requests with Workspaces and Layers
+#       wms: true|false   # allows use of OWS WMS requests with Workspaces and Layers
+#       wps: true|false   # allows use of OWS WPS requests with Workspaces and Processes
+#       api: true|false   # allows use of REST API requests with OGC API and Web UI endpoints
+#
+#   - type: thredds    (see also: https://pavics-magpie.readthedocs.io/en/latest/services.html#servicethredds)
+#     configuration:
+#       skip_prefix: "<path>/<sub>"   # path prefix to skip (strip) before processing the rest of the request path
+#       file_patterns:                # patterns to map different path variations to a same file resource
+#         - "<regex>"
+#       metadata_type:                #  path prefix to resources to consider as BROWSE-able metadata
+#         prefixes:
+#           - "<regex|path>"
+#       data_type:                    #  path prefix to resources to consider as READ-able data
+#         prefixes:
+#           - "<regex|path>"
 #
 # Hooks: (requires Magpie>=3.25.0, Twitcher>=0.7.0)
 # ------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -215,7 +215,8 @@ linkcheck_ignore = [
     "https://pcmdi.llnl.gov/",  # works, but very often causes false-positive 'broken' links
 ] + ignore_down_providers()
 linkcheck_anchors_ignore = [
-    r".*issuecomment.*"   # GitHub issue comment anchors not resolved
+    r".*issuecomment.*",  # GitHub issue comment anchors not resolved
+    "defusedxmllxml",  # not found because of GitHub dynamic links
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -571,16 +571,18 @@ administrator intends to only make use (for the moment) of :term:`WFS` functiona
         url: http://localhost:1234
         type: geoserver
 
-        # customizable configuration (enable desired OWS request handlers)
-        # all OWS are enabled by default if no configuration is provided
+        # customizable configuration (enable desired OWS/REST request handlers)
+        # all OWS/REST services are enabled by default if no configuration is provided
         configuration:
           wfs: true
           wms: false
           wps: false
+          api: false
 
-This would make sure that request parsing and access to :term:`WMS` and :term:`WPS` endpoints is disabled, but leaves
-the :term:`Resource` definitions available for use at a later time if the administrator decides to eventually make use
-of them. For example, the administrator could decide to start using :term:`WMS` as well without any further change
+This would make sure that request parsing and access to :term:`WMS`, :term:`WPS` and any REST :term:`API` endpoints
+are disabled, but leaves the :term:`Resource` definitions available for use at a later time if the administrator
+decides to eventually make use of them.
+For example, the administrator could decide to start using :term:`WMS` as well without any further change
 needed other than updating this :term:`Service` custom configuration and applying :term:`Permissions <Permission>`
 specific only to :term:`WMS`.
 All other :term:`Applied Permissions <Applied Permission>` to existing :term:`User`, :term:`Group` and :term:`Resource`
@@ -590,7 +592,8 @@ the :term:`WFS` to :term:`WMS` request handlers.
 .. note::
     Custom configuration can be provided With either the `providers.cfg`_ (as presented above), in
     a :ref:`config_file` as described in greater lengths within the :ref:`configuration` chapter,
-    or by providing the ``configuration`` field directly within the API request body during :term:`Service` creation.
+    or by providing the ``configuration`` field directly within the :term:`API` request body during
+    :term:`Service` creation.
 
 
 Service Synchronization

--- a/magpie/owsrequest.py
+++ b/magpie/owsrequest.py
@@ -48,7 +48,6 @@ def ows_parser_factory(request):
 
 
 class OWSParser(object):
-
     def __init__(self, request):
         self.request = request
         self.params = {}
@@ -94,7 +93,6 @@ class OWSGetParser(OWSParser):
 
 
 class OWSPostParser(OWSParser):
-
     def __init__(self, request):
         super(OWSPostParser, self).__init__(request)
         self.document = xml_util.fromstring(self.request.body)

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -1004,7 +1004,7 @@ class ServiceGeoserverBase(ServiceOWS):
         """
         if cls.resource_param is None:
             return []
-        elif isinstance(cls.resource_param, six.string_types):
+        if isinstance(cls.resource_param, six.string_types):
             impl_params = [cls.resource_param]
         elif isinstance(cls.resource_param, list):
             impl_params = cls.resource_param
@@ -1527,7 +1527,7 @@ class ServiceGeoserver(ServiceGeoserverBase):
         Without the :class:`models.Workspace` scope in the path, ``identifier`` parameter fails to be resolved by
         `Geoserver`, as if it was unspecified. Attribute :attr:`ServiceGeoserverWPS.resource_scoped` controls the
         behaviour of splitting the defined :attr:`resource_param` into :class:`models.Workspace` and child components.
-        
+
     .. note::
         The :class:`models.Route` is allowed at the root of the service and for any nested :class:`models.Route`
         resource to support various endpoints such as the ``/web`` user interface, or the REST interface for the

--- a/magpie/ui/home/static/style.css
+++ b/magpie/ui/home/static/style.css
@@ -388,6 +388,12 @@ table.panel-line td {
     max-width: 1em;
 }
 
+.panel-line-permissions {
+    max-width: 100%;
+    white-space: normal;
+    line-height: 1.5em;
+}
+
 .panel-line-checkbox {
     padding-top: 0.1em;
     display: inline-block;
@@ -400,6 +406,11 @@ table.panel-line td {
 .panel-entry {
     font-weight: bold;
     margin-right: 0.5em;
+    margin-top: 0.25em;
+}
+
+.panel-entry-title {
+    vertical-align: top;
 }
 
 .panel-value {
@@ -912,6 +923,7 @@ table.simple-list td:last-child {
 
 .tree-line-scroll-visible {
     overflow-x: auto;
+    min-height: 2.5em;  /* ensure the scroll-bar doesn't hide the title texts */
 }
 
 .tree-key {
@@ -977,6 +989,7 @@ div.tree-button {
     text-overflow: ellipsis;
     overflow: auto;
     text-align: left;
+    min-height: 2em;  /* ensure the scroll-bar doesn't hide the title texts */
 }
 
 .permission-cell {

--- a/magpie/ui/management/templates/edit_group.mako
+++ b/magpie/ui/management/templates/edit_group.mako
@@ -55,8 +55,8 @@
             <div class="panel-fields">
                 <table class="panel-line">
                     <tr>
-                        <td>
-                            <span class="panel-entry">Name: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Name: </div>
                         </td>
                         <td>
                             <form id="edit_name" action="${request.path}" method="post">
@@ -97,8 +97,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Description: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Description: </div>
                         </td>
                         <td>
                             <form id="edit_description" action="${request.path}" method="post">
@@ -135,8 +135,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Discoverable: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Discoverable: </div>
                         </td>
                         <td>
                             <form id="edit_discoverable" action="${request.path}" method="post">

--- a/magpie/ui/management/templates/edit_service.mako
+++ b/magpie/ui/management/templates/edit_service.mako
@@ -82,8 +82,8 @@
             <div class="panel-fields">
                 <table class="panel-line">
                     <tr>
-                        <td>
-                            <span class="panel-entry">Name: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Name: </div>
                         </td>
                         <td>
                             <form action="${request.path}" method="post">
@@ -106,8 +106,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Protected URL: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Protected URL: </div>
                         </td>
                         <td>
                             <form action="${request.path}" method="post">
@@ -130,8 +130,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Public URL: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Public URL: </div>
                         </td>
                         <td>
                             <div class="panel-line-entry">
@@ -140,8 +140,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Type: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Type: </div>
                         </td>
                         <td>
                             <div class="panel-line-entry">
@@ -150,8 +150,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Sync Type: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Sync Type: </div>
                         </td>
                         <td>
                             <div class="panel-line-entry">
@@ -162,11 +162,11 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Permissions: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Permissions: </div>
                         </td>
                         <td>
-                            <div class="panel-line-entry panel-line-limit-size">
+                            <div class="panel-line-entry panel-line-limit-size panel-line-permissions">
                                 %for perm in service_perm:
                                     <span class="label label-warning">${perm}</span>
                                 %endfor
@@ -174,8 +174,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">ID: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">ID: </div>
                         </td>
                         <td>
                             <div class="panel-line-entry">

--- a/magpie/ui/management/templates/edit_user.mako
+++ b/magpie/ui/management/templates/edit_user.mako
@@ -55,8 +55,8 @@
             <div class="panel-fields">
                 <table class="panel-line">
                     <tr>
-                        <td>
-                            <span class="panel-entry">Username: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Username: </div>
                         </td>
                         <td>
                             %if user_name not in MAGPIE_FIXED_USERS:
@@ -107,8 +107,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Password: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Password: </div>
                         </td>
                         <td>
                             %if user_name not in MAGPIE_USER_PWD_DISABLED:
@@ -159,8 +159,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Email: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Email: </div>
                         </td>
                         <td>
                             %if user_name not in MAGPIE_FIXED_USERS:
@@ -210,8 +210,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Status: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Status: </div>
                         </td>
                         <td>
                             <div class="status-container">

--- a/magpie/ui/management/templates/view_pending_user.mako
+++ b/magpie/ui/management/templates/view_pending_user.mako
@@ -39,8 +39,8 @@
             <div class="panel-fields">
                 <table class="panel-line">
                     <tr>
-                        <td>
-                            <span class="panel-entry">Username: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Username: </div>
                         </td>
                         <td>
                             <div class="panel-line-entry">
@@ -51,8 +51,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Email: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Email: </div>
                         </td>
                         <td>
                             <form id="edit_email" action="${request.path}" method="post">
@@ -68,8 +68,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Status: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Status: </div>
                         </td>
                         <td>
                             <div class="status-container">
@@ -92,8 +92,8 @@
                 <table class="panel-line">
                     <!--- fixme: should have a way to regenerate a new email confirmation url? --->
                     <tr>
-                        <td>
-                            <span class="panel-entry">Registration: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Registration: </div>
                         </td>
                         <td>
                             <div class="panel-line-entry">

--- a/magpie/ui/user/templates/edit_current_user.mako
+++ b/magpie/ui/user/templates/edit_current_user.mako
@@ -81,8 +81,8 @@
             <div class="panel-fields">
                 <table class="panel-line">
                     <tr>
-                        <td>
-                            <span class="panel-entry">Username: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Username: </div>
                         </td>
                         <td>
                             <div class="panel-line-entry">
@@ -105,8 +105,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Password: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Password: </div>
                         </td>
                         <td>
                             <form id="edit_password" action="${request.path}" method="post">
@@ -156,8 +156,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Email: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Email: </div>
                         </td>
                         <td>
                             %if user_edit_email:
@@ -216,8 +216,8 @@
                         </td>
                     </tr>
                     <tr>
-                        <td>
-                            <span class="panel-entry">Status: </span>
+                        <td class="panel-entry-title">
+                            <div class="panel-entry">Status: </div>
                         </td>
                         <td>
                             <div class="status-container">

--- a/magpie/xml_util.py
+++ b/magpie/xml_util.py
@@ -5,7 +5,7 @@ Package :mod:`lxml` is employed directly even though some linters (e.g.: ``bandi
 instead, because that package's extension with ``lxml`` is marked as deprecated.
 
 .. seealso::
-    https://pypi.org/project/defusedxml/#defusedxml-lxml
+    https://github.com/tiran/defusedxml#defusedxmllxml
 
 To use the module, import is as if importing ``lxml.etree``:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ universal = 1
 [doc8]
 max-line-length = 120
 ignore-path = docs/_build,docs/autoapi
+ignore-path-errors = docs/changes.rst;D000,
 
 [flake8]
 ignore = E501,W291,W503,W504

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -6910,8 +6910,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                 Workspace.resource_type_name,
             ]
             struct_allowed = {
-                Service.resource_type_name: [Workspace.resource_type_name, Route.resource_type_name],
-                Route.resource_type_name: [Workspace.resource_type_name, Route.resource_type_name],
+                Service.resource_type_name: [Route.resource_type_name, Workspace.resource_type_name],
+                Route.resource_type_name: [Route.resource_type_name, Workspace.resource_type_name],
                 Workspace.resource_type_name: [Layer.resource_type_name, Process.resource_type_name],
                 Layer.resource_type_name: [],
                 Process.resource_type_name: [],
@@ -6934,7 +6934,7 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.check_val_is_in("resource_types_allowed", svc)
         utils.check_val_is_in("resource_structure_allowed", svc)
         utils.check_val_equal(svc["resource_child_allowed"], True)
-        utils.check_val_equal(svc["resource_types_allowed"], res_types_allowed)
+        utils.check_all_equal(svc["resource_types_allowed"], res_types_allowed, any_order=True)
         utils.check_val_equal(svc["resource_structure_allowed"], struct_allowed)
 
         path = "/resources/{}/types".format(svc_id)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -248,7 +248,6 @@ class TestAdapter(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
 @runner.MAGPIE_TEST_ADAPTER
 @runner.MAGPIE_TEST_FUNCTIONAL
 class TestAdapterHooks(ti.SetupTwitcher, ti.UserTestCase, ti.BaseTestCase):
-
     __test__ = True
 
     @classmethod


### PR DESCRIPTION
# Features / Changes

* Add support of RESTful API endpoints (i.e.: ``ServiceAPI``) under ``ServiceGeoserver`` using ``Route`` resources
  (fixes https://github.com/Ouranosinc/Magpie/issues/584).
  Requires the `Service` to be configured either with the default ``configuration``,
  or by explicitly setting ``api: true``. When a HTTP request is sent toward a `Service` typed ``ServiceGeoserver``,
  any non-`OWS` request (i.e.: `WFS`, `WMS`, `WPS`) will default to the resolution handling of typical ``ServiceAPI``.
  This can be used notably to access the ``/web`` and ``/ogc`` endpoints of a `GeoServer` instance.

# Bug Fixes

* Fix `UI` rendering of the `Permission` label list under a `Service` edition page when a large amount of possible
  permissions is applicable. This was notably the case of ``ServiceGeoserver`` that combines permissions of multiple
  `OWS`-based services, which where going out of bound of the UI page.
* Fix `UI` scrollbars going over the `Permission` titles in the `User` and `Group` permission edition pages.

  Before UI fixes: 
  ![image](https://github.com/Ouranosinc/Magpie/assets/19194484/e22747a2-8fe1-48fd-ba5b-64e1480b6e28)

  After UI fixes: 
  ![image](https://github.com/Ouranosinc/Magpie/assets/19194484/07b9dbe2-cb16-4989-8de8-db473e905c99)

Relates to https://github.com/bird-house/birdhouse-deploy/pull/348
