### PR TITLE
Add API endpoint ``GET /services/{service_name}/resources/{resource_id}``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,13 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+* Add `API` endpoint ``GET /services/{service_name}/resources/{resource_id}`` similar to
+  existing endpoint ``GET /resources/{resource_id}`` allowing retrieval of a `Resource` details
+  with prior validation that it lies under the referenced `Service`
+  (fixes `#347 <https://github.com/Ouranosinc/Magpie/issues/347>`_).
+* Improve ``JSON`` typing definitions to reduce false-positives linting errors and add missing typing definitions.
 
 .. _changes_3.35.0:
 

--- a/magpie/api/management/resource/resource_views.py
+++ b/magpie/api/management/resource/resource_views.py
@@ -61,14 +61,16 @@ def get_resource_handler(request):
     if "service_name" in request.matchdict:
         # if the requested resource ID is the service itself, 'root_service_id=None', must check 'resource_id' also
         service = ar.get_service_matchdict_checked(request)
-        ax.verify_param(service.resource_id, [resource.root_service_id, resource.resource_id],
-                        is_in=True, param_name="service_name",
-                        http_error=HTTPNotFound,
-                        content={
-                            "service": sf.format_service(service, basic_info=True),
-                            "resource": rf.format_resource(resource, basic_info=True),
-                        },
-                        msg_on_fail="Requested resource is not located under the specified service.")
+        ax.verify_param(
+            service.resource_id, [resource.root_service_id, resource.resource_id],
+            is_in=True, param_name="service_name",
+            http_error=HTTPNotFound,
+            content={
+                "service": sf.format_service(service, basic_info=True),
+                "resource": rf.format_resource(resource, basic_info=True),
+            },
+            msg_on_fail="Requested resource is not located under the specified service.",
+        )
 
     parents = asbool(ar.get_query_param(request, ["parents", "parent"], False))
     flatten = False

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -455,19 +455,19 @@ class ContentType(colander.SchemaNode):
 
 class RequestHeaderSchemaAPI(colander.MappingSchema):
     accept = AcceptType(name="Accept", validator=colander.OneOf(SUPPORTED_ACCEPT_TYPES),
-                        description="Desired MIME type for the response body content.")
+                        description="Desired media-type for the response body content.")
     content_type = ContentType(validator=colander.OneOf(KNOWN_CONTENT_TYPES),
-                               description="MIME content type of the request body.")
+                               description="Media-type of the request body content.")
 
 
 class RequestHeaderSchemaUI(colander.MappingSchema):
     content_type = ContentType(default=CONTENT_TYPE_HTML, example=CONTENT_TYPE_HTML,
-                               description="MIME content type of the request body.")
+                               description="Media-type of the request body content.")
 
 
 class QueryRequestSchemaAPI(colander.MappingSchema):
     format = AcceptType(validator=colander.OneOf(SUPPORTED_FORMAT_TYPES),
-                        description="Desired MIME type for the response body content. "
+                        description="Desired media-type for the response body content. "
                                     "This formatting alternative by query parameter overrides the Accept header.")
 
 
@@ -601,7 +601,7 @@ class BaseRequestSchemaAPI(colander.MappingSchema):
 
 class HeaderResponseSchema(colander.MappingSchema):
     content_type = ContentType(validator=colander.OneOf(SUPPORTED_ACCEPT_TYPES),
-                               description="MIME content type of the response body.")
+                               description="Media-type of the response body content.")
 
 
 class BaseResponseSchemaAPI(colander.MappingSchema):
@@ -1787,6 +1787,10 @@ class ServiceResources_POST_ForbiddenResponseSchema(Resources_POST_ForbiddenResp
 class ServiceResources_POST_UnprocessableEntityResponseSchema(BaseResponseSchemaAPI):
     description = "Provided 'parent_id' value is invalid."
     body = ErrorResponseBodySchema(code=HTTPUnprocessableEntity.code, description=description)
+
+
+class ServiceResource_GET_RequestSchema(Resource_GET_RequestSchema):
+    service_name = ServiceNameParameter
 
 
 # delete service's resource use same method as direct resource delete
@@ -3654,6 +3658,7 @@ ServiceTypeResourceTypes_GET_responses = {
     "422": UnprocessableEntityResponseSchema(),
     "500": InternalServerErrorResponseSchema(),
 }
+ServiceResource_GET_responses = Resource_GET_responses
 ServiceResource_DELETE_responses = {
     "200": ServiceResource_DELETE_OkResponseSchema(),
     "400": Resource_MatchDictCheck_BadRequestResponseSchema(),  # FIXME: https://github.com/Ouranosinc/Magpie/issues/359

--- a/magpie/typedefs.py
+++ b/magpie/typedefs.py
@@ -56,9 +56,13 @@ if TYPE_CHECKING:
 
     AnyKey = Union[Str, int]
     AnyValue = Union[Str, Number, bool, None]
-    _JSONType = "JSON"  # type: TypeAlias   # pylint: disable=C0103
-    BaseJSON = Union[AnyValue, List[_JSONType], Dict[AnyKey, _JSONType]]
-    JSON = Union[Dict[Str, Union[_JSONType]], List[_JSONType]]
+    _JSON = "JSON"  # type: TypeAlias  # pylint: disable=C0103
+    _JsonObjectItemAlias = "_JsonObjectItem"  # type: TypeAlias  # pylint: disable=C0103
+    _JsonListItemAlias = "_JsonListItem"  # type: TypeAlias  # pylint: disable=C0103
+    _JsonObjectItem = Dict[str, Union[AnyValue, _JSON, _JsonObjectItemAlias, _JsonListItemAlias]]
+    _JsonListItem = List[Union[AnyValue, _JSON, _JsonObjectItem, _JsonListItemAlias]]
+    _JsonItem = Union[AnyValue, _JSON, _JsonObjectItem, _JsonListItem]
+    JSON = Union[Dict[str, Union[_JSON, _JsonItem]], List[Union[_JSON, _JsonItem]], AnyValue]
 
     GroupPriority = Union[int, Type[math.inf]]
     UserServicesType = Union[Dict[Str, Dict[Str, Any]], List[Dict[Str, Any]]]

--- a/tests/test_magpie_api.py
+++ b/tests/test_magpie_api.py
@@ -591,7 +591,7 @@ class TestCase_MagpieAPI_UsersAuth_Remote(ti.Interface_MagpieAPI_UsersAuth, unit
         cls.version = utils.TestSetup.get_Version(cls, real_version=True)
         cls.setup_admin()
         cls.headers, cls.cookies = utils.check_or_try_login_user(cls, cls.usr, cls.pwd, use_ui_form_submit=True)
-        cls.require = "cannot run tests without logged in user with '{}' permissions".format(cls.grp)
+        cls.require = "cannot run tests without logged-in user with '{}' permissions".format(cls.grp)
         assert cls.headers and cls.cookies, cls.require  # nosec
 
         cls.test_service_name = "unittest-user-auth-remote_test-service"
@@ -688,4 +688,4 @@ def test_response_metadata():
 
 if __name__ == "__main__":
     import sys
-    sys.exit(unittest.main())
+    sys.exit(unittest.main())  # type: ignore

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,7 +61,6 @@ if TYPE_CHECKING:
 
     import tests.interfaces as ti
     from magpie.compat import TupleVersion
-    from magpie.services import ServiceInterface
     from magpie.typedefs import (
         JSON,
         AnyCookiesType,
@@ -613,7 +612,7 @@ def get_json_body(response):
 
 
 def get_service_types_for_version(version):
-    # type: (Str) -> List[ServiceInterface]
+    # type: (Str) -> List[Str]
     available_service_types = set(services.SERVICE_TYPE_DICT)
     if TestVersion(version) <= TestVersion("0.6.1"):
         available_service_types = available_service_types - {ServiceAccess.service_type}


### PR DESCRIPTION
## Changes

* Add `API` endpoint ``GET /services/{service_name}/resources/{resource_id}`` similar to
  existing endpoint ``GET /resources/{resource_id}`` allowing retrieval of a `Resource` details
  with prior validation that it lies under the referenced `Service`
  (fixes #347).
* Improve ``JSON`` typing definitions to reduce false-positives linting errors and add missing typing definitions.