### PR TITLE
fix incorrect reserved user names validations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Features / Changes
 
 * Fix incorrect message employed in error response when validating reserved user names.
 * Replace ``magpie.api.management.user.user_utils.check_user_info`` parameter ``check_not_anonymous``
-  to ``check_not_reserved`` to better reflect that it valides reserved user names and emails for both
+  to ``check_not_reserved`` to better reflect that it validates reserved user names and emails for both
   the ``MAGPIE_ANONYMOUS_USER`` and ``MAGPIE_ADMIN_USER`` special users.
 
 .. _changes_5.0.2:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
 * Fix incorrect message employed in error response when validating reserved user names.
+* Replace ``magpie.api.management.user.user_utils.check_user_info`` parameter ``check_not_anonymous``
+  to ``check_not_reserved`` to better reflect that it valides reserved user names and emails for both
+  the ``MAGPIE_ANONYMOUS_USER`` and ``MAGPIE_ADMIN_USER`` special users.
 
 .. _changes_5.0.2:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Features / Changes
+~~~~~~~~~~~~~~~~~~~~~
+
+* Fix incorrect message employed in error response when validating reserved user names.
 
 .. _changes_5.0.2:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -486,7 +486,7 @@ Features / Changes
 ~~~~~~~~~~~~~~~~~~~~~
 * Add missing ``ServiceWFS`` permissions according to `OGC WFS standard <https://www.ogc.org/standards/wfs>`_.
 * Add missing ``DescribeLayer`` permission to ``ServiceGeoserverWMS`` according
-  to `GeoServer WMS implementation <https://docs.geoserver.org/latest/en/user/services/wms/reference.html>`_.
+  to `GeoServer WMS implementation <https://docs.geoserver.org/latest/en/user/services/wms/reference/>`_.
 * Add support of specific hierarchy of ``Resource`` type ``Layer`` nested under ``Workspace``
   for ``ServiceGeoserverWMS``.
 * Add support of ``Resource`` type ``Layer`` under ``ServiceWFS``.

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -403,7 +403,7 @@ ServiceGeoserverWFS
 
 .. seealso::
 
-    - https://docs.geoserver.org/latest/en/user/services/wfs/reference.html
+    - https://docs.geoserver.org/latest/en/user/services/wfs/reference/
     - Consider using `ServiceGeoserver`_ for multi-:term:`OWS` implementation support under a common
       endpoint representing a `GeoServer`_ instance.
 
@@ -442,7 +442,7 @@ ServiceGeoserverWMS
 .. seealso::
 
     - Base class: `ServiceBaseWMS`_
-    - https://docs.geoserver.org/latest/en/user/services/wms/reference.html
+    - https://docs.geoserver.org/latest/en/user/services/wms/reference/
     - Consider using `ServiceGeoserver`_ for multi-:term:`OWS` implementation support under a common
       endpoint representing a `GeoServer`_ instance.
 

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -410,9 +410,9 @@ def handle_user_group_terms_confirmation(tmp_token, request):
         request.db.delete(token)
 
     msg = cleandoc("""
-        You have accepted the terms and conditions of the '{grp_name}' group. 
+        You have accepted the terms and conditions of the '{grp_name}' group.
 
-        User '{user_name}' has now been successfully added to the '{grp_name}' group. 
+        User '{user_name}' has now been successfully added to the '{grp_name}' group.
         """.format(grp_name=tmp_token.group.group_name, user_name=tmp_token.user.user_name))
 
     return BaseViews(request).render("magpie.ui.home:templates/message.mako", {"message": msg})
@@ -894,7 +894,7 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
                             param_compare=anonymous_user_name_regex,
                             param_name="user_name",
                             http_error=HTTPBadRequest,
-                            msg_on_fail=s.Users_CheckInfo_Email_BadRequestResponseSchema.description)
+                            msg_on_fail=s.Users_CheckInfo_ReservedKeyword_BadRequestResponseSchema.description)
     if check_email:
         ax.verify_param(email, not_none=True, not_empty=True, param_name="email",
                         http_error=HTTPBadRequest,

--- a/magpie/api/management/user/user_utils.py
+++ b/magpie/api/management/user/user_utils.py
@@ -854,7 +854,7 @@ def get_user_service_resources_permissions_dict(user, service, request,
 
 
 def check_user_info(user_name=None, email=None, password=None, group_name=None,  # required unless disabled explicitly
-                    check_name=True, check_email=True, check_password=True, check_group=True, check_not_anonymous=True):
+                    check_name=True, check_email=True, check_password=True, check_group=True, check_not_reserved=True):
     # type: (Str, Str, Str, Str, bool, bool, bool, bool, bool) -> None
     """
     Validates provided user information to ensure they are adequate for user creation.
@@ -887,7 +887,7 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         ax.verify_param(user_name, param_compare=name_logged, not_equal=True, param_name="user_name",
                         http_error=HTTPBadRequest,
                         msg_on_fail=s.Users_CheckInfo_ReservedKeyword_BadRequestResponseSchema.description)
-        if check_not_anonymous:
+        if check_not_reserved:
             anonymous_user_name_regex = protected_user_name_regex()
             ax.verify_param(user_name,
                             not_matches=True,
@@ -902,7 +902,7 @@ def check_user_info(user_name=None, email=None, password=None, group_name=None, 
         ax.verify_param(email, matches=True, param_compare=ax.EMAIL_REGEX, param_name="email",
                         http_error=HTTPBadRequest,
                         msg_on_fail=s.Users_CheckInfo_Email_BadRequestResponseSchema.description)
-        if check_not_anonymous:
+        if check_not_reserved:
             anonymous_email_regex = protected_user_email_regex()
             ax.verify_param(email, not_matches=True, param_compare=anonymous_email_regex, param_name="email",
                             http_error=HTTPBadRequest,

--- a/magpie/cli/register_defaults.py
+++ b/magpie/cli/register_defaults.py
@@ -57,7 +57,7 @@ def register_user_with_group(user_name, group_name, email, password, db_session)
             LOGGER.debug("No password provided for user [%s], auto-generating one.", user_name)
             password = pseudo_random_string(length=get_constant("MAGPIE_PASSWORD_MIN_LENGTH"))
         uu.check_user_info(user_name=user_name, password=password, group_name=group_name, check_email=False,
-                           check_not_anonymous=False)
+                           check_not_reserved=False)
         new_user = models.User(user_name=user_name, email=email)  # noqa
         UserService.set_password(new_user, password)
         db_session.add(new_user)
@@ -128,7 +128,7 @@ def init_admin(db_session, settings=None):
         LOGGER.warning("Detected password change for 'MAGPIE_ADMIN_USER'. Attempting to update...")
         try:
             uu.check_user_info(password=admin_password, check_name=False, check_email=False, check_group=False,
-                               check_not_anonymous=False)
+                               check_not_reserved=False)
             UserService.set_password(admin_usr, admin_password)
             UserService.regenerate_security_code(admin_usr)
         except Exception as http_exc:  # noqa  # re-raised as value error  # pragma: no cover

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -1300,7 +1300,7 @@ class ServiceGeoserverWFS(ServiceGeoserverBase, ServiceWFS):  # order important 
     Service that represents a `Web Feature Service` endpoint with functionalities specific to `Geoserver`.
 
     .. seealso::
-        https://docs.geoserver.org/latest/en/user/services/wfs/reference.html
+        https://docs.geoserver.org/latest/en/user/services/wfs/reference/
     """
     service_base = "wfs"
     service_type = "geoserverwfs"

--- a/magpie/services.py
+++ b/magpie/services.py
@@ -1144,7 +1144,7 @@ class ServiceGeoserverWMS(ServiceGeoserverBase, ServiceBaseWMS):  # order import
     Service that represents a `Web Map Service` endpoint with functionalities specific to `Geoserver`.
 
     .. seealso::
-        https://docs.geoserver.org/latest/en/user/services/wms/reference.html
+        https://docs.geoserver.org/latest/en/user/services/wms/reference/
     """
     service_base = "wms"
     service_type = "geoserverwms"
@@ -1496,7 +1496,7 @@ class ServiceGeoserver(ServiceGeoserverBase):
     Service that encapsulates the multiple :term:`OWS` endpoints from `Geoserver` services.
 
     .. seealso::
-        https://docs.geoserver.org/stable/en/user/services/index.html
+        https://docs.geoserver.org/latest/en/user/services/
     """
     service_base = None  # use 'service_map' and 'service_ows'
     service_type = "geoserver"

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -5512,6 +5512,11 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
                                   headers=self.json_headers, cookies=self.cookies, expect_errors=True)
         utils.check_response_basic_info(resp, 400, expected_method="POST")
 
+        # the following specific contents are important as they are relied upon by the permissions 'magpie.register'
+        # procedures that handle these special 'reserved keywords' cases to bypass user profile auto-creation errors
+        utils.check_val_is_in("reserved keyword", resp.json["detail"],
+                              msg="Specific cause of bad request should be indicated in the error response.")
+
     @runner.MAGPIE_TEST_USERS
     def test_PostUsers_Conflict_Name(self):
         utils.TestSetup.create_TestGroup(self)

--- a/tests/interfaces.py
+++ b/tests/interfaces.py
@@ -5514,7 +5514,8 @@ class Interface_MagpieAPI_AdminAuth(AdminTestCase, BaseTestCase):
 
         # the following specific contents are important as they are relied upon by the permissions 'magpie.register'
         # procedures that handle these special 'reserved keywords' cases to bypass user profile auto-creation errors
-        utils.check_val_is_in("reserved keyword", resp.json["detail"],
+        json_body = utils.get_json_body(resp)
+        utils.check_val_is_in("reserved keyword", json_body["detail"],
                               msg="Specific cause of bad request should be indicated in the error response.")
 
     @runner.MAGPIE_TEST_USERS

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -492,7 +492,7 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
                         # custom configuration definition
                         configuration:
                             file_patterns:
-                                # note: 
+                                # note:
                                 #   following patterns should have only one-double backslash escape each,
                                 #   but needs quadruple in this case because of 2-steps (dump to YAML, read from YAML)
                                 - ".*\\\\.ncml"   # matched before plain '.nc', will correspond to another resource
@@ -846,12 +846,12 @@ class TestServices(ti.SetupMagpieAdapter, ti.UserTestCase, ti.BaseTestCase):
         utils.check_raises(lambda: self.ows.check_request(req), OWSAccessForbidden)
 
         # evaluate parsing of POST-formatted Execute requests
-        # (source: https://docs.geoserver.org/stable/en/user/services/wps/operations.html)
+        # (source: https://docs.geoserver.org/latest/en/user/services/wps/operations/)
         wps_xml_post_body_template = inspect.cleandoc("""
         <?xml version="1.0" encoding="UTF-8"?>
         <wps:Execute version="1.0.0" service="WPS"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.opengis.net/wps/1.0.0" 
-         xmlns:wfs="http://www.opengis.net/wfs" xmlns:wps="http://www.opengis.net/wps/1.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.opengis.net/wps/1.0.0"
+         xmlns:wfs="http://www.opengis.net/wfs" xmlns:wps="http://www.opengis.net/wps/1.0.0"
          xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://www.opengis.net/gml"
          xmlns:ogc="http://www.opengis.net/ogc" xmlns:wcs="http://www.opengis.net/wcs/1.1.1"
          xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0


### PR DESCRIPTION
# Description

Original message erroneously employed the `"email"` message, which made debugging of Cowbird response hard to interpret. It now employs the expected `"user_name + reserved keyword"` message.

While debugging specifically an "admin" use case, it was ambiguous to detect the cause because of the errorneous parameter names.

## Changes

* Fix incorrect message employed in error response when validating reserved user names.
* Replace ``magpie.api.management.user.user_utils.check_user_info`` parameter ``check_not_anonymous``  to ``check_not_reserved`` to better reflect that it valides reserved user names and emails for both   the ``MAGPIE_ANONYMOUS_USER`` and ``MAGPIE_ADMIN_USER`` special users.
