### PR TITLE
fix invalid package classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -206,8 +206,9 @@ setup(
     license=__meta__.__license__,
     keywords=__meta__.__title__ + ", Authentication, AuthN, Birdhouse",
     classifiers=[
-        "Development Status :: 6 - Production/Stable",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
- fix miss-valued 5/6 readiness level
- fixes #424

Purposely omit other elements mentioned in #424 since they are not intended to indicate "what the app uses", but "what it is built for". 
