### PR TITLE
network mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,9 @@ Changes
 
 Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
-* n/a
+* Introduce "Network Mode" which allows other Magpie instances to act as external authentication providers using JSON
+  Web Tokens (JWT). This allows users registered across multiple Magpie instances in a network to more easily gain
+  access to the resources within the network, without requiring the duplication of user credentials across the network.
 
 Bug Fixes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -28,6 +28,10 @@ pyramid.includes =
 magpie.port = 2001
 magpie.url = http://localhost:2001
 
+# Enable network mode which allows different instances of Magpie to authenticate users for each other.
+# magpie.network_mode = true
+# magpie.default_token_expiry = 86400
+
 # magpie.config_path =
 
 # --- cookie definition --- (defaults below if omitted)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -969,6 +969,83 @@ remain available as described at the start of the :ref:`Configuration` section.
     Name of the :term:`Provider` used for login. This represents the identifier that is set to define how to
     differentiate between a local sign-in procedure and a dispatched one some known :ref:`authn_providers`.
 
+Network Mode Settings
+~~~~~~~~~~~~~~~~~~~~~
+
+The following configuration parameters are related to Magpie's "Network Mode" which allows networked instances of Magpie
+to authenticate users for each other. All variables defined in this section are only used if
+:envvar:`MAGPIE_NETWORK_MODE` is enabled.
+
+.. envvar:: MAGPIE_NETWORK_MODE
+
+    [:class:`bool`]
+    (Default: ``False``)
+
+    .. versionadded:: 3.37
+
+    Enable "Network Mode" which enables all functionality to authenticate users using other Magpie instances as
+    external authentication providers.
+
+.. envvar:: MAGPIE_INSTANCE_NAME
+
+    [:class:`str`]
+
+    .. versionadded:: 3.37
+
+    The name of this Magpie instance in the network. This variable is used to determine if an authentication token was
+    issued by this instance of Magpie, or another instance in the network.
+
+    This variable is required if :envvar:`MAGPIE_NETWORK_MODE` is ``True``.
+
+.. envvar:: MAGPIE_DEFAULT_TOKEN_EXPIRY
+
+    [:class:`int`]
+    (Default: ``86400``)
+
+    .. versionadded:: 3.37
+
+    The default expiry time (in seconds) for an authentication token issued for the purpose of network authentication.
+
+.. envvar:: MAGPIE_NETWORK_TOKEN_NAME
+
+    [|constant|_]
+    (Value: ``"magpie_token"``)
+
+    .. versionadded:: 3.37
+
+    The name of the request parameter key whose value is the authentication token issued for the purpose of network
+    authentication.
+
+.. envvar:: MAGPIE_NETWORK_PROVIDER
+
+    [|constant|_]
+    (Value: ``"magpie_network"``)
+
+    .. versionadded:: 3.37
+
+    The name of the external provider that authenticates users using other Magpie instances as external authentication
+    providers.
+
+.. envvar:: MAGPIE_NETWORK_NAME_PREFIX
+
+    [|constant|_]
+    (Value: ``"anonymous_network_"``)
+
+    .. versionadded:: 3.37
+
+    A prefix added to the anonymous network user and network group names. These names are constructed by prepending the
+    remote Magpie instance name with this prefix. For example, a Magpie instance named ``"example123"`` will have a
+    corresponding user and group named ``"anonymous_network_example123"``.
+
+.. envvar:: MAGPIE_NETWORK_GROUP_NAME
+
+    [|constant|_]
+    (Value: ``"magpie_network"``)
+
+    .. versionadded:: 3.37
+
+    The name of the group created to manage permissions for all users authenticated using Magpie instances as external
+    authentication providers.
 
 .. _config_phoenix:
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -138,6 +138,16 @@ Glossary
         :py:data:`magpie.constants.MAGPIE_ANONYMOUS_USER`. Otherwise, it is whoever the
         :term:`Authentication` mechanism identifies with token extracted from request :term:`Cookies`.
 
+    Network Node
+        A reference to an instance of the Magpie software within a network of Magpie instances. Each Magpie instance
+        within the network is registered in the database as a row in the ``network_nodes`` table. Each node is
+        represented by a name that is unique across all nodes in the network, and a url that is used to send http
+        requests to that specific node.
+
+    Network Token
+        A unique random string that can be used to authenticate a user as part of the :ref:`Network Mode` authentication
+        procedure.
+
     OpenAPI
     OAS
         The |OpenAPI-spec|_ (`OAS`) defines a standard, programming language-agnostic interface description for

--- a/magpie/alembic/versions/2023-08-25_2cfe144538e8_add_network_tables.py
+++ b/magpie/alembic/versions/2023-08-25_2cfe144538e8_add_network_tables.py
@@ -1,0 +1,54 @@
+"""
+Add Network_Tokens Table
+
+Revision ID: 2cfe144538e8
+Revises: 5e5acc33adce
+Create Date: 2023-08-25 13:36:16.930374
+"""
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm.session import sessionmaker
+from sqlalchemy_utils import URLType
+
+# Revision identifiers, used by Alembic.
+# pylint: disable=C0103,invalid-name  # revision control variables not uppercase
+revision = "2cfe144538e8"
+down_revision = "5e5acc33adce"
+branch_labels = None
+depends_on = None
+
+Session = sessionmaker()
+
+
+def upgrade():
+    op.create_table("network_tokens",
+                    sa.Column("token", UUID(as_uuid=True),
+                              primary_key=True, default=uuid.uuid4, unique=True),
+                    sa.Column("user_id", sa.Integer,
+                              sa.ForeignKey("users.id", onupdate="CASCADE", ondelete="CASCADE"), unique=True)
+                    )
+    op.create_table("network_nodes",
+                    sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+                    sa.Column("name", sa.Unicode(128), nullable=False, unique=True),
+                    sa.Column("url", URLType(), nullable=False)
+                    )
+    op.add_column("users", sa.Column("network_node_id", sa.Integer,
+                                     sa.ForeignKey("network_nodes.id", onupdate="CASCADE", ondelete="CASCADE"),
+                                     nullable=True))
+    op.drop_constraint("uq_users_user_name", "users")
+    op.create_unique_constraint("uq_users_user_name_network_node_id", "users", ["user_name", "network_node_id"])
+    op.drop_constraint("uq_users_email", "users")
+    op.create_unique_constraint("uq_users_email_network_node_id", "users", ["email", "network_node_id"])
+
+
+def downgrade():
+    op.drop_constraint("uq_users_user_name_network_node_id", "users")
+    op.create_unique_constraint("uq_users_user_name", "users", ["user_name"])
+    op.drop_constraint("uq_users_email_network_node_id", "users")
+    op.create_unique_constraint("uq_users_email", "users", ["email"])
+    op.drop_table("network_tokens")
+    op.drop_table("network_nodes")
+    op.drop_column("users", "network_node_id")

--- a/magpie/api/login/__init__.py
+++ b/magpie/api/login/__init__.py
@@ -1,3 +1,4 @@
+from magpie.constants import get_constant
 from magpie.utils import get_logger
 
 LOGGER = get_logger(__name__)
@@ -11,4 +12,7 @@ def includeme(config):
     config.add_route(**s.service_api_route_info(s.SigninAPI))
     config.add_route(**s.service_api_route_info(s.ProvidersAPI))
     config.add_route(**s.service_api_route_info(s.ProviderSigninAPI))
+    if get_constant("MAGPIE_NETWORK_MODE", settings_name="magpie.network_mode"):
+        config.add_route(**s.service_api_route_info(s.TokenAPI))
+        config.add_route(**s.service_api_route_info(s.TokenValidateAPI))
     config.scan()

--- a/magpie/api/login/login.py
+++ b/magpie/api/login/login.py
@@ -1,6 +1,10 @@
 import json
+import uuid
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
+import jwt
+import requests
 from authomatic.adapters import WebObAdapter
 from authomatic.core import Credentials, LoginResult, resolve_provider_class
 from authomatic.exceptions import OAuth2Error
@@ -34,7 +38,7 @@ from magpie.api import requests as ar
 from magpie.api import schemas as s
 from magpie.api.management.user.user_formats import format_user
 from magpie.api.management.user.user_utils import create_user
-from magpie.constants import get_constant
+from magpie.constants import get_constant, protected_user_name_regex
 from magpie.security import authomatic_setup, get_providers
 from magpie.utils import (
     CONTENT_TYPE_JSON,
@@ -47,14 +51,23 @@ from magpie.utils import (
 
 if TYPE_CHECKING:
     from magpie.typedefs import Session, Str
+    from typing import Optional
 
 LOGGER = get_logger(__name__)
 
+MAGPIE_NETWORK_MODE = get_constant("MAGPIE_NETWORK_MODE", settings_name="magpie.network_mode")
 
 # dictionaries of {'provider_id': 'provider_display_name'}
 MAGPIE_DEFAULT_PROVIDER = get_constant("MAGPIE_DEFAULT_PROVIDER")
 MAGPIE_INTERNAL_PROVIDERS = {MAGPIE_DEFAULT_PROVIDER: MAGPIE_DEFAULT_PROVIDER.capitalize()}
 MAGPIE_EXTERNAL_PROVIDERS = get_providers()
+
+if MAGPIE_NETWORK_MODE:
+    MAGPIE_NETWORK_TOKEN_NAME = get_constant("MAGPIE_NETWORK_TOKEN_NAME")
+    MAGPIE_NETWORK_PROVIDER = get_constant("MAGPIE_NETWORK_PROVIDER")
+    MAGPIE_INSTANCE_NAME = get_constant("MAGPIE_INSTANCE_NAME")
+    MAGPIE_EXTERNAL_PROVIDERS[MAGPIE_NETWORK_PROVIDER] = MAGPIE_NETWORK_PROVIDER
+
 MAGPIE_PROVIDER_KEYS = frozenset(set(MAGPIE_INTERNAL_PROVIDERS) | set(MAGPIE_EXTERNAL_PROVIDERS))
 
 
@@ -130,8 +143,8 @@ def sign_in_view(request):
     # request handler. Catch that specific exception and return it to bypass the EXCVIEW tween that result in that
     # automatic convert to return 403 directly.
     try:
-        anonymous = get_constant("MAGPIE_ANONYMOUS_USER", request)
-        ax.verify_param(user_name, not_equal=True, param_compare=anonymous, param_name="user_name",
+        anonymous_regex = protected_user_name_regex(include_admin=False, settings_container=request)
+        ax.verify_param(user_name, not_matches=True, param_compare=anonymous_regex, param_name="user_name",
                         http_error=HTTPForbidden, msg_on_fail=s.Signin_POST_ForbiddenResponseSchema.description)
     except HTTPForbidden as http_error:
         return http_error
@@ -239,17 +252,12 @@ def new_user_external(external_user_name, external_id, email, provider_name, db_
     return user
 
 
-def login_success_external(request, external_user_name, external_id, email, provider_name):
-    # type: (Request, Str, Str, Str, Str) -> HTTPException
+def login_success_external(request, user):
+    # type: (Request, models.User) -> HTTPException
     """
     Generates the login response in case of successful external provider identification.
     """
-    # find possibly already registered user by external_id/provider
-    user = ExternalIdentityService.user_by_external_id_and_provider(external_id, provider_name, request.db)
-    if user is None:
-        # create new user with an External Identity
-        user = new_user_external(external_user_name=external_user_name, external_id=external_id,
-                                 email=email, provider_name=provider_name, db_session=request.db)
+
     # set a header to remember user (set-cookie)
     headers = remember(request, user.id)
 
@@ -271,10 +279,27 @@ def login_success_external(request, external_user_name, external_id, email, prov
                          http_kwargs={"location": homepage_route, "headers": headers})
 
 
+def user_from_token(request, token):
+    # type: (Request, Str) -> Optional[models.User]
+    """
+    Return the ``User`` associated with the token as long as the token is valid and issued by this Magpie instance.
+    """
+    magpie_secret = get_constant("MAGPIE_SECRET", request, settings_name="magpie.secret")
+    decoded_token = jwt.decode(token, magpie_secret, algorithms="HS256", issuer=MAGPIE_INSTANCE_NAME,
+                               options={"require": ["exp", "token"]})
+
+    network_token = (request.db.query(models.NetworkToken)
+                     .join(models.User)
+                     .filter(models.NetworkToken.token == decoded_token["token"])
+                     .first())
+    if network_token:
+        return network_token.user
+
+
 @s.ProviderSigninAPI.get(schema=s.ProviderSignin_GET_RequestSchema, tags=[s.SessionTag],
                          response_schemas=s.ProviderSignin_GET_responses)
 @view_config(route_name=s.ProviderSigninAPI.name, permission=NO_PERMISSION_REQUIRED)
-def authomatic_login_view(request):
+def external_login_view(request):
     """
     Signs in a user session using an external provider.
     """
@@ -282,58 +307,99 @@ def authomatic_login_view(request):
     response = Response()
     verify_provider(provider_name)
     try:
-        authomatic_handler = authomatic_setup(request)
+        if provider_name == MAGPIE_NETWORK_PROVIDER:
+            if "Authorization" in request.headers:
+                token_type, token = request.headers.get("Authorization").split()
+                if token_type != "Bearer":
+                    ax.raise_http(http_error=HTTPBadRequest,
+                                  detail=s.ProviderSignin_GET_BadRequestResponseSchema.description)
+                authenticated_user = None
+                try:
+                    authenticated_user = user_from_token(request, token)
+                except jwt.exceptions.InvalidIssuerError:
+                    decoded_token = jwt.decode(token, options={"verify_signature": False})
+                    issuer = decoded_token.get("iss")
+                    node = request.db.query(models.NetworkNode).filter(models.NetworkNode.name == issuer).first()
+                    if node:
+                        response = requests.get("{}{}".format(node.url, s.TokenValidateAPI.path),
+                                                headers={"Accept": CONTENT_TYPE_JSON})
 
-        # if we directly have the Authorization header, bypass authomatic login and retrieve 'userinfo' to signin
-        if "Authorization" in request.headers and "authomatic" not in request.cookies:
-            provider_config = authomatic_handler.config.get(provider_name, {})
-            provider_class = resolve_provider_class(provider_config.get("class_"))
-            provider = provider_class(authomatic_handler, adapter=None, provider_name=provider_name)
-            # provide the token user data, let the external provider update it on login afterwards
-            token_type, access_token = request.headers.get("Authorization").split()
-            data = {"access_token": access_token, "token_type": token_type}
-            cred = Credentials(authomatic_handler.config, token=access_token, token_type=token_type, provider=provider)
-            provider.credentials = cred
-            result = LoginResult(provider)
-            # pylint: disable=W0212
-            result.provider.user = result.provider._update_or_create_user(data, credentials=cred)  # noqa: W0212
-
-        # otherwise, use the standard login procedure
-        else:
-            result = authomatic_handler.login(WebObAdapter(request, response), provider_name)
-            if result is None:
-                if response.location is not None:
-                    return HTTPTemporaryRedirect(location=response.location, headers=response.headers)
-                return response
-
-        if result:
-            if result.error:
-                # Login procedure finished with an error.
-                error = result.error.to_dict() if hasattr(result.error, "to_dict") else result.error
-                LOGGER.debug("Login failure with error. [%r]", error)
-                return login_failure_view(request, reason=result.error.message)
-            if result.user:
-                # OAuth 2.0 and OAuth 1.0a provide only limited user data on login,
-                # update the user to get more info.
-                if not (result.user.name and result.user.id):
-                    try:
-                        response = result.user.update()
-                    # this error can happen if providing incorrectly formed authorization header
-                    except OAuth2Error as exc:
-                        LOGGER.debug("Login failure with Authorization header.")
-                        ax.raise_http(http_error=HTTPBadRequest, content={"reason": str(exc.message)},
-                                      detail=s.ProviderSignin_GET_BadRequestResponseSchema.description)
-                    # verify that the update procedure succeeded with provided token
-                    if 400 <= response.status < 500:
-                        LOGGER.debug("Login failure with invalid token.")
+                        if response.status_code != HTTPOk.code:
+                            ax.raise_http(http_error=HTTPUnauthorized,
+                                          detail=s.ProviderSignin_GET_UnauthorizedTokenSchema.description)
+                        user_name = response.json().get("user_name")
+                        authenticated_user = (node.users.filter(models.User.name == user_name).first() or
+                                              node.anonymous_user)
+                    else:
                         ax.raise_http(http_error=HTTPUnauthorized,
-                                      detail=s.ProviderSignin_GET_UnauthorizedResponseSchema.description)
-                # create/retrieve the user using found details from login provider
-                return login_success_external(request,
-                                              external_id=result.user.username or result.user.id,
-                                              email=result.user.email,
-                                              provider_name=result.provider.name,
-                                              external_user_name=result.user.name)
+                                      detail=s.ProviderSignin_GET_UnauthorizedTokenSchema.description)
+                except jwt.exceptions.PyJWTError as exc:
+                    ax.raise_http(http_error=HTTPUnauthorized, content={"reason": str(exc)},
+                                  detail=s.ProviderSignin_GET_UnauthorizedTokenSchema.description)
+                if authenticated_user:
+                    return login_success_external(request, authenticated_user)
+            else:
+                ax.raise_http(http_error=HTTPBadRequest,
+                              detail=s.ProviderSignin_GET_BadRequestResponseSchema.description)
+        else:
+            authomatic_handler = authomatic_setup(request)
+
+            # if we directly have the Authorization header, bypass authomatic login and retrieve 'userinfo' to signin
+            if "Authorization" in request.headers and "authomatic" not in request.cookies:
+                provider_config = authomatic_handler.config.get(provider_name, {})
+                provider_class = resolve_provider_class(provider_config.get("class_"))
+                provider = provider_class(authomatic_handler, adapter=None, provider_name=provider_name)
+                # provide the token user data, let the external provider update it on login afterwards
+                token_type, access_token = request.headers.get("Authorization").split()
+                data = {"access_token": access_token, "token_type": token_type}
+                cred = Credentials(authomatic_handler.config, token=access_token, token_type=token_type,
+                                   provider=provider)
+                provider.credentials = cred
+                result = LoginResult(provider)
+                # pylint: disable=W0212
+                result.provider.user = result.provider._update_or_create_user(data, credentials=cred)  # noqa: W0212
+
+            # otherwise, use the standard login procedure
+            else:
+                result = authomatic_handler.login(WebObAdapter(request, response), provider_name)
+                if result is None:
+                    if response.location is not None:
+                        return HTTPTemporaryRedirect(location=response.location, headers=response.headers)
+                    return response
+
+            if result:
+                if result.error:
+                    # Login procedure finished with an error.
+                    error = result.error.to_dict() if hasattr(result.error, "to_dict") else result.error
+                    LOGGER.debug("Login failure with error. [%r]", error)
+                    return login_failure_view(request, reason=result.error.message)
+                if result.user:
+                    # OAuth 2.0 and OAuth 1.0a provide only limited user data on login,
+                    # update the user to get more info.
+                    if not (result.user.name and result.user.id):
+                        try:
+                            response = result.user.update()
+                        # this error can happen if providing incorrectly formed authorization header
+                        except OAuth2Error as exc:
+                            LOGGER.debug("Login failure with Authorization header.")
+                            ax.raise_http(http_error=HTTPBadRequest, content={"reason": str(exc.message)},
+                                          detail=s.ProviderSignin_GET_BadRequestResponseSchema.description)
+                        # verify that the update procedure succeeded with provided token
+                        if 400 <= response.status < 500:
+                            LOGGER.debug("Login failure with invalid token.")
+                            ax.raise_http(http_error=HTTPUnauthorized,
+                                          detail=s.ProviderSignin_GET_UnauthorizedResponseSchema.description)
+                    # create/retrieve the user using found details from login provider
+                    # find possibly already registered user by external_id/provider
+                    external_id = result.user.username or result.user.id
+                    user = ExternalIdentityService.user_by_external_id_and_provider(external_id, provider_name,
+                                                                                    request.db)
+                    if user is None:
+                        # create new user with an External Identity
+                        user = new_user_external(external_user_name=result.user.name, external_id=external_id,
+                                                 email=result.user.email, provider_name=result.provider.name,
+                                                 db_session=request.db)
+                    return login_success_external(request, user)
     except Exception as exc:
         exc_msg = "Unhandled error during external provider '{}' login. [{!s}]".format(provider_name, exc)
         LOGGER.exception(exc_msg, exc_info=True)
@@ -371,6 +437,71 @@ def get_session_view(request):
     session_json = ax.evaluate_call(lambda: _get_session(request), http_error=HTTPInternalServerError,
                                     msg_on_fail=s.Session_GET_InternalServerErrorResponseSchema.description)
     return ax.valid_http(http_success=HTTPOk, detail=s.Session_GET_OkResponseSchema.description, content=session_json)
+
+
+if MAGPIE_NETWORK_MODE:
+    @s.TokenAPI.patch(schema=s.Token_PATCH_RequestBodySchema, tags=[s.SessionTag],
+                      response_schemas=s.Token_PATCH_responses)
+    @view_config(route_name=s.TokenAPI.name, request_method="PATCH", permission=Authenticated)
+    def token_view(request):
+        """
+        Get a token. Generates a new token every time this route is accessed so this can also
+        be used to invalidate a previously generated token.
+        """
+        magpie_secret = get_constant("MAGPIE_SECRET", request, settings_name="magpie.secret")
+        default_expiry = get_constant("MAGPIE_DEFAULT_TOKEN_EXPIRY", request,
+                                      settings_name="magpie.default_token_expiry")
+        magpie_instance_name = get_constant("MAGPIE_INSTANCE_NAME",
+                                            request,
+                                            settings_name="magpie.instance_name")
+
+        expires = request.GET.get("expires", default_expiry)
+        try:
+            expires = int(expires)
+        except ValueError:
+            expires = int(default_expiry)
+
+        expiry = datetime.utcnow() + timedelta(seconds=expires)
+
+        def upsert_token():
+            network_token = request.db.query(models.NetworkToken).filter(
+                models.NetworkToken.user_id == request.user.id).first()
+            if network_token:
+                network_token.token = uuid.uuid4()
+            else:
+                network_token = models.NetworkToken(user_id=request.user.id)
+                request.db.add(network_token)
+            return network_token.token
+
+        token_value = ax.evaluate_call(lambda: upsert_token(), fallback=lambda: request.db.rollback(),
+                                       http_error=HTTPInternalServerError)
+
+        token = jwt.encode({"token": str(token_value),
+                            "exp": expiry,
+                            "iss": magpie_instance_name}, magpie_secret, algorithm="HS256")
+
+        return ax.valid_http(http_success=HTTPOk, detail=s.Token_PATCH_OkResponseSchema.description,
+                             content={"token": token})
+
+
+    @s.TokenValidateAPI.get(schema=s.TokenValidate_GET_RequestBodySchema, tags=[s.SessionTag],
+                            response_schemas=s.TokenValidate_GET_responses)
+    @view_config(route_name=s.TokenValidateAPI.name, permission=NO_PERMISSION_REQUIRED)
+    def validate_token_view(request):
+        """ Validate a token """
+        token = request.GET.get("token")
+        try:
+            authenticated_user = user_from_token(request, token)
+            if authenticated_user:
+                return ax.valid_http(http_success=HTTPOk,
+                                     detail=s.TokenValidate_GET_OkResponseSchema.description,
+                                     content={"user_name": authenticated_user.user_name})
+            else:
+                ax.raise_http(http_error=HTTPUnauthorized,
+                              detail=s.TokenValidate_GET_BadRequestResponseSchema.description)
+        except jwt.exceptions.PyJWTError as exc:
+            ax.raise_http(http_error=HTTPUnauthorized, content={"reason": str(exc)},
+                          detail=s.TokenValidate_GET_BadRequestResponseSchema.description)
 
 
 @s.ProvidersAPI.get(tags=[s.SessionTag], response_schemas=s.Providers_GET_responses)

--- a/magpie/api/management/__init__.py
+++ b/magpie/api/management/__init__.py
@@ -10,4 +10,5 @@ def includeme(config):
     config.include("magpie.api.management.service")
     config.include("magpie.api.management.resource")
     config.include("magpie.api.management.register")
+    config.include("magpie.api.management.network_node")
     config.scan()

--- a/magpie/api/management/network_node/__init__.py
+++ b/magpie/api/management/network_node/__init__.py
@@ -1,0 +1,13 @@
+from magpie.api import schemas as s
+from magpie.constants import get_constant
+from magpie.utils import get_logger
+
+LOGGER = get_logger(__name__)
+
+
+def includeme(config):
+    if get_constant("MAGPIE_NETWORK_MODE", settings_name="magpie.network_mode"):
+        LOGGER.info("Adding API network node...")
+        config.add_route(**s.service_api_route_info(s.NetworkNodeAPI))
+        config.add_route(**s.service_api_route_info(s.NetworkNodesAPI))
+        config.scan()

--- a/magpie/api/management/network_node/network_node_utils.py
+++ b/magpie/api/management/network_node/network_node_utils.py
@@ -1,0 +1,54 @@
+from typing import TYPE_CHECKING
+
+from magpie import models
+from magpie.cli.register_defaults import register_user_with_group
+from magpie.constants import get_constant
+
+if TYPE_CHECKING:
+    from magpie.typedefs import Str
+    from pyramid.request import Request
+
+
+def create_network_node(request, name, url):
+    # type: (Request, Str, Str) -> None
+    """
+    Create a NetworkNode with the given name and url.
+    """
+    network_node = models.NetworkNode(name=name, url=url)
+    name = network_node.anonymous_user_name
+
+    # create an anonymous user and group for this network node
+    register_user_with_group(user_name=name,
+                             group_name=name,
+                             email=get_constant("MAGPIE_ANONYMOUS_EMAIL"),
+                             password=None,  # autogen, value doesn't matter as no login applicable, just make it valid
+                             db_session=request.db)
+
+    group = models.GroupService.by_group_name(name, db_session=request.db)
+    group.description = "Group for users who have accounts on the networked Magpie instance named '{}'.".format(name)
+    group.discoverable = False
+
+    # add the anonymous user to a group for all users in the network (from nodes other than this one).
+    register_user_with_group(user_name=name,
+                             group_name=get_constant("MAGPIE_NETWORK_GROUP_NAME"),
+                             email=get_constant("MAGPIE_ANONYMOUS_EMAIL"),
+                             password=None,
+                             db_session=request.db)
+
+    group = models.GroupService.by_group_name(get_constant("MAGPIE_NETWORK_GROUP_NAME"), db_session=request.db)
+    group.description = "Group for users who have accounts on a different Magpie instance on this network.".format(name)
+    group.discoverable = False
+
+    request.tm.commit()
+
+
+def delete_network_node(request, node):
+    # type: (Request, Str) -> None
+    """
+    Delete a NetworkNode and the associated anonymous user.
+    """
+    anonymous_user = node.anonymous_user
+    if anonymous_user:
+        anonymous_user.delete()
+    node.delete()
+    request.tm.commit()

--- a/magpie/api/management/network_node/network_node_views.py
+++ b/magpie/api/management/network_node/network_node_views.py
@@ -1,0 +1,89 @@
+from pyramid.httpexceptions import (
+    HTTPBadRequest,
+    HTTPConflict,
+    HTTPNotFound,
+    HTTPOk,
+    HTTPCreated,
+    HTTPInternalServerError
+)
+
+from pyramid.view import view_config
+
+from magpie import models
+from magpie.api import exception as ax
+from magpie.api import requests as ar
+from magpie.api import schemas as s
+from magpie.api.management.network_node.network_node_utils import create_network_node, delete_network_node
+from magpie.constants import get_constant
+
+
+if get_constant("MAGPIE_NETWORK_MODE", settings_name="magpie.network_mode"):
+    @s.NetworkNodesAPI.get(tags=[s.NetworkNodeTag], response_schemas=s.NetworkNodes_GET_responses)
+    @view_config(route_name=s.NetworkNodesAPI.name, request_method="GET")
+    def get_network_nodes_view(request):
+        nodes = [{"name": n.name, "url": n.url} for n in request.db.query(models.NetworkNode).all()]
+        return ax.valid_http(http_success=HTTPOk, detail=s.NetworkNode_GET_OkResponseSchema.description,
+                             content={"nodes": nodes})
+
+
+    @s.NetworkNodeAPI.get(tags=[s.NetworkNodeTag], response_schemas=s.NetworkNode_GET_responses)
+    @view_config(route_name=s.NetworkNodeAPI.name, request_method="GET")
+    def get_network_node_view(request):
+        node_name = ar.get_value_matchdict_checked(request, "node")
+        node = ax.evaluate_call(
+            lambda: request.db.query(models.NetworkNode).filter(models.NetworkNode.name == node_name).one(),
+            http_error=HTTPNotFound,
+            msg_on_fail=s.NetworkNode_GET_NotFoundResponseSchema.description)
+        return ax.valid_http(http_success=HTTPOk, detail=s.NetworkNode_GET_OkResponseSchema.description,
+                             content={"name": node.name, "url": node.url})
+
+
+    @s.NetworkNodesAPI.post(schema=s.NetworkNode_POST_RequestBodySchema, tags=[s.NetworkNodeTag],
+                            response_schemas=s.NetworkNodes_POST_responses)
+    @view_config(route_name=s.NetworkNodesAPI.name, request_method="POST")
+    def create_network_node_view(request):
+        node_name = request.POST.get("name")
+        node_url = request.POST.get("url")
+        ax.verify_param(all([node_name, node_url]), is_true=True,
+                        http_error=HTTPBadRequest, msg_on_fail=s.BadRequestResponseSchema.description)
+        ax.evaluate_call(lambda: create_network_node(request, node_name, node_url),
+                         http_error=HTTPConflict,
+                         msg_on_fail=s.NetworkNodes_POST_ConflictResponseSchema.description)
+        return ax.valid_http(http_success=HTTPCreated, detail=s.NetworkNode_GET_OkResponseSchema.description)
+
+
+    @s.NetworkNodeAPI.put(schema=s.NetworkNode_PUT_RequestBodySchema,
+                          tags=[s.NetworkNodeTag], response_schemas=s.NetworkNode_PUT_responses)
+    @view_config(route_name=s.NetworkNodeAPI.name, request_method="PUT")
+    def update_network_node_view(request):
+        node_name = ar.get_value_matchdict_checked(request, "node")
+        node = ax.evaluate_call(
+            lambda: request.db.query(models.NetworkNode).filter(models.NetworkNode.name == node_name).one(),
+            http_error=HTTPNotFound,
+            msg_on_fail=s.NetworkNode_GET_NotFoundResponseSchema.description)
+        new_name = request.POST.get("name")
+        new_url = request.POST.get("url")
+        ax.verify_param(any([new_name, new_url]), is_true=True,
+                        http_error=HTTPBadRequest, msg_on_fail=s.BadRequestResponseSchema.description)
+        node.name = new_name or node.name
+        node.url = new_url or node.url
+        ax.evaluate_call(lambda: request.tm.commit(),
+                         http_error=HTTPConflict,
+                         fallback=lambda: request.db.rollback(),
+                         msg_on_fail=s.NetworkNode_PUT_ConflictResponseSchema.description)
+        return ax.valid_http(http_success=HTTPOk, detail=s.NetworkNode_GET_OkResponseSchema.description)
+
+
+    @s.NetworkNodeAPI.delete(tags=[s.NetworkNodeTag], response_schemas=s.NetworkNode_DELETE_responses)
+    @view_config(route_name=s.NetworkNodeAPI.name, request_method="DELETE")
+    def delete_network_node_view(request):
+        node_name = ar.get_value_matchdict_checked(request, "node")
+        node = ax.evaluate_call(
+            lambda: request.db.query(models.NetworkNode).filter(models.NetworkNode.name == node_name).one(),
+            http_error=HTTPNotFound,
+            msg_on_fail=s.NetworkNode_GET_NotFoundResponseSchema.description)
+        ax.evaluate_call(lambda: delete_network_node(request, node),
+                         http_error=HTTPInternalServerError,
+                         fallback=lambda: request.db.rollback(),
+                         msg_on_fail=s.InternalServerErrorResponseSchema.description)
+        return ax.valid_http(http_success=HTTPOk, detail=s.NetworkNode_DELETE_OkResponseSchema.description)

--- a/magpie/api/management/user/user_formats.py
+++ b/magpie/api/management/user/user_formats.py
@@ -1,9 +1,10 @@
+import re
 from typing import TYPE_CHECKING
 
 from pyramid.httpexceptions import HTTPInternalServerError
 
 from magpie.api.exception import evaluate_call
-from magpie.constants import get_constant
+from magpie.constants import get_constant, protected_user_name_regex
 from magpie.models import UserGroupStatus, UserStatuses
 
 if TYPE_CHECKING:
@@ -47,7 +48,8 @@ def format_user(user, group_names=None, basic_info=False, dotted=False):
             user_info["has_pending_group"] = bool(user.get_groups_by_status(UserGroupStatus.PENDING))
 
         # special users not meant to be used as valid "accounts" marked as without an ID
-        if user.user_name != get_constant("MAGPIE_ANONYMOUS_USER") and status != UserStatuses.Pending:
+        anonymous_regex = protected_user_name_regex(include_admin=False)
+        if not re.search(anonymous_regex, user.user_name) and status != UserStatuses.Pending:
             user_info["user{}id".format(sep)] = int(user.id)
         return user_info
 

--- a/magpie/ui/utils.py
+++ b/magpie/ui/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from secrets import compare_digest  # noqa 'python2-secrets'
 from typing import TYPE_CHECKING
 
@@ -20,7 +21,7 @@ from magpie import __meta__
 from magpie.api import schemas
 from magpie.api.generic import get_exception_info, get_request_info
 from magpie.api.requests import get_logged_user
-from magpie.constants import get_constant
+from magpie.constants import get_constant, protected_user_name_regex, protected_group_name_regex
 from magpie.models import UserGroupStatus
 from magpie.security import mask_credentials
 from magpie.utils import CONTENT_TYPE_JSON, get_header, get_json, get_logger, get_magpie_url
@@ -175,39 +176,61 @@ def handle_errors(func):
     return wrap
 
 
+class _ReContainsWrapper(object):
+    """
+    Class that wraps the re.search function with the __contains__ method.
+
+    Used in BaseViews so that code in mako templates can continue to use syntax like:
+
+    .. code-block:: python
+
+        user_name in MAGPIE_FIXED_USERS
+    """
+
+    def __init__(self, regex="x^"):  # Note that the default "x^" matches nothing
+        self.regex = regex
+
+    def __contains__(self, item):
+        # type: (Any) -> bool
+        try:
+            return bool(re.search(self.regex, item))
+        except TypeError:
+            return False
+
+
 @view_defaults(decorator=handle_errors)
 class BaseViews(object):
     """
     Base methods for Magpie UI pages.
     """
-    MAGPIE_FIXED_GROUP_MEMBERSHIPS = []
+    MAGPIE_FIXED_GROUP_MEMBERSHIPS = _ReContainsWrapper()
     """
     Special :term:`Group` memberships that cannot be edited.
     """
 
-    MAGPIE_FIXED_GROUP_EDITS = []
+    MAGPIE_FIXED_GROUP_EDITS = _ReContainsWrapper()
     """
     Special :term:`Group` details that cannot be edited.
     """
 
-    MAGPIE_FIXED_USERS = []
+    MAGPIE_FIXED_USERS = _ReContainsWrapper()
     """
     Special :term:`User` details that cannot be edited.
     """
 
-    MAGPIE_FIXED_USERS_REFS = []
+    MAGPIE_FIXED_USERS_REFS = _ReContainsWrapper()
     """
     Special :term:`User` that cannot have any relationship edited.
 
     This includes both :term:`Group` memberships and :term:`Permission` references.
     """
 
-    MAGPIE_USER_PWD_LOCKED = []
+    MAGPIE_USER_PWD_LOCKED = _ReContainsWrapper()
     """
     Special :term:`User` that *could* self-edit themselves, but is disabled since conflicting with other policies.
     """
 
-    MAGPIE_USER_PWD_DISABLED = []
+    MAGPIE_USER_PWD_DISABLED = _ReContainsWrapper()
     """
     Special :term:`User` where password cannot be edited (managed by `Magpie` configuration settings).
     """
@@ -223,22 +246,29 @@ class BaseViews(object):
         self.ui_theme = get_constant("MAGPIE_UI_THEME", self.request)
         self.logged_user = get_logged_user(self.request)
 
-        anonym_grp = get_constant("MAGPIE_ANONYMOUS_GROUP", settings_container=self.request)
-        admin_grp = get_constant("MAGPIE_ADMIN_GROUP", settings_container=self.request)
-        self.__class__.MAGPIE_FIXED_GROUP_MEMBERSHIPS = [anonym_grp]
-        self.__class__.MAGPIE_FIXED_GROUP_EDITS = [anonym_grp, admin_grp]
-        # special users that cannot be deleted
-        anonym_usr = get_constant("MAGPIE_ANONYMOUS_USER", self.request)
-        admin_usr = get_constant("MAGPIE_ADMIN_USER", self.request)
-        self.__class__.MAGPIE_FIXED_USERS_REFS = [anonym_usr]
-        self.__class__.MAGPIE_FIXED_USERS = [admin_usr, anonym_usr]
-        self.__class__.MAGPIE_USER_PWD_LOCKED = [admin_usr]
-        self.__class__.MAGPIE_USER_PWD_DISABLED = [anonym_usr, admin_usr]
+        self.__class__.MAGPIE_FIXED_GROUP_MEMBERSHIPS = _ReContainsWrapper(
+            protected_group_name_regex(include_admin=False, include_network=False, settings_container=self.request)
+        )
+        self.__class__.MAGPIE_FIXED_GROUP_EDITS = _ReContainsWrapper(
+            protected_group_name_regex(settings_container=self.request)
+        )
+        self.__class__.MAGPIE_FIXED_USERS_REFS = _ReContainsWrapper(
+            protected_user_name_regex(include_admin=False, settings_container=self.request)
+        )
+        self.__class__.MAGPIE_FIXED_USERS = _ReContainsWrapper(
+            protected_user_name_regex(settings_container=self.request)
+        )
+        self.__class__.MAGPIE_USER_PWD_LOCKED = _ReContainsWrapper(
+            protected_user_name_regex(include_anonymous=False, include_network=False, settings_container=self.request)
+        )
+        self.__class__.MAGPIE_USER_PWD_DISABLED = _ReContainsWrapper(
+            protected_user_name_regex(settings_container=self.request)
+        )
         self.__class__.MAGPIE_USER_REGISTRATION_ENABLED = asbool(
             get_constant("MAGPIE_USER_REGISTRATION_ENABLED", self.request,
                          default_value=False, print_missing=True, raise_missing=False, raise_not_set=False)
         )
-        self.__class__.MAGPIE_ANONYMOUS_GROUP = anonym_grp
+        self.__class__.MAGPIE_ANONYMOUS_GROUP = get_constant("MAGPIE_ANONYMOUS_GROUP", settings_container=self.request)
 
     def add_template_data(self, data=None):
         # type: (Optional[Dict[Str, Any]]) -> Dict[Str, Any]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ paste
 pastedeploy
 pluggy
 psycopg2-binary>=2.7.1
+PyJWT==2.8.0
 pyramid>=1.10.2,<2
 pyramid_beaker==0.8
 pyramid_chameleon>=0.3


### PR DESCRIPTION
Introduce "Network Mode" which allows other Magpie instances to act as external authentication providers using JSON Web Tokens (JWT). 

This allows users registered across multiple Magpie instances in a network to more easily gain access to the resources within the network, without requiring the duplication of user credentials across the network.

In response to the discussion here: https://github.com/DACCS-Climate/DACCS-executive-committee/issues/8.

This change is fully backwards compatible and is only enabled if the `MAGPIE_NETWORK_MODE` is set (not set by default). Otherwise, magpie admins and regular users should see no changes at all.

TODO:

- [ ] add tests for new functionality
- [ ] add UI view to get a token (optional)