### PR TITLE
fix doc8 config parsing error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -570,7 +570,7 @@ Features / Changes
   `Ouranosinc/Magpie#473 <https://github.com/Ouranosinc/Magpie/pull/473>`_,
   see also
   `Avoid Accessing the Authentication Policy
-  <https://docs.pylonsproject.org/projects/pyramid-tm/en/latest/#avoid-accessing-the-authentication-policy>`_).
+  <https://docs.pylonsproject.org/projects/pyramid_tm/en/latest/#avoid-accessing-the-authentication-policy>`_).
 
 .. _changes_3.17.1:
 

--- a/Makefile
+++ b/Makefile
@@ -564,10 +564,7 @@ check-security-code-only: mkdir-reports  ## run security checks on source code
 .PHONY: check-docs-only
 check-docs-only: check-doc8-only check-docf-only check-links-only	## run every code documentation checks
 
-# FIXME: temporary workaround (https://github.com/PyCQA/doc8/issues/145 and https://github.com/PyCQA/doc8/issues/147)
-# 		configuration somehow not picked up directly from setup.cfg in python 3.11
-#		setting 'ignore-path-errors' not working without the full path (relative 'docs/changes.rst' fails)
-CHECK_DOC8_XARGS := --ignore-path-errors "$(APP_ROOT)/docs/changes.rst;D000"
+CHECK_DOC8_XARGS ?=
 
 .PHONY: check-doc8-only
 check-doc8-only: mkdir-reports		## run PEP8 documentation style checks

--- a/magpie/api/exception.py
+++ b/magpie/api/exception.py
@@ -437,7 +437,8 @@ def raise_http(http_error=HTTPInternalServerError,  # type: Type[HTTPError]
 
     # fail-fast if recursion generates too many calls
     # this would happen only if a major programming error occurred within this function
-    global RAISE_RECURSIVE_SAFEGUARD_MAX    # pylint: disable=W0602,W0603
+    # a global variable is used since raised conditions are not "directly" recursive (they can be included anywhere),
+    # and therefore there is no obvious method to "pass down" the recursive count variable between those calls
     global RAISE_RECURSIVE_SAFEGUARD_COUNT  # pylint: disable=W0602,W0603
     RAISE_RECURSIVE_SAFEGUARD_COUNT = RAISE_RECURSIVE_SAFEGUARD_COUNT + 1
     if RAISE_RECURSIVE_SAFEGUARD_COUNT > RAISE_RECURSIVE_SAFEGUARD_MAX:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ codacy-coverage>=1.3.11
 coverage==5.5; python_version < "3"  # pyup: ignore
 coverage>=5.5; python_version >= "3"
 doc8; python_version < "3.6"
-doc8>=0.8; python_version >= "3.6"
+doc8>=1.1.2; python_version >= "3.7"
 docformatter==1.4; python_version < "3.6"  # pyup: ignore
 docformatter; python_version >= "3.6"
 flake8; python_version < "3.6"


### PR DESCRIPTION
Depends on https://github.com/PyCQA/doc8/pull/148
Requires eventual release of `doc8>=1.1.2` integrating above fix.