### PR TITLE
secure email verification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,10 @@ Changes
 `Unreleased <https://github.com/Ouranosinc/Magpie/tree/master>`_ (latest)
 ------------------------------------------------------------------------------------
 
-* Nothing new for the moment.
+Bug Fixes
+~~~~~~~~~
+
+* Don't report confirm URL in registration reponse to ensure that email is actually verified.
 
 .. _changes_5.1.1:
 

--- a/magpie/api/management/register/register_utils.py
+++ b/magpie/api/management/register/register_utils.py
@@ -201,6 +201,8 @@ def register_pending_user(user_name, email, password, request):
                      msg_on_fail="Error occurred during user registration when trying to send "
                                  "email to pending user for confirmation of its submitted email.")
 
+    # basic_info=True is required to prevent the confirm_url from being included in the response
+    # the confirm_url should only be available to the user through the email (sent above)
     user_content = rf.format_pending_user(tmp_user, basic_info=True)
     return ax.valid_http(http_success=HTTPCreated, detail=s.Users_POST_CreatedResponseSchema.description,
                          content={"registration": user_content})

--- a/magpie/api/management/register/register_utils.py
+++ b/magpie/api/management/register/register_utils.py
@@ -201,7 +201,7 @@ def register_pending_user(user_name, email, password, request):
                      msg_on_fail="Error occurred during user registration when trying to send "
                                  "email to pending user for confirmation of its submitted email.")
 
-    user_content = rf.format_pending_user(tmp_user)
+    user_content = rf.format_pending_user(tmp_user, basic_info=True)
     return ax.valid_http(http_success=HTTPCreated, detail=s.Users_POST_CreatedResponseSchema.description,
                          content={"registration": user_content})
 


### PR DESCRIPTION
Previously, the user registration endpoint (`POST /register/users`) returned the `confirm_url` in the response body. This is the same URL that is sent to the pending user's email address for verification.

This meant that the `confirm_url` is immediately visible to the person who submitted the pending user request **without** them having to actually confirm their email address. This would allow someone to create a pending user request with a fake email and still be able to "confirm their email" with the link.

This change removes the `confirm_url` value from the response so that the **only** way the pending user can access this URL is if they get it in their email.