### PR TITLE
Add supplemental regex setting to validate username

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes
 Features / Changes
 ~~~~~~~~~~~~~~~~~~
 
-* Create an additional settings/environment variable ``MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX`` that acts as an additional
+* Create an additional settings/environment variable ``MAGPIE_USER_NAME_EXTRA_REGEX`` that acts as an additional
   check for whether a ``username`` is valid. This creates a further restriction on this value which is useful when there
   are additional limits on the ``username`` that should be enforced by `Magpie`.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,12 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~
+
+* Create an additional settings/environment variable ``MAGPIE_SUPPLEMENTAL_USERNAME_REGEX`` that acts as an additional
+  check for whether a ``username`` is valid. This creates a further restriction on this value which is useful when there
+  are additional limits on the ``username`` that should be enforced by `Magpie`.
 
 .. _changes_3.36.0:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes
 Features / Changes
 ~~~~~~~~~~~~~~~~~~
 
-* Create an additional settings/environment variable ``MAGPIE_SUPPLEMENTAL_USERNAME_REGEX`` that acts as an additional
+* Create an additional settings/environment variable ``MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX`` that acts as an additional
   check for whether a ``username`` is valid. This creates a further restriction on this value which is useful when there
   are additional limits on the ``username`` that should be enforced by `Magpie`.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,8 +13,8 @@ Features / Changes
 ~~~~~~~~~~~~~~~~~~
 
 * Create an additional settings/environment variable ``MAGPIE_USER_NAME_EXTRA_REGEX`` that acts as an additional
-  check for whether a ``username`` is valid. This creates a further restriction on this value which is useful when there
-  are additional limits on the ``username`` that should be enforced by `Magpie`.
+  check for whether a ``user_name`` is valid. This creates a further restriction on this value which is useful when there
+  are additional limits on the ``user_name`` that should be enforced by `Magpie`.
 
 .. _changes_3.36.0:
 

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -63,7 +63,7 @@ magpie.user_registration_notify_email_template =
 
 # --- user validation settings ---
 
-#magpie.supplemental_user_name_regex =
+#magpie.user_name_extra_regex =
 
 # --- user assignment to groups with t&c ---
 magpie.group_terms_submission_email_template =

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -61,6 +61,10 @@ magpie.user_registration_notify_enabled = false
 magpie.user_registration_notify_email_recipient =
 magpie.user_registration_notify_email_template =
 
+# --- user validation settings ---
+
+#magpie.supplemental_username_regex =
+
 # --- user assignment to groups with t&c ---
 magpie.group_terms_submission_email_template =
 magpie.group_terms_approved_email_template =

--- a/config/magpie.ini
+++ b/config/magpie.ini
@@ -63,7 +63,7 @@ magpie.user_registration_notify_email_template =
 
 # --- user validation settings ---
 
-#magpie.supplemental_username_regex =
+#magpie.supplemental_user_name_regex =
 
 # --- user assignment to groups with t&c ---
 magpie.group_terms_submission_email_template =

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1433,15 +1433,15 @@ approval procedures.
 User Validation Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. envvar:: MAGPIE_SUPPLEMENTAL_USERNAME_REGEX
+.. envvar:: MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX
 
     (Default: ``None``)
 
-    .. versionadded:: 3.36.1
+    .. versionadded:: 3.37
 
     A (python3 syntax) regular expression used to validate a ``username`` when creating or updating a `User`.
 
-    For example, if ``MAGPIE_SUPPLEMENTAL_USERNAME_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``username``
+    For example, if ``MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``username``
     but not ``user.A`` or ``user-A``.
 
     Note that `Magpie` enforces other restrictions that must also be met for a ``username`` to be considered valid.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -953,9 +953,9 @@ remain available as described at the start of the :ref:`Configuration` section.
 
     .. versionadded:: 3.37
 
-    A (python3 syntax) regular expression used to validate a ``user_name`` when creating or updating a `User`.
+    A (python3 syntax) regular expression used to validate a ``user_name`` when creating or updating a :term:`User`.
 
-    For example, if ``MAGPIE_USER_NAME_EXTRA_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``user_name``
+    For example, if ``MAGPIE_USER_NAME_EXTRA_REGEX='^\w+$'``, then a :term:`User` can have ``userA`` as a ``user_name``
     but not ``user.A`` or ``user-A``.
 
     Note that `Magpie` enforces other restrictions that must also be met for a ``user_name`` to be considered valid.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1433,7 +1433,7 @@ approval procedures.
 User Validation Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. envvar:: MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX
+.. envvar:: MAGPIE_USER_NAME_EXTRA_REGEX
 
     (Default: ``None``)
 
@@ -1441,7 +1441,7 @@ User Validation Settings
 
     A (python3 syntax) regular expression used to validate a ``username`` when creating or updating a `User`.
 
-    For example, if ``MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``username``
+    For example, if ``MAGPIE_USER_NAME_EXTRA_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``username``
     but not ``user.A`` or ``user-A``.
 
     Note that `Magpie` enforces other restrictions that must also be met for a ``username`` to be considered valid.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1428,6 +1428,28 @@ approval procedures.
         obtained from the :term:`Pending User`. Parameter ``approval_required`` is provided to generate alternative
         `Mako Template`_ contents in case different messages should be sent for each situation.
 
+.. _config_user_validation_settings
+
+User Validation Settings
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. envvar:: MAGPIE_SUPPLEMENTAL_USERNAME_REGEX
+
+    (Default: ``None``)
+
+    .. versionadded:: 3.36.1
+
+    A (python3 syntax) regular expression used to validate a ``username`` when creating or updating a `User`.
+
+    For example, if ``MAGPIE_SUPPLEMENTAL_USERNAME_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``username``
+    but not ``user.A`` or ``user-A``.
+
+    Note that `Magpie` enforces other restrictions that must also be met for a ``username`` to be considered valid.
+    This creates an additional restriction, it does not replace an existing restriction on the ``username``.
+
+    If this variable is empty or unset, then no additional ``username`` validations will be performed.
+
+
 .. envvar:: MAGPIE_USER_REGISTRATION_DECLINED_EMAIL_TEMPLATE
 
     (Default: |email_ur_declined_mako|_)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -947,6 +947,22 @@ remain available as described at the start of the :ref:`Configuration` section.
         This value **MUST NOT** be greater than the token length used to identify a :term:`User` to preserve internal
         functionalities.
 
+.. envvar:: MAGPIE_USER_NAME_EXTRA_REGEX
+
+    (Default: ``None``)
+
+    .. versionadded:: 3.37
+
+    A (python3 syntax) regular expression used to validate a ``user_name`` when creating or updating a `User`.
+
+    For example, if ``MAGPIE_USER_NAME_EXTRA_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``user_name``
+    but not ``user.A`` or ``user-A``.
+
+    Note that `Magpie` enforces other restrictions that must also be met for a ``user_name`` to be considered valid.
+    This creates an additional restriction, it does not replace an existing restriction on the ``user_name``.
+
+    If this variable is empty or unset, then no additional ``user_name`` validations will be performed.
+
 .. envvar:: MAGPIE_PASSWORD_MIN_LENGTH
 
     [:class:`int`]
@@ -1427,27 +1443,6 @@ approval procedures.
         will be sent only after the account was approved. Otherwise, it is sent as soon as email conformation is
         obtained from the :term:`Pending User`. Parameter ``approval_required`` is provided to generate alternative
         `Mako Template`_ contents in case different messages should be sent for each situation.
-
-.. _config_user_validation_settings
-
-User Validation Settings
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. envvar:: MAGPIE_USER_NAME_EXTRA_REGEX
-
-    (Default: ``None``)
-
-    .. versionadded:: 3.37
-
-    A (python3 syntax) regular expression used to validate a ``username`` when creating or updating a `User`.
-
-    For example, if ``MAGPIE_USER_NAME_EXTRA_REGEX='^\w+$'``, then a `User` can have ``userA`` as a ``username``
-    but not ``user.A`` or ``user-A``.
-
-    Note that `Magpie` enforces other restrictions that must also be met for a ``username`` to be considered valid.
-    This creates an additional restriction, it does not replace an existing restriction on the ``username``.
-
-    If this variable is empty or unset, then no additional ``username`` validations will be performed.
 
 
 .. envvar:: MAGPIE_USER_REGISTRATION_DECLINED_EMAIL_TEMPLATE

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -872,14 +872,14 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         ax.verify_param(user_name, matches=True, param_name="user_name", param_compare=ax.PARAM_REGEX,
                         http_error=HTTPBadRequest,
                         msg_on_fail=s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description)
-        supplemental_regex = get_constant("MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX", raise_missing=False,
+        extra_regex = get_constant("MAGPIE_USER_NAME_EXTRA_REGEX", raise_missing=False,
                                           raise_not_set=False)
-        if supplemental_regex:
+        if extra_regex:
             ax.verify_param(
-                user_name, matches=True, param_name="user_name", param_compare=supplemental_regex,
+                user_name, matches=True, param_name="user_name", param_compare=extra_regex,
                 http_error=HTTPBadRequest,
-                msg_on_fail=s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description,
-                param_content={"setting": "magpie.supplemental_user_name_regex"}
+                msg_on_fail=s.Users_CheckInfo_UserNameValueExtraRegex_BadRequestResponseSchema.description,
+                param_content={"setting": "magpie.user_name_extra_regex"}
             )
         name_range = range(1, 1 + get_constant("MAGPIE_USER_NAME_MAX_LENGTH"))
         ax.verify_param(len(user_name), is_in=True, param_name="user_name", param_compare=name_range,

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -878,7 +878,8 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
             ax.verify_param(
                 user_name, matches=True, param_name="user_name", param_compare=supplemental_regex,
                 http_error=HTTPBadRequest,
-                msg_on_fail=s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description
+                msg_on_fail=s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description,
+                param_content="magpie.supplemental_user_name_regex"
             )
         name_range = range(1, 1 + get_constant("MAGPIE_USER_NAME_MAX_LENGTH"))
         ax.verify_param(len(user_name), is_in=True, param_name="user_name", param_compare=name_range,

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -872,8 +872,7 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         ax.verify_param(user_name, matches=True, param_name="user_name", param_compare=ax.PARAM_REGEX,
                         http_error=HTTPBadRequest,
                         msg_on_fail=s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description)
-        extra_regex = get_constant("MAGPIE_USER_NAME_EXTRA_REGEX", raise_missing=False,
-                                          raise_not_set=False)
+        extra_regex = get_constant("MAGPIE_USER_NAME_EXTRA_REGEX", raise_missing=False, raise_not_set=False)
         if extra_regex:
             ax.verify_param(
                 user_name, matches=True, param_name="user_name", param_compare=extra_regex,

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -879,7 +879,7 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
                 user_name, matches=True, param_name="user_name", param_compare=supplemental_regex,
                 http_error=HTTPBadRequest,
                 msg_on_fail=s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description,
-                param_content="magpie.supplemental_user_name_regex"
+                param_content={"setting": "magpie.supplemental_user_name_regex"}
             )
         name_range = range(1, 1 + get_constant("MAGPIE_USER_NAME_MAX_LENGTH"))
         ax.verify_param(len(user_name), is_in=True, param_name="user_name", param_compare=name_range,

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -872,6 +872,11 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         ax.verify_param(user_name, matches=True, param_name="user_name", param_compare=ax.PARAM_REGEX,
                         http_error=HTTPBadRequest,
                         msg_on_fail=s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description)
+        supplemental_regex = get_constant("MAGPIE_SUPPLEMENTAL_USERNAME_REGEX", raise_missing=False)
+        if supplemental_regex:
+            ax.verify_param(user_name, matches=True, param_name="user_name", param_compare=supplemental_regex,
+                            http_error=HTTPBadRequest,
+                            msg_on_fail=s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description)
         name_range = range(1, 1 + get_constant("MAGPIE_USER_NAME_MAX_LENGTH"))
         ax.verify_param(len(user_name), is_in=True, param_name="user_name", param_compare=name_range,
                         http_error=HTTPBadRequest,

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -872,11 +872,14 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         ax.verify_param(user_name, matches=True, param_name="user_name", param_compare=ax.PARAM_REGEX,
                         http_error=HTTPBadRequest,
                         msg_on_fail=s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description)
-        supplemental_regex = get_constant("MAGPIE_SUPPLEMENTAL_USERNAME_REGEX", raise_missing=False)
+        supplemental_regex = get_constant("MAGPIE_SUPPLEMENTAL_USER_NAME_REGEX", raise_missing=False,
+                                          raise_not_set=False)
         if supplemental_regex:
-            ax.verify_param(user_name, matches=True, param_name="user_name", param_compare=supplemental_regex,
-                            http_error=HTTPBadRequest,
-                            msg_on_fail=s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description)
+            ax.verify_param(
+                user_name, matches=True, param_name="user_name", param_compare=supplemental_regex,
+                http_error=HTTPBadRequest,
+                msg_on_fail=s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description
+            )
         name_range = range(1, 1 + get_constant("MAGPIE_USER_NAME_MAX_LENGTH"))
         ax.verify_param(len(user_name), is_in=True, param_name="user_name", param_compare=name_range,
                         http_error=HTTPBadRequest,

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1962,6 +1962,11 @@ class Users_CheckInfo_UserNameValue_BadRequestResponseSchema(BaseResponseSchemaA
     body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
 
 
+class Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema(BaseResponseSchemaAPI):
+    description = "Invalid 'user_name' value specified. Does not match the supplemental user name regex.."
+    body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
+
+
 class Users_CheckInfo_UserNameSize_BadRequestResponseSchema(BaseResponseSchemaAPI):
     description = "Invalid 'user_name' length specified (>{length} characters)." \
                   .format(length=get_constant("MAGPIE_USER_NAME_MAX_LENGTH"))

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1962,8 +1962,8 @@ class Users_CheckInfo_UserNameValue_BadRequestResponseSchema(BaseResponseSchemaA
     body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
 
 
-class Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema(BaseResponseSchemaAPI):
-    description = "Invalid 'user_name' value specified. Does not match the supplemental user name regex."
+class Users_CheckInfo_UserNameValueExtraRegex_BadRequestResponseSchema(BaseResponseSchemaAPI):
+    description = "Invalid 'user_name' value specified. Does not match the extra user name regex."
     body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
 
 

--- a/magpie/api/schemas.py
+++ b/magpie/api/schemas.py
@@ -1963,7 +1963,7 @@ class Users_CheckInfo_UserNameValue_BadRequestResponseSchema(BaseResponseSchemaA
 
 
 class Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema(BaseResponseSchemaAPI):
-    description = "Invalid 'user_name' value specified. Does not match the supplemental user name regex.."
+    description = "Invalid 'user_name' value specified. Does not match the supplemental user name regex."
     body = ErrorResponseBodySchema(code=HTTPBadRequest.code, description=description)
 
 

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7517,12 +7517,15 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.check_val_is_in(self.test_user_name, body)
 
     @runner.MAGPIE_TEST_USERS
-    def test_AddUser_FormSubmit_WithSupplementalUsernameRegex_Invalid(self):
+    def test_AddUser_FormSubmit_WithExtraUsernameRegex_Invalid(self):
         """
-        Check that the supplemental_user_name_regex setting is used to validate a new user name when the user name is
+        Check that the extra_user_name_regex setting is used to validate a new user name when the user name is
         invalid according to that regex but is valid according to the ax.PARAM_REGEX.
+        
+        .. versionadded:: 3.37
         """
-        with utils.mocked_get_settings(settings={"magpie.supplemental_user_name_regex": "^$"}):
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^$"}):
             data = {"user_name": self.test_user_name, "group_name": get_constant("MAGPIE_USERS_GROUP"),
                     "email": "{}@mail.com".format(self.test_user_name),
                     "password": self.test_user_name, "confirm": self.test_user_name}
@@ -7531,16 +7534,19 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
             resp = utils.TestSetup.check_FormSubmit(self, form_match=form, form_submit="create", form_data=data,
                                                     path=path)
             body = utils.check_ui_response_basic_info(resp)
-            msg = s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description
+            msg = s.Users_CheckInfo_UserNameValueExtraRegex_BadRequestResponseSchema.description
             utils.check_val_is_in(msg, html.unescape(body))
 
     @runner.MAGPIE_TEST_USERS
-    def test_AddUser_FormSubmit_WithSupplementalUsernameRegex_ValidGoodUsername(self):
+    def test_AddUser_FormSubmit_WithExtraUsernameRegex_ValidGoodUsername(self):
         """
-        Check that the supplemental_user_name_regex setting is used to validate a new user name when the user name is
+        Check that the user_name_extra_regex setting is used to validate a new user name when the user name is
         valid according to that regex and the ax.PARAM_REGEX.
+        
+        .. versionadded:: 3.37
         """
-        with utils.mocked_get_settings(settings={"magpie.supplemental_user_name_regex": "^.*$"}):
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^.*$"}):
             data = {"user_name": self.test_user_name, "group_name": get_constant("MAGPIE_USERS_GROUP"),
                     "email": "{}@mail.com".format(self.test_user_name),
                     "password": self.test_user_name, "confirm": self.test_user_name}
@@ -7556,12 +7562,15 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
             utils.check_val_is_in(self.test_user_name, body)
 
     @runner.MAGPIE_TEST_USERS
-    def test_AddUser_FormSubmit_WithSupplementalUsernameRegex_InvalidBadUsername(self):
+    def test_AddUser_FormSubmit_WithExtraUsernameRegex_InvalidBadUsername(self):
         """
-        Check that the supplemental_user_name_regex setting is used to validate a new user name when the user name is
+        Check that the extra_user_name_regex setting is used to validate a new user name when the user name is
         valid according to that regex but not the ax.PARAM_REGEX.
+        
+        .. versionadded:: 3.37
         """
-        with utils.mocked_get_settings(settings={"magpie.supplemental_user_name_regex": "^.*$"}):
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^.*$"}):
             email = "{}@mail.com".format(self.test_user_name) # the @ symbol is invalid according to the ax.PARAM_REGEX
             data = {"user_name": email, "group_name": get_constant("MAGPIE_USERS_GROUP"), "email": email,
                     "password": self.test_user_name, "confirm": self.test_user_name}
@@ -7572,10 +7581,10 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
             body = utils.check_ui_response_basic_info(resp)
 
             # the error message should indicate that the user name is invalid according to the original regex
-            # (ax.PARAM_REGEX) not the supplemental regex
+            # (ax.PARAM_REGEX) not the extra regex
             msg = s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description
             utils.check_val_is_in(msg, html.unescape(body))
-            msg = s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description
+            msg = s.Users_CheckInfo_UserNameValueExtraRegex_BadRequestResponseSchema.description
             utils.check_val_not_in(msg, html.unescape(body))
 
     @runner.MAGPIE_TEST_STATUS

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -1,3 +1,4 @@
+import html
 import itertools
 import os
 import secrets
@@ -7514,6 +7515,68 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         utils.check_val_is_in("<h1>Users</h1>", body)
         utils.check_val_is_in("id=\"view_users_list\"", body)
         utils.check_val_is_in(self.test_user_name, body)
+
+    @runner.MAGPIE_TEST_USERS
+    def test_AddUser_FormSubmit_WithSupplementalUsernameRegex_Invalid(self):
+        """
+        Check that the supplemental_user_name_regex setting is used to validate a new user name when the user name is
+        invalid according to that regex but is valid according to the ax.PARAM_REGEX.
+        """
+        with utils.mocked_get_settings(settings={"magpie.supplemental_user_name_regex": "^$"}):
+            data = {"user_name": self.test_user_name, "group_name": get_constant("MAGPIE_USERS_GROUP"),
+                    "email": "{}@mail.com".format(self.test_user_name),
+                    "password": self.test_user_name, "confirm": self.test_user_name}
+            path = "/ui/users/add"
+            form = "add_user_form"
+            resp = utils.TestSetup.check_FormSubmit(self, form_match=form, form_submit="create", form_data=data,
+                                                    path=path)
+            body = utils.check_ui_response_basic_info(resp)
+            msg = s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description
+            utils.check_val_is_in(msg, html.unescape(body))
+
+    @runner.MAGPIE_TEST_USERS
+    def test_AddUser_FormSubmit_WithSupplementalUsernameRegex_ValidGoodUsername(self):
+        """
+        Check that the supplemental_user_name_regex setting is used to validate a new user name when the user name is
+        valid according to that regex and the ax.PARAM_REGEX.
+        """
+        with utils.mocked_get_settings(settings={"magpie.supplemental_user_name_regex": "^.*$"}):
+            data = {"user_name": self.test_user_name, "group_name": get_constant("MAGPIE_USERS_GROUP"),
+                    "email": "{}@mail.com".format(self.test_user_name),
+                    "password": self.test_user_name, "confirm": self.test_user_name}
+            path = "/ui/users/add"
+            form = "add_user_form"
+            resp = utils.TestSetup.check_FormSubmit(self, form_match=form, form_submit="create", form_data=data,
+                                                    path=path)
+            body = utils.check_ui_response_basic_info(resp)
+
+            # redirected response should be directly the list of users with the new one added
+            utils.check_val_is_in("<h1>Users</h1>", body)
+            utils.check_val_is_in("id=\"view_users_list\"", body)
+            utils.check_val_is_in(self.test_user_name, body)
+
+    @runner.MAGPIE_TEST_USERS
+    def test_AddUser_FormSubmit_WithSupplementalUsernameRegex_InvalidBadUsername(self):
+        """
+        Check that the supplemental_user_name_regex setting is used to validate a new user name when the user name is
+        valid according to that regex but not the ax.PARAM_REGEX.
+        """
+        with utils.mocked_get_settings(settings={"magpie.supplemental_user_name_regex": "^.*$"}):
+            email = "{}@mail.com".format(self.test_user_name) # the @ symbol is invalid according to the ax.PARAM_REGEX
+            data = {"user_name": email, "group_name": get_constant("MAGPIE_USERS_GROUP"), "email": email,
+                    "password": self.test_user_name, "confirm": self.test_user_name}
+            path = "/ui/users/add"
+            form = "add_user_form"
+            resp = utils.TestSetup.check_FormSubmit(self, form_match=form, form_submit="create", form_data=data,
+                                                    path=path)
+            body = utils.check_ui_response_basic_info(resp)
+
+            # the error message should indicate that the user name is invalid according to the original regex
+            # (ax.PARAM_REGEX) not the supplemental regex
+            msg = s.Users_CheckInfo_UserNameValue_BadRequestResponseSchema.description
+            utils.check_val_is_in(msg, html.unescape(body))
+            msg = s.Users_CheckInfo_UserNameValueSupplementalRegex_BadRequestResponseSchema.description
+            utils.check_val_not_in(msg, html.unescape(body))
 
     @runner.MAGPIE_TEST_STATUS
     def test_AddGroup_PageStatus(self):

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7521,7 +7521,7 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         """
         Check that the extra_user_name_regex setting is used to validate a new user name when the user name is
         invalid according to that regex but is valid according to the ax.PARAM_REGEX.
-        
+
         .. versionadded:: 3.37
         """
         utils.warn_version(self, "extra username regex added", "3.37", skip=True)
@@ -7542,7 +7542,7 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         """
         Check that the user_name_extra_regex setting is used to validate a new user name when the user name is
         valid according to that regex and the ax.PARAM_REGEX.
-        
+
         .. versionadded:: 3.37
         """
         utils.warn_version(self, "extra username regex added", "3.37", skip=True)
@@ -7566,12 +7566,12 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         """
         Check that the extra_user_name_regex setting is used to validate a new user name when the user name is
         valid according to that regex but not the ax.PARAM_REGEX.
-        
+
         .. versionadded:: 3.37
         """
         utils.warn_version(self, "extra username regex added", "3.37", skip=True)
         with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^.*$"}):
-            email = "{}@mail.com".format(self.test_user_name) # the @ symbol is invalid according to the ax.PARAM_REGEX
+            email = "{}@mail.com".format(self.test_user_name)  # the @ symbol is invalid according to the ax.PARAM_REGEX
             data = {"user_name": email, "group_name": get_constant("MAGPIE_USERS_GROUP"), "email": email,
                     "password": self.test_user_name, "confirm": self.test_user_name}
             path = "/ui/users/add"

--- a/tests/test_magpie_api.py
+++ b/tests/test_magpie_api.py
@@ -451,6 +451,82 @@ class TestCase_MagpieAPI_AdminAuth_Local(ti.Interface_MagpieAPI_AdminAuth, unitt
         utils.check_val_type(body["user_names"], list)
         utils.check_val_not_in(self.test_user_name, body["user_names"])
 
+    @runner.MAGPIE_TEST_USERS
+    def test_PostUsers_NoExtraRegex_ValidRegex(self):
+        """
+        Check that the user_name_extra_regex setting is not used to validate a new user name when user_name_extra_regex
+        is falsy.
+
+        .. versionadded:: 3.37
+        """
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": None}):
+            data = {
+                "user_name": self.test_user_name,
+                "password": self.test_user_name,
+                "email": "email@example.com",
+            }
+            resp = utils.test_request(self, "POST", "/users", data=data,
+                                      headers=self.json_headers, cookies=self.cookies, expect_errors=True)
+            utils.check_response_basic_info(resp, 201, expected_method="POST")
+
+    @runner.MAGPIE_TEST_USERS
+    def test_PostUsers_WithExtraRegex_InvalidExtraRegex(self):
+        """
+        Check that the user_name_extra_regex setting is used to validate a new user name when the user name is
+        invalid according to that regex but is valid according to the ax.PARAM_REGEX.
+
+        .. versionadded:: 3.37
+        """
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^$"}):
+            data = {
+                "user_name": self.test_user_name,
+                "password": self.test_user_name,
+                "email": "email@example.com",
+            }
+            resp = utils.test_request(self, "POST", "/users", data=data,
+                                      headers=self.json_headers, cookies=self.cookies, expect_errors=True)
+            utils.check_response_basic_info(resp, 400, expected_method="POST")
+
+    @runner.MAGPIE_TEST_USERS
+    def test_PostUsers_WithExtraRegex_InvalidRegex(self):
+        """
+        Check that the user_name_extra_regex setting is used to validate a new user name when the user name is
+        valid according to that regex but is invalid according to the ax.PARAM_REGEX.
+
+        .. versionadded:: 3.37
+        """
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^.*$"}):
+            data = {
+                "user_name": "email@example.com",
+                "password": self.test_user_name,
+                "email": "email@example.com",
+            }
+            resp = utils.test_request(self, "POST", "/users", data=data,
+                                      headers=self.json_headers, cookies=self.cookies, expect_errors=True)
+            utils.check_response_basic_info(resp, 400, expected_method="POST")
+
+
+    @runner.MAGPIE_TEST_USERS
+    def test_PostUsers_WithExtraRegex_ValidBoth(self):
+        """
+        Check that the user_name_extra_regex setting is used to validate a new user name when the user name is
+        valid according to that regex and the ax.PARAM_REGEX.
+
+        .. versionadded:: 3.37
+        """
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^.*$"}):
+            data = {
+                "user_name": self.test_user_name,
+                "password": self.test_user_name,
+                "email": "email@example.com",
+            }
+            resp = utils.test_request(self, "POST", "/users", data=data,
+                                      headers=self.json_headers, cookies=self.cookies, expect_errors=True)
+            utils.check_response_basic_info(resp, 201, expected_method="POST")
 
 @runner.MAGPIE_TEST_API
 @runner.MAGPIE_TEST_LOCAL

--- a/tests/test_magpie_api.py
+++ b/tests/test_magpie_api.py
@@ -508,7 +508,6 @@ class TestCase_MagpieAPI_AdminAuth_Local(ti.Interface_MagpieAPI_AdminAuth, unitt
                                       headers=self.json_headers, cookies=self.cookies, expect_errors=True)
             utils.check_response_basic_info(resp, 400, expected_method="POST")
 
-
     @runner.MAGPIE_TEST_USERS
     def test_PostUsers_WithExtraRegex_ValidBoth(self):
         """
@@ -527,6 +526,7 @@ class TestCase_MagpieAPI_AdminAuth_Local(ti.Interface_MagpieAPI_AdminAuth, unitt
             resp = utils.test_request(self, "POST", "/users", data=data,
                                       headers=self.json_headers, cookies=self.cookies, expect_errors=True)
             utils.check_response_basic_info(resp, 201, expected_method="POST")
+
 
 @runner.MAGPIE_TEST_API
 @runner.MAGPIE_TEST_LOCAL


### PR DESCRIPTION
Create an additional settings/environment variable `MAGPIE_SUPPLEMENTAL_USERNAME_REGEX` that acts as an additional check for whether a `username` is valid. This creates a further restriction on this value which is useful when there are additional limits on the `username` that should be enforced by `Magpie`.

Resolves #497 
