### PR TITLE
allow case sensitive regex matches for the `MAGPIE_USER_NAME_EXTRA_REGEX` setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,13 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~
+
+* Ensure that the settings/environment variable ``MAGPIE_USER_NAME_EXTRA_REGEX`` is case sensitive.
+  Previously, the check was case insensitive meaning that it could not be used to restrict usernames based on case.
+  For example, setting this value to ``^[a-z]+$`` would have permit the username ``"someuser"`` as well as
+  ``"Someuser"``. Now, the same regular expression will not match ``"Someuser"`` since case sensitivity in enforced.
 
 .. _changes_3.37.0:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -953,7 +953,8 @@ remain available as described at the start of the :ref:`Configuration` section.
 
     .. versionadded:: 3.37
 
-    A (python3 syntax) regular expression used to validate a ``user_name`` when creating or updating a :term:`User`.
+    A case sensitive (python3 syntax) regular expression used to validate a ``user_name`` when creating or updating a
+    :term:`User`.
 
     For example, if ``MAGPIE_USER_NAME_EXTRA_REGEX='^\w+$'``, then a :term:`User` can have ``userA`` as a ``user_name``
     but not ``user.A`` or ``user-A``.

--- a/magpie/api/exception.py
+++ b/magpie/api/exception.py
@@ -85,6 +85,7 @@ def verify_param(  # noqa: E126  # pylint: disable=R0913,too-many-arguments
                  is_equal=False,                    # type: bool
                  is_type=False,                     # type: bool
                  matches=False,                     # type: bool
+                 regex_flags=re.I | re.X            # type: re.RegexFlag
                  ):                                 # type: (...) -> None   # noqa: E123,E126
     # pylint: disable=R0912,R0914
     """
@@ -123,6 +124,7 @@ def verify_param(  # noqa: E126  # pylint: disable=R0913,too-many-arguments
     :param is_equal: test that :paramref:`param` equals :paramref:`param_compare` value
     :param is_type: test that :paramref:`param` is of same type as specified by :paramref:`param_compare` type
     :param matches: test that :paramref:`param` matches the regex specified by :paramref:`param_compare` value
+    :param regex_flags: flags to pass to the ``re.compile`` function when comparing using a regular expression
     :raises HTTPError: if tests fail, specified exception is raised (default: :class:`HTTPBadRequest`)
     :raises HTTPInternalServerError: for evaluation error
     :return: nothing if all tests passed
@@ -249,7 +251,7 @@ def verify_param(  # noqa: E126  # pylint: disable=R0913,too-many-arguments
     if matches:
         param_compare_regex = param_compare
         if isinstance(param_compare, six.string_types):
-            param_compare_regex = re.compile(param_compare, re.I | re.X)
+            param_compare_regex = re.compile(param_compare, regex_flags)
         fail_conditions.update({"matches": bool(re.match(param_compare_regex, param))})
         fail_verify = fail_verify or not fail_conditions["matches"]
     if fail_verify:

--- a/magpie/api/exception.py
+++ b/magpie/api/exception.py
@@ -85,7 +85,7 @@ def verify_param(  # noqa: E126  # pylint: disable=R0913,too-many-arguments
                  is_equal=False,                    # type: bool
                  is_type=False,                     # type: bool
                  matches=False,                     # type: bool
-                 regex_flags=re.I | re.X            # type: re.RegexFlag
+                 regex_flags=re.I | re.X            # type: re.RegexFlag  # noqa: E741
                  ):                                 # type: (...) -> None   # noqa: E123,E126
     # pylint: disable=R0912,R0914
     """

--- a/magpie/api/exception.py
+++ b/magpie/api/exception.py
@@ -85,7 +85,6 @@ def verify_param(  # noqa: E126  # pylint: disable=R0913,too-many-arguments
                  is_equal=False,                    # type: bool
                  is_type=False,                     # type: bool
                  matches=False,                     # type: bool
-                 regex_flags=re.I | re.X            # type: re.RegexFlag  # noqa: E741
                  ):                                 # type: (...) -> None   # noqa: E123,E126
     # pylint: disable=R0912,R0914
     """
@@ -124,7 +123,6 @@ def verify_param(  # noqa: E126  # pylint: disable=R0913,too-many-arguments
     :param is_equal: test that :paramref:`param` equals :paramref:`param_compare` value
     :param is_type: test that :paramref:`param` is of same type as specified by :paramref:`param_compare` type
     :param matches: test that :paramref:`param` matches the regex specified by :paramref:`param_compare` value
-    :param regex_flags: flags to pass to the ``re.compile`` function when comparing using a regular expression
     :raises HTTPError: if tests fail, specified exception is raised (default: :class:`HTTPBadRequest`)
     :raises HTTPInternalServerError: for evaluation error
     :return: nothing if all tests passed
@@ -251,7 +249,7 @@ def verify_param(  # noqa: E126  # pylint: disable=R0913,too-many-arguments
     if matches:
         param_compare_regex = param_compare
         if isinstance(param_compare, six.string_types):
-            param_compare_regex = re.compile(param_compare, regex_flags)
+            param_compare_regex = re.compile(param_compare, re.X)
         fail_conditions.update({"matches": bool(re.match(param_compare_regex, param))})
         fail_verify = fail_verify or not fail_conditions["matches"]
     if fail_verify:

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -1,3 +1,4 @@
+import re
 from inspect import cleandoc
 from secrets import compare_digest  # noqa 'python2-secrets'
 from typing import TYPE_CHECKING
@@ -875,7 +876,7 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         extra_regex = get_constant("MAGPIE_USER_NAME_EXTRA_REGEX", raise_missing=False, raise_not_set=False)
         if extra_regex:
             ax.verify_param(
-                user_name, matches=True, param_name="user_name", param_compare=extra_regex,
+                user_name, matches=True, param_name="user_name", param_compare=extra_regex, regex_flags=re.X,
                 http_error=HTTPBadRequest,
                 msg_on_fail=s.Users_CheckInfo_UserNameValueExtraRegex_BadRequestResponseSchema.description,
                 param_content={"setting": "magpie.user_name_extra_regex"}

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -876,7 +876,7 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         extra_regex = get_constant("MAGPIE_USER_NAME_EXTRA_REGEX", raise_missing=False, raise_not_set=False)
         if extra_regex:
             ax.verify_param(
-                user_name, matches=True, param_name="user_name", param_compare=extra_regex, regex_flags=re.X,
+                user_name, matches=True, param_name="user_name", param_compare=extra_regex,
                 http_error=HTTPBadRequest,
                 msg_on_fail=s.Users_CheckInfo_UserNameValueExtraRegex_BadRequestResponseSchema.description,
                 param_content={"setting": "magpie.user_name_extra_regex"}

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -1,4 +1,3 @@
-import re
 from inspect import cleandoc
 from secrets import compare_digest  # noqa 'python2-secrets'
 from typing import TYPE_CHECKING

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7538,6 +7538,27 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
             utils.check_val_is_in(msg, html.unescape(body))
 
     @runner.MAGPIE_TEST_USERS
+    def test_AddUser_FormSubmit_WithExtraUsernameRegex_CaseInvalid(self):
+        """
+        Check that the extra_user_name_regex setting is used to validate a new user name when the user name is
+        invalid according to that regex because the case is incorrect but is valid according to the ax.PARAM_REGEX.
+
+        .. versionadded:: 3.37
+        """
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^[a-z]+$"}):
+            data = {"user_name": "UpperCaseUserName", "group_name": get_constant("MAGPIE_USERS_GROUP"),
+                    "email": "{}@mail.com".format(self.test_user_name),
+                    "password": self.test_user_name, "confirm": self.test_user_name}
+            path = "/ui/users/add"
+            form = "add_user_form"
+            resp = utils.TestSetup.check_FormSubmit(self, form_match=form, form_submit="create", form_data=data,
+                                                    path=path)
+            body = utils.check_ui_response_basic_info(resp)
+            msg = s.Users_CheckInfo_UserNameValueExtraRegex_BadRequestResponseSchema.description
+            utils.check_val_is_in(msg, html.unescape(body))
+
+    @runner.MAGPIE_TEST_USERS
     def test_AddUser_FormSubmit_WithExtraUsernameRegex_ValidGoodUsername(self):
         """
         Check that the user_name_extra_regex setting is used to validate a new user name when the user name is

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7543,9 +7543,9 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         Check that the extra_user_name_regex setting is used to validate a new user name when the user name is
         invalid according to that regex because the case is incorrect but is valid according to the ax.PARAM_REGEX.
 
-        .. versionadded:: 3.37
+        .. versionchanged:: 3.37.1
         """
-        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        utils.warn_version(self, "case sensitive user name extra regex", "3.37.1", skip=True)
         with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^[a-z]+$"}):
             data = {"user_name": "UpperCaseUserName", "group_name": get_constant("MAGPIE_USERS_GROUP"),
                     "email": "{}@mail.com".format(self.test_user_name),

--- a/tests/test_magpie_api.py
+++ b/tests/test_magpie_api.py
@@ -490,6 +490,25 @@ class TestCase_MagpieAPI_AdminAuth_Local(ti.Interface_MagpieAPI_AdminAuth, unitt
             utils.check_response_basic_info(resp, 400, expected_method="POST")
 
     @runner.MAGPIE_TEST_USERS
+    def test_PostUsers_WithExtraRegex_CaseInvalidExtraRegex(self):
+        """
+        Check that the user_name_extra_regex setting is used to validate a new user name when the user name is
+        invalid according to that regex because the case is incorrect but is valid according to the ax.PARAM_REGEX.
+
+        .. versionadded:: 3.37
+        """
+        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^[a-z]+$"}):
+            data = {
+                "user_name": "UpperCaseUserName",
+                "password": self.test_user_name,
+                "email": "email@example.com",
+            }
+            resp = utils.test_request(self, "POST", "/users", data=data,
+                                      headers=self.json_headers, cookies=self.cookies, expect_errors=True)
+            utils.check_response_basic_info(resp, 400, expected_method="POST")
+
+    @runner.MAGPIE_TEST_USERS
     def test_PostUsers_WithExtraRegex_InvalidRegex(self):
         """
         Check that the user_name_extra_regex setting is used to validate a new user name when the user name is

--- a/tests/test_magpie_api.py
+++ b/tests/test_magpie_api.py
@@ -495,9 +495,9 @@ class TestCase_MagpieAPI_AdminAuth_Local(ti.Interface_MagpieAPI_AdminAuth, unitt
         Check that the user_name_extra_regex setting is used to validate a new user name when the user name is
         invalid according to that regex because the case is incorrect but is valid according to the ax.PARAM_REGEX.
 
-        .. versionadded:: 3.37
+        .. versionchanged:: 3.37.1
         """
-        utils.warn_version(self, "extra username regex added", "3.37", skip=True)
+        utils.warn_version(self, "case sensitive user name extra regex", "3.37.1", skip=True)
         with utils.mocked_get_settings(settings={"magpie.user_name_extra_regex": "^[a-z]+$"}):
             data = {
                 "user_name": "UpperCaseUserName",


### PR DESCRIPTION
Ensures that the settings/environment variable ``MAGPIE_USER_NAME_EXTRA_REGEX`` is case sensitive.

Previously, the check was case insensitive meaning that it could not be used to restrict usernames based on case.
For example, setting this value to `^[a-z]+$` would have permit the username `"someuser"` as well as `"Someuser"`. 

Now, the same regular expression will not match `"Someuser"` since case sensitivity in enforced.