### PR TITLE
do not allow conflicting usernames where only difference is case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,11 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+* Do not allow users to have the same username that only differs in terms of upper/lowercase
+  Ziggurat foundations assumes that users will not have usernames that differ in terms of case.
+  This means that if the database contains a user with the username "Test" and another with the username "test". The
+  login procedure will not know to differentiate the two.
+  (fixes `#595 <https://github.com/Ouranosinc/Magpie/issues/595>`_).
 
 .. _changes_3.37.1:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,13 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Do not allow users to have the same username that only differs in terms of upper/lowercase
-  Ziggurat foundations assumes that users will not have usernames that differ in terms of case.
-  This means that if the database contains a user with the username "Test" and another with the username "test". The
-  login procedure will not know to differentiate the two.
+Bug Fixes
+~~~~~~~~~
+
+* Do not allow any `User` to have the same ``user_name`` as another `User` that only differs in terms of upper/lowercase
+  Ziggurat foundations assumes that a `User` will not have a ``user_name`` that differs from another only in terms of case.
+  This means that if the database contains a `User` with the ``user_name`` "Test" and another with the ``user_name``
+  "test". The login procedure will not know to differentiate the two.
   (fixes `#595 <https://github.com/Ouranosinc/Magpie/issues/595>`_).
 
 .. _changes_3.37.1:

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -135,7 +135,7 @@ def create_user(user_name,              # type: Str
     user_params = {"with_param": False}
     if user_checked:
         user_params["with_param"] = True
-        if compare_digest(user_checked.user_name, user_name):
+        if compare_digest(user_checked.user_name.lower(), user_name.lower()):
             user_params["msg_on_fail"] = s.User_Check_Name_ConflictResponseSchema.description
             user_params["param_name"] = "user_name"
             user_params["param_content"] = {"value": user_name, "conditions": [{"unique": False}]}

--- a/magpie/models.py
+++ b/magpie/models.py
@@ -484,7 +484,8 @@ class UserSearchService(UserService):
         users = list(cls.by_status(status=status, db_session=db_session))
         if not users:
             return None
-        users = [user for user in users if user.user_name == user_name]
+        # replicate functionality of UserService.by_user_name, which does a case-insensitive search for usernames
+        users = [user for user in users if user.user_name.lower() == user_name.lower()]
         if not users:
             return None
         if len(users) == 1:
@@ -513,7 +514,9 @@ class UserSearchService(UserService):
             if status is not None:
                 status = [int(status) for status in status]
                 query = query.in_(status)
-            return query.filter((User.user_name == user_name) | (func.lower(User.email) == email.lower())).first()
+            # replicate functionality of UserService.by_user_name, which does a case-insensitive search
+            return query.filter(
+                (func.lower(User.user_name) == user_name.lower()) | (func.lower(User.email) == email.lower())).first()
         user = cls.by_user_name(user_name=user_name, status=status, db_session=db_session)
         if user is not None:
             return user

--- a/magpie/ui/utils.py
+++ b/magpie/ui/utils.py
@@ -567,7 +567,7 @@ class AdminRequests(BaseViews):
         if len(user_name) > get_constant("MAGPIE_USER_NAME_MAX_LENGTH", self.request):
             data["invalid_user_name"] = True
             data["reason_user_name"] = "Too Long"
-        if user_name in [usr["user_name"] for usr in user_details]:
+        if user_name.lower() in [usr["user_name"].lower() for usr in user_details]:
             data["invalid_user_name"] = True
             data["reason_user_name"] = "Conflict"
         if user_name == "":

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -7663,7 +7663,6 @@ class Interface_MagpieUI_AdminAuth(AdminTestCase, BaseTestCase):
         body = utils.check_ui_response_basic_info(resp)
         utils.check_val_is_in("Conflict", html.unescape(body))
 
-
     @runner.MAGPIE_TEST_STATUS
     def test_AddGroup_PageStatus(self):
         path = "/ui/groups/add"


### PR DESCRIPTION
Do not allow users to have the same username that only differs in terms of upper/lowercase
Ziggurat foundations assumes that users will not have usernames that differ in terms of case.
This means that if the database contains a user with the username "Test" and another with the username "test". The login procedure will not know to differentiate the two.
 
Resolves #595