### PR TITLE
ignore expected protected user/group create on permission registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ Features / Changes
 * Replace ``magpie.api.management.user.user_utils.check_user_info`` parameter ``check_not_anonymous``
   to ``check_not_reserved`` to better reflect that it valides reserved user names and emails for both
   the ``MAGPIE_ANONYMOUS_USER`` and ``MAGPIE_ADMIN_USER`` special users.
+* Fix self-induced error on reserved keywords (special `Users`) when resolving `Permission` registrations.
+  Notably, when a `Webhook` request is provided with a `Permission` batch to generate or when loading registration
+  configurations, both methods employ the ``magpie.register`` functions. These perform an automatic creation
+  of `User`/`Group`/`Permission` definitions as needed to make a seamless integration of referenced resources.
+  However, if a reserved `User` is referenced for a `Permission` creation on it, while that creation is itself valid,
+  the auto-creation procedure of the `User` would yield a distinct HTTP error that was not handled properly by the
+  registration process.
 
 .. _changes_5.0.2:
 

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -967,8 +967,8 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
                 from magpie.api.management.group.group_utils import create_group
                 return create_group(**grp_data)
 
-    def _validate_response(operation, is_create, item_type="Permission"):
-        # type: (Callable[[], Optional[AnyResponseType]], bool, str) -> None
+    def _validate_response(operation, is_create, item_type="permission"):
+        # type: (Callable[[], Optional[AnyResponseType]], bool, Literal["permission", "user", "group"]) -> None
         """
         Validate action/operation applied and handles raised ``HTTPException`` as returned response.
         """
@@ -986,32 +986,52 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
         # validation according to status code returned
         if is_create:
             if _resp.status_code in [200, 201]:  # update/create
-                _handle_permission("{} successfully created.".format(item_type), entry_index,
-                                   level=logging.INFO, trail="")
+                _handle_permission(
+                    "{} successfully created.".format(item_type.capitalize()), entry_index,
+                    level=logging.INFO, trail=""
+                )
             elif _resp.status_code == 409:
-                _handle_permission("{} already exists.".format(item_type), entry_index, level=logging.INFO)
+                _handle_permission(
+                    "{} already exists.".format(item_type.capitalize()), entry_index,
+                    level=logging.INFO
+                )
+            elif _resp.status_code in [400, 403] and item_type != "permission" and "reserved keyword" in _resp.text:
+                _handle_permission(
+                    "{} protected creation ignored.".format(item_type.capitalize()), entry_index,
+                    level=logging.INFO
+                )
             else:
-                _handle_permission("Unknown response [{}]".format(_resp.status_code), entry_index,
-                                   permission=permission_config_entry, level=logging.ERROR, raise_errors=raise_errors)
+                _handle_permission(
+                    "Unknown response [{}]".format(_resp.status_code), entry_index,
+                    permission=perm_msg, level=logging.ERROR, raise_errors=raise_errors
+                )
         else:
             if _resp.status_code == 200:
-                _handle_permission("{} successfully removed.".format(item_type), entry_index,
-                                   level=logging.INFO, trail="")
+                _handle_permission(
+                    "{} successfully removed.".format(item_type.capitalize()), entry_index,
+                    level=logging.INFO, trail=""
+                )
             elif _resp.status_code == 404:
-                _handle_permission("{} already removed.".format(item_type), entry_index, level=logging.INFO)
+                _handle_permission(
+                    "{} already removed.".format(item_type.capitalize()), entry_index,
+                    level=logging.INFO
+                )
             else:
-                _handle_permission("Unknown response [{}]".format(_resp.status_code), entry_index,
-                                   permission=permission_config_entry, level=logging.ERROR, raise_errors=raise_errors)
+                _handle_permission(
+                    "Unknown response [{}]".format(_resp.status_code), entry_index,
+                    permission=perm_msg, level=logging.ERROR, raise_errors=raise_errors
+                )
 
     create_perm = permission_config_entry["action"] == "create"
     perm_def = permission_config_entry["permission"]  # name or object
     usr_name = permission_config_entry.get("user")
     grp_name = permission_config_entry.get("group")
     perm = PermissionSet(perm_def)
+    perm_msg = perm.explicit_permission
 
     # process groups first as they can be referenced by user definitions
-    _validate_response(lambda: _apply_profile(None, grp_name), is_create=True)
-    _validate_response(lambda: _apply_profile(usr_name, None), is_create=True)
+    _validate_response(lambda: _apply_profile(None, grp_name), is_create=True, item_type="group")
+    _validate_response(lambda: _apply_profile(usr_name, None), is_create=True, item_type="user")
     if _use_request(cookies_or_session):
         _validate_response(lambda: _apply_request(None, grp_name), is_create=create_perm)
         _validate_response(lambda: _apply_request(usr_name, None), is_create=create_perm)

--- a/magpie/register.py
+++ b/magpie/register.py
@@ -886,7 +886,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
     or db session accordingly to arguments.
     """
 
-    def _apply_request(_usr_name=None, _grp_name=None):
+    def _apply_perm_request(_usr_name=None, _grp_name=None):
         # type: (Optional[Str], Optional[Str]) -> Optional[AnyResponseType]
         """
         Apply operation using HTTP request.
@@ -904,7 +904,7 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
         action_resp = action_func(action_path, json=action_body, cookies=cookies_or_session, timeout=5)
         return action_resp
 
-    def _apply_session(_usr_name=None, _grp_name=None):
+    def _apply_perm_session(_usr_name=None, _grp_name=None):
         # type: (Optional[Str], Optional[Str]) -> Optional[AnyResponseType]
         """
         Apply operation using db session.
@@ -995,10 +995,15 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
                     "{} already exists.".format(item_type.capitalize()), entry_index,
                     level=logging.INFO
                 )
-            elif _resp.status_code in [400, 403] and item_type != "permission" and "reserved keyword" in _resp.text:
+            elif (
+                # avoid error on auto-created user/group if it happens to be a protected resource
+                _resp.status_code in [400, 403] and
+                item_type != "permission" and
+                "reserved keyword" in _resp.json["detail"]
+            ):
                 _handle_permission(
-                    "{} protected creation ignored.".format(item_type.capitalize()), entry_index,
-                    level=logging.INFO
+                    "{} protected creation detected.".format(item_type.capitalize()), entry_index,
+                    level=logging.INFO, raise_errors=False,
                 )
             else:
                 _handle_permission(
@@ -1033,11 +1038,11 @@ def _apply_permission_entry(permission_config_entry,    # type: PermissionConfig
     _validate_response(lambda: _apply_profile(None, grp_name), is_create=True, item_type="group")
     _validate_response(lambda: _apply_profile(usr_name, None), is_create=True, item_type="user")
     if _use_request(cookies_or_session):
-        _validate_response(lambda: _apply_request(None, grp_name), is_create=create_perm)
-        _validate_response(lambda: _apply_request(usr_name, None), is_create=create_perm)
+        _validate_response(lambda: _apply_perm_request(None, grp_name), is_create=create_perm)
+        _validate_response(lambda: _apply_perm_request(usr_name, None), is_create=create_perm)
     else:
-        _validate_response(lambda: _apply_session(None, grp_name), is_create=create_perm)
-        _validate_response(lambda: _apply_session(usr_name, None), is_create=create_perm)
+        _validate_response(lambda: _apply_perm_session(None, grp_name), is_create=create_perm)
+        _validate_response(lambda: _apply_perm_session(usr_name, None), is_create=create_perm)
 
 
 def magpie_register_permissions_from_config(

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -167,6 +167,86 @@ class TestRegister(interfaces.AdminTestCase, unittest.TestCase):
         body = utils.check_response_basic_info(resp)
         utils.check_val_is_in(str(res4_perm), body["permission_names"])
 
+    def test_register_permissions_reserved_keyword_user_create_entries(self):
+        """
+        Validates that permissions can be registered for a reserved keyword user (admin) without raising errors.
+
+        When attempting to create permissions for a reserved user such as the admin user, the system would
+        normally return a 400 error when trying to auto-create the user profile. This test ensures that such
+        errors are handled transparently, allowing the permission registration to proceed successfully despite
+        the user creation failure. The test verifies that all configured permissions are properly created for
+        the reserved user across service and resource levels.
+        """
+        utils.TestSetup.create_TestService(self,
+                                           override_service_name=self.test_perm_svc_name,
+                                           override_service_type=ServiceAPI.service_type)
+        session = get_db_session_from_settings(self.app.app.registry.settings)
+
+        admin_user = get_constant("MAGPIE_ADMIN_USER")
+        svc_perm_dict = {
+            "name": Permission.READ.value,
+            "scope": Scope.MATCH.value,
+            "access": Access.ALLOW.value,
+        }
+        svc_perm_set = PermissionSet(svc_perm_dict)
+        res1_perm = Permission.READ
+        res2_perm = Permission.WRITE
+        res1_name = "test-resource"
+        res2_name = "sub-test-resource"
+        perm_config = {
+            "permissions": [
+                {
+                    "service": self.test_perm_svc_name,
+                    "permission": svc_perm_dict,
+                    "action": "create",
+                    "user": admin_user,
+                },
+                {
+                    "service": self.test_perm_svc_name,
+                    "resource": res1_name,
+                    "permission": res1_perm.value,
+                    "action": "create",
+                    "user": admin_user,
+                },
+                {
+                    "service": self.test_perm_svc_name,
+                    "resource": res1_name + "/" + res2_name,
+                    "permission": res2_perm.value,
+                    "action": "create",
+                    "user": admin_user,
+                }
+            ]
+        }
+        utils.check_no_raise(
+            lambda: register.magpie_register_permissions_from_config(perm_config, db_session=session),
+            msg="Registration should handle the reserved keyworkd 'admin' user creation by avoiding the raised error."
+        )
+
+        services = utils.TestSetup.get_RegisteredServicesList(self)
+        utils.check_val_is_in(self.test_perm_svc_name, [s["service_name"] for s in services])
+        resp = utils.test_request(self.app, "GET", "/services/{}/resources".format(self.test_perm_svc_name))
+        body = utils.check_response_basic_info(resp)
+        svc_res = body[self.test_perm_svc_name]["resources"]
+        svc_res_id = body[self.test_perm_svc_name]["resource_id"]
+        utils.check_val_is_in(res1_name, [svc_res[r]["resource_name"] for r in svc_res])
+        res1_id = [svc_res[r]["resource_id"] for r in svc_res if svc_res[r]["resource_name"] == res1_name][0]
+        res1_sub = svc_res[str(res1_id)]["children"]
+        utils.check_val_is_in(res2_name, [res1_sub[r]["resource_name"] for r in res1_sub])
+        res2_id = [res1_sub[r]["resource_id"] for r in res1_sub if res1_sub[r]["resource_name"] == res2_name][0]
+
+        path = "/users/{}/resources/{}/permissions".format(admin_user, svc_res_id)
+        resp = utils.test_request(self.app, "GET", path)
+        body = utils.check_response_basic_info(resp)
+        utils.check_val_true(all(svc_perm_set.like(p) for p in body["permission_names"]))
+        path = "/users/{}/resources/{}/permissions".format(admin_user, res1_id)
+        resp = utils.test_request(self.app, "GET", path)
+        body = utils.check_response_basic_info(resp)
+        utils.check_val_is_in(res1_perm.value, body["permission_names"])
+        path = "/users/{}/resources/{}/permissions".format(admin_user, res2_id)
+        resp = utils.test_request(self.app, "GET", path)
+        body = utils.check_response_basic_info(resp)
+        utils.check_val_is_in(res2_perm.value, body["permission_names"])
+
     def test_register_permissions_existing_group_create_some_entries(self):
         utils.TestSetup.create_TestService(self,
                                            override_service_name=self.test_perm_svc_name,


### PR DESCRIPTION
## Description

Fix self-induced error on reserved keywords (special `Users`) when resolving `Permission` registrations.
  Notably, when a `Webhook` request is provided with a `Permission` batch to generate or when loading registration configurations, both methods employ the ``magpie.register`` functions. These perform an automatic creation of `User`/`Group`/`Permission` definitions as needed to make a seamless integration of referenced resources. However, if a reserved `User` is referenced for a `Permission` creation on it, while that creation is itself valid, the auto-creation procedure of the `User` would yield a distinct HTTP error that was not handled properly by the registration process.

## References

- based on #650 since the message fix is needed to handle it
- relates to https://github.com/Ouranosinc/cowbird/pull/103