### PR TITLE
pin cornice version to <6.1 for python 3.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,11 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Bug Fixes
+~~~~~~~~~
+
+* The ``cornice`` package dropped support for python 3.5 as of version 6.1.0. Update the requirements file to ensure
+  that a supported version of ``cornice`` is installed for python 3.5.
 
 .. _changes_3.38.1:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ bcrypt>=3.1.6
 beaker @ https://github.com/crim-ca/beaker/archive/0ac88bcd8cca063a571fc385ffbe9bcc8acaa690.zip
 colander
 cornice<5; python_version < "3"
-cornice; python_version >= "3"
+cornice; python_version >= "3.6"
+cornice<6.1; python_version == "3.5"
 cornice_swagger>=0.7.0
 dicttoxml
 # futures is required for gunicorn threads


### PR DESCRIPTION
The ``cornice`` package dropped support for python 3.5 as of version 6.1.0. Update the requirements file to ensure that a supported version of ``cornice`` is installed for python 3.5.