### PR TITLE
Resolve approval URL properly when approving pending users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Bug Fixes
 ~~~~~~~~~
 
 * Don't report confirm URL in registration reponse to ensure that email is actually verified.
+* Resolve approval URL properly when approving pending users.
 
 .. _changes_5.1.1:
 

--- a/magpie/ui/management/views.py
+++ b/magpie/ui/management/views.py
@@ -339,7 +339,9 @@ class ManagementViews(AdminRequests, BaseViews):
 
         # approval must be done with the explicit URL, user should exist afterwards
         if "approve" in self.request.POST and data["approve_url"]:
-            path = data["approve_url"]
+            # request_api expects a relative path and data["approve_url"] is an absolute URL
+            # removeprefix is necessary to extract the relative path from the URL.
+            path = data["approve_url"].removeprefix(self.request.application_url)
             resp = request_api(self.request, path, "GET")
             check_response(resp)
             return HTTPFound(self.request.route_url("edit_user", user_name=user_name, cur_svc_type="default"))


### PR DESCRIPTION
In the `view_pending_user` view an admin can click the "approve" button to approve a pending user.

Currently, if the root URL for Magpie uses a subpath (e.g. https://my-domain/magpie) then the actual approval request that gets sent to the API will add that subpath twice (e.g. https://my-domain/magpie/magpie/tmp/approval-token) which is invalid in most cases.

This is because the `approve_url` is stored as an absolute URL, not a path relative to Magpie's root URL and the function that resolves the request to the API (`request_api` in magpie/ui/utils.py) expects a relative path.

This fixes the issue by removing the root URL from the `approve_url` so that the `request_api` function can resolve it properly.

